### PR TITLE
Add local symbolization using llvm-symbolizer

### DIFF
--- a/internal/binutils/addr2liner.go
+++ b/internal/binutils/addr2liner.go
@@ -77,7 +77,7 @@ func (a *addr2LinerJob) close() {
 
 // newAddr2liner starts the given addr2liner command reporting
 // information about the given executable file. If file is a shared
-// library, base should be the address at which is was mapped in the
+// library, base should be the address at which it was mapped in the
 // program under consideration.
 func newAddr2Liner(cmd, file string, base uint64) (*addr2Liner, error) {
 	if cmd == "" {

--- a/internal/binutils/addr2liner_llvm.go
+++ b/internal/binutils/addr2liner_llvm.go
@@ -60,7 +60,7 @@ func (a *llvmSymbolizerJob) close() {
 
 // newLlvmSymbolizer starts the given llvmSymbolizer command reporting
 // information about the given executable file. If file is a shared
-// library, base should be the address at which is was mapped in the
+// library, base should be the address at which it was mapped in the
 // program under consideration.
 func newLLVMSymbolizer(cmd, file string, base uint64) (*llvmSymbolizer, error) {
 	if cmd == "" {

--- a/internal/binutils/addr2liner_llvm.go
+++ b/internal/binutils/addr2liner_llvm.go
@@ -150,7 +150,7 @@ func (d *llvmSymbolizer) readFrame() (plugin.Frame, bool) {
 // addrInfo returns the stack frame information for a specific program
 // address. It returns nil if the address could not be identified.
 func (d *llvmSymbolizer) addrInfo(addr uint64) ([]plugin.Frame, error) {
-	if err := d.rw.write(fmt.Sprintf("%s %x", d.filename, addr-d.base)); err != nil {
+	if err := d.rw.write(fmt.Sprintf("%s 0x%x", d.filename, addr-d.base)); err != nil {
 		return nil, err
 	}
 

--- a/internal/binutils/addr2liner_nm.go
+++ b/internal/binutils/addr2liner_nm.go
@@ -61,7 +61,7 @@ func newAddr2LinerNM(cmd, file string, base uint64) (*addr2LinerNM, error) {
 		return nil, err
 	}
 
-	// Parse addr2line output and populate symbol map.
+	// Parse nm output and populate symbol map.
 	// Skip lines we fail to parse.
 	buf := bufio.NewReader(&b)
 	for {
@@ -72,6 +72,7 @@ func newAddr2LinerNM(cmd, file string, base uint64) (*addr2LinerNM, error) {
 			}
 			return nil, err
 		}
+		line = strings.TrimSpace(line)
 		fields := strings.SplitN(line, " ", 3)
 		if len(fields) != 3 {
 			continue

--- a/internal/binutils/addr2liner_nm.go
+++ b/internal/binutils/addr2liner_nm.go
@@ -42,7 +42,7 @@ type symbolInfo struct {
 
 //  newAddr2LinerNM starts the given nm command reporting information about the
 // given executable file. If file is a shared library, base should be
-// the address at which is was mapped in the program under
+// the address at which it was mapped in the program under
 // consideration.
 func newAddr2LinerNM(cmd, file string, base uint64) (*addr2LinerNM, error) {
 	if cmd == "" {

--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -273,7 +273,7 @@ func newMapping(prof *profile.Profile, obj plugin.ObjTool, ui plugin.UI, force b
 	}
 
 	missingBinaries := false
-	for mix, m := range prof.Mapping {
+	for midx, m := range prof.Mapping {
 		if !mappings[m] {
 			continue
 		}
@@ -284,7 +284,7 @@ func newMapping(prof *profile.Profile, obj plugin.ObjTool, ui plugin.UI, force b
 		}
 
 		if m.File == "" {
-			if mix == 0 {
+			if midx == 0 {
 				ui.PrintErr("Main binary filename not available.\n" +
 					"Try passing the path to the main binary before the profile.")
 				continue


### PR DESCRIPTION
The llvm-symbolizer tool part of llvm appears to be much faster at symbolization than addr2line, and
uses symbol table information when available.

Will still fallback to addr2line if llvm-symbolizer isn't found.
