### PR TITLE
Fix error handling threadz legacy profiles

### DIFF
--- a/profile/legacy_profile.go
+++ b/profile/legacy_profile.go
@@ -983,7 +983,8 @@ func parseAdditionalSections(l string, b *bytes.Buffer, p *Profile) (err error) 
 			break
 		}
 		// Ignore any unrecognized sections.
-		if l, err := b.ReadString('\n'); err != nil {
+		var err error
+		if l, err = b.ReadString('\n'); err != nil {
 			if err != io.EOF {
 				return err
 			}


### PR DESCRIPTION
A Go redefinition error causes pprof to skip parsing profile mappings.

Inadvertently created a new variable in the inner check means the variable in the loop is not updated.