### PR TITLE
Apply -1 adjustment to leaf frames for some legacy profiles

### DIFF
--- a/profile/legacy_profile.go
+++ b/profile/legacy_profile.go
@@ -114,11 +114,8 @@ func parseGoCount(b []byte) (*Profile, error) {
 			if err != nil {
 				return nil, errMalformed
 			}
-			// Adjust all frames by -1 (except the leaf) to land on top of
-			// the call instruction.
-			if len(locs) > 0 {
-				addr--
-			}
+			// Adjust all frames by -1 to land on top of the call instruction.
+			addr--
 			loc := locations[addr]
 			if loc == nil {
 				loc = &Location{
@@ -527,13 +524,10 @@ func parseHeap(b []byte) (p *Profile, err error) {
 		}
 
 		var sloc []*Location
-		for i, addr := range addrs {
+		for _, addr := range addrs {
 			// Addresses from stack traces point to the next instruction after
-			// each call.  Adjust by -1 to land somewhere on the actual call
-			// (except for the leaf, which is not a call).
-			if i > 0 {
-				addr--
-			}
+			// each call.  Adjust by -1 to land somewhere on the actual call.
+			addr--
 			loc := locs[addr]
 			if locs[addr] == nil {
 				loc = &Location{
@@ -769,13 +763,10 @@ func parseContention(b []byte) (p *Profile, err error) {
 			return nil, err
 		}
 		var sloc []*Location
-		for i, addr := range addrs {
+		for _, addr := range addrs {
 			// Addresses from stack traces point to the next instruction after
-			// each call.  Adjust by -1 to land somewhere on the actual call
-			// (except for the leaf, which is not a call).
-			if i > 0 {
-				addr--
-			}
+			// each call.  Adjust by -1 to land somewhere on the actual call.
+			addr--
 			loc := locs[addr]
 			if locs[addr] == nil {
 				loc = &Location{

--- a/profile/testdata/cppbench.contention.string
+++ b/profile/testdata/cppbench.contention.string
@@ -10,7 +10,7 @@ contentions/count delay/nanoseconds
         100      75976: 1 15 16 17 18 25 26 27 28 29 30 31 32 33 34 9 
         300   63568134: 1 35 36 37 38 39 40 6 7 8 9 10 11 12 13 
 Locations
-     1: 0xbccc97 M=1 
+     1: 0xbccc96 M=1
      2: 0xc61201 M=1 
      3: 0x42ed5e M=1 
      4: 0x42edc0 M=1 

--- a/profile/testdata/cppbench.growth.string
+++ b/profile/testdata/cppbench.growth.string
@@ -173,7 +173,7 @@ objects/count space/bytes
           1    2097152: 1 2 3 58 59 60 
                 bytes:[2097152] 
 Locations
-     1: 0xb83003 M=1 
+     1: 0xb83002 M=1
      2: 0xb87d4f M=1 
      3: 0xc635ef M=1 
      4: 0x42ecc2 M=1 
@@ -186,7 +186,7 @@ Locations
     11: 0x7a296c M=1 
     12: 0xa456e3 M=1 
     13: 0x7fcdc2ff214d M=7 
-    14: 0xc635c8 M=1 
+    14: 0xc635c7 M=1
     15: 0xafc0ea M=1 
     16: 0xb087b0 M=1 
     17: 0xb0aa7c M=1 

--- a/profile/testdata/cppbench.heap.string
+++ b/profile/testdata/cppbench.heap.string
@@ -65,7 +65,7 @@ objects/count space/bytes
         379   12439381: 1 2 3 4 5 6 7 8 9 10 11 
                 bytes:[32768] 
 Locations
-     1: 0xc635c8 M=1 
+     1: 0xc635c7 M=1
      2: 0x42ecc2 M=1 
      3: 0x42e14b M=1 
      4: 0x5261ae M=1 
@@ -119,7 +119,7 @@ Locations
     52: 0x41c710 M=1 
     53: 0xc25cc5 M=1 
     54: 0x40651a M=1 
-    55: 0xc63568 M=1 
+    55: 0xc63567 M=1
     56: 0xbc462d M=1 
     57: 0xbc4bb4 M=1 
     58: 0xbc4ed9 M=1 

--- a/profile/testdata/go.godoc.thread.string
+++ b/profile/testdata/go.godoc.thread.string
@@ -10,7 +10,7 @@ threadcreate/count
           1: 1 19 20 21 
           1: 22 23 
 Locations
-     1: 0x44cb3 M=1 
+     1: 0x44cb2 M=1
      2: 0x45044 M=1 
      3: 0x45322 M=1 
      4: 0x45533 M=1 
@@ -23,15 +23,15 @@ Locations
     11: 0x51583 M=1 
     12: 0x461df M=1 
     13: 0x45546 M=1 
-    14: 0x40962 M=1 
+    14: 0x40962 M=1
     15: 0x4562d M=1 
     16: 0x460ec M=1 
     17: 0x51a58 M=1 
     18: 0x441ad M=1 
-    19: 0x44e03 M=1 
+    19: 0x44e03 M=1
     20: 0x44b7f M=1 
     21: 0x5192c M=1 
-    22: 0x440e2 M=1 
+    22: 0x440e1 M=1
     23: 0x51919 M=1 
 Mappings
 1: 0x0/0xffffffffffffffff/0x0   

--- a/profile/testdata/gobench.heap.string
+++ b/profile/testdata/gobench.heap.string
@@ -33,7 +33,7 @@ alloc_objects/count alloc_space/bytes inuse_objects/count inuse_space/bytes
       32768     524296          0          0: 1 88 89 90 91 92 93 94 95 96 97 98 99 100 10 
                 bytes:[16] 
 Locations
-     1: 0x420cef M=1 
+     1: 0x420cee M=1
      2: 0x422150 M=1 
      3: 0x4221d9 M=1 
      4: 0x41dc0c M=1 


### PR DESCRIPTION
Legacy profiles that are not based on interrupt-based sampling
only include addresses that are call stack return addresses. For
them, all callstack addresses should be adjusted by -1 to land
on top of the call instruction and permit accurate symbolization.