### PR TITLE
Add diagnostics for symbolization without mapping filenames

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -412,7 +412,7 @@ func (nm NodeMap) nodes() Nodes {
 
 func (nm NodeMap) findOrInsertLocation(l *profile.Location, keepBinary bool, kept NodeSet) Nodes {
 	var objfile string
-	if m := l.Mapping; m != nil {
+	if m := l.Mapping; m != nil && m.File != "" {
 		objfile = filepath.Base(m.File)
 	}
 

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -909,7 +909,7 @@ func New(prof *profile.Profile, o *Options) *Report {
 func NewDefault(prof *profile.Profile, options Options) *Report {
 	index := len(prof.SampleType) - 1
 	o := &options
-	if o.Title == "" && len(prof.Mapping) > 0 {
+	if o.Title == "" && len(prof.Mapping) > 0 && prof.Mapping[0].File != "" {
 		o.Title = filepath.Base(prof.Mapping[0].File)
 	}
 	o.SampleType = prof.SampleType[index].Type

--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -272,7 +272,8 @@ func newMapping(prof *profile.Profile, obj plugin.ObjTool, ui plugin.UI, force b
 		mappings[l.Mapping] = true
 	}
 
-	for _, m := range prof.Mapping {
+	missingBinaries := false
+	for mix, m := range prof.Mapping {
 		if !mappings[m] {
 			continue
 		}
@@ -282,9 +283,19 @@ func newMapping(prof *profile.Profile, obj plugin.ObjTool, ui plugin.UI, force b
 			continue
 		}
 
+		if m.File == "" {
+			if mix == 0 {
+				ui.PrintErr("Main binary filename not available.\n" +
+					"Try passing the path to the main binary before the profile.")
+				continue
+			}
+			missingBinaries = true
+			continue
+		}
+		
 		// Skip well-known system mappings
 		name := filepath.Base(m.File)
-		if m.File == "" || name == "[vdso]" || strings.HasPrefix(name, "linux-vdso") {
+		if name == "[vdso]" || strings.HasPrefix(name, "linux-vdso") {
 			continue
 		}
 
@@ -301,7 +312,9 @@ func newMapping(prof *profile.Profile, obj plugin.ObjTool, ui plugin.UI, force b
 
 		mt.segments[m] = f
 	}
-
+	if missingBinaries {
+		ui.PrintErr("Some binary filenames not available. Symbolization may be incomplete.")
+	}
 	return mt, nil
 }
 

--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -273,7 +273,7 @@ func newMapping(prof *profile.Profile, obj plugin.ObjTool, ui plugin.UI, force b
 	}
 
 	missingBinaries := false
-	for mix, m := range prof.Mapping {
+	for midx, m := range prof.Mapping {
 		if !mappings[m] {
 			continue
 		}
@@ -284,7 +284,7 @@ func newMapping(prof *profile.Profile, obj plugin.ObjTool, ui plugin.UI, force b
 		}
 
 		if m.File == "" {
-			if mix == 0 {
+			if midx == 0 {
 				ui.PrintErr("Main binary filename not available.\n" +
 					"Try passing the path to the main binary before the profile.")
 				continue


### PR DESCRIPTION
Add diagnostic directing the user to pass the binary filename to pprof if it is not available and it is needed for local symbolization.