### PR TITLE
Generate kcachegrind reports under line granularity

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -135,7 +135,7 @@ func applyCommandOverrides(cmd []string, v variables) variables {
 		v.set("addressnoinlines", "t")
 	case "peek":
 		trim, focus, hide = false, false, false
-	case "callgrind", "list":
+	case "kcachegrind", "callgrind", "list":
 		v.set("nodecount", "0")
 		v.set("lines", "t")
 	case "text", "top", "topproto":


### PR DESCRIPTION
Callgrind reports are generated with line granularity since kcachegrind
can take advantage of the information. However, kcachegrind reports were
not being generated with that granularity, creating an unnecessary difference.