### PR TITLE
Add source_path option to point pprof to source files

### DIFF
--- a/internal/driver/commands.go
+++ b/internal/driver/commands.go
@@ -152,6 +152,7 @@ var pprofVariables = variables{
 		" For memory profiles, use megabytes, kilobytes, bytes, etc.",
 		" auto will scale each value independently to the most natural unit.")},
 	"compact_labels": &variable{boolKind, "f", "", "Show minimal headers"},
+	"source_path":    &variable{stringKind, "", "", "Search path for source files"},
 
 	// Filtering options
 	"nodecount": &variable{intKind, "-1", "", helpText(

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -235,6 +235,8 @@ func reportOptions(p *profile.Profile, vars variables) (*report.Options, error) 
 		SampleUnit:  sample.Unit,
 
 		OutputUnit: vars["unit"].value,
+
+		SourcePath: vars["source_path"].stringValue(),
 	}
 
 	if len(p.Mapping) > 0 && p.Mapping[0].File != "" {

--- a/internal/driver/interactive.go
+++ b/internal/driver/interactive.go
@@ -167,6 +167,8 @@ func pprofPrompt(p *profile.Profile) string {
 			if o.boolValue() == false {
 				continue
 			}
+		case n == "source_path":
+			continue
 		}
 		args = append(args, fmt.Sprintf("  %-25s : %s", n, v))
 	}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -881,7 +881,8 @@ type Options struct {
 
 	OutputUnit string // Units for data formatting in report.
 
-	Symbol *regexp.Regexp // Symbols to include on disassembly report.
+	Symbol     *regexp.Regexp // Symbols to include on disassembly report.
+	SourcePath string         // Search path for source files.
 }
 
 // New builds a new report indexing the sample values interpreting the

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -431,9 +431,9 @@ func getMissingFunctionSource(filename string, asm map[int]graph.Nodes, start, e
 
 // openSourceFile opens a source file from a name encoded in a
 // profile. File names in a profile after often relative paths, so
-// search them in each of the paths in sourcePath (or CWD by default),
+// search them in each of the paths in searchPath (or CWD by default),
 // and their parents.
-func openSourceFile(path string, sourcePath string) (*os.File, string, error) {
+func openSourceFile(path, searchPath string) (*os.File, string, error) {
 	path = trimPath(path)
 
 	if filepath.IsAbs(path) {
@@ -442,7 +442,7 @@ func openSourceFile(path string, sourcePath string) (*os.File, string, error) {
 	}
 
 	// Scan each component of the path
-	for _, dir := range strings.Split(sourcePath, ":") {
+	for _, dir := range strings.Split(searchPath, ":") {
 		// Search up for every parent of each possible path.
 		for {
 			filename := filepath.Join(dir, path)
@@ -457,7 +457,7 @@ func openSourceFile(path string, sourcePath string) (*os.File, string, error) {
 		}
 	}
 
-	return nil, "", fmt.Errorf("Could not find file %s on path %s", path, sourcePath)
+	return nil, "", fmt.Errorf("Could not find file %s on path %s", path, searchPath)
 }
 
 // trimPath cleans up a path by removing prefixes that are commonly

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -55,6 +55,15 @@ func printSource(w io.Writer, rpt *Report) error {
 	}
 	functions.Sort(graph.NameOrder)
 
+	sourcePath := o.SourcePath
+	if sourcePath == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("Could not stat current dir: %v", err)
+		}
+		sourcePath = wd
+	}
+
 	fmt.Fprintf(w, "Total: %s\n", rpt.formatValue(rpt.total))
 	for _, fn := range functions {
 		name := fn.Info.Name
@@ -86,7 +95,7 @@ func printSource(w io.Writer, rpt *Report) error {
 			fns := fileNodes[filename]
 			flatSum, cumSum := fns.Sum()
 
-			fnodes, path, err := getFunctionSource(name, filename, fns, 0, 0)
+			fnodes, path, err := getFunctionSource(name, filename, sourcePath, fns, 0, 0)
 			fmt.Fprintf(w, "ROUTINE ======================== %s in %s\n", name, path)
 			fmt.Fprintf(w, "%10s %10s (flat, cum) %s of Total\n",
 				rpt.formatValue(flatSum), rpt.formatValue(cumSum),
@@ -116,6 +125,15 @@ func printWebSource(w io.Writer, rpt *Report, obj plugin.ObjTool) error {
 	var address *uint64
 	if hex, err := strconv.ParseUint(o.Symbol.String(), 0, 64); err == nil {
 		address = &hex
+	}
+
+	sourcePath := o.SourcePath
+	if sourcePath == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("Could not stat current dir: %v", err)
+		}
+		sourcePath = wd
 	}
 
 	// Extract interesting symbols from binary files in the profile and
@@ -166,7 +184,7 @@ func printWebSource(w io.Writer, rpt *Report, obj plugin.ObjTool) error {
 			asm := assemblyPerSourceLine(symbols, fns, filename, obj)
 			start, end := sourceCoordinates(asm)
 
-			fnodes, path, err := getFunctionSource(name, filename, fns, start, end)
+			fnodes, path, err := getFunctionSource(name, filename, sourcePath, fns, start, end)
 			if err != nil {
 				fnodes, path = getMissingFunctionSource(filename, asm, start, end)
 			}
@@ -319,8 +337,8 @@ func printPageClosing(w io.Writer) {
 // getFunctionSource collects the sources of a function from a source
 // file and annotates it with the samples in fns. Returns the sources
 // as nodes, using the info.name field to hold the source code.
-func getFunctionSource(fun, file string, fns graph.Nodes, start, end int) (graph.Nodes, string, error) {
-	f, file, err := adjustSourcePath(file)
+func getFunctionSource(fun, file, sourcePath string, fns graph.Nodes, start, end int) (graph.Nodes, string, error) {
+	f, file, err := openSourceFile(file, sourcePath)
 	if err != nil {
 		return nil, file, err
 	}
@@ -411,31 +429,35 @@ func getMissingFunctionSource(filename string, asm map[int]graph.Nodes, start, e
 	return fnodes, filename
 }
 
-// adjustSourcePath adjusts the path for a source file by trimmming
-// known prefixes and searching for the file on all parents of the
-// current working dir.
-func adjustSourcePath(path string) (*os.File, string, error) {
+// openSourceFile opens a source file from a name encoded in a
+// profile. File names in a profile after often relative paths, so
+// search them in each of the paths in sourcePath (or CWD by default),
+// and their parents.
+func openSourceFile(path string, sourcePath string) (*os.File, string, error) {
 	path = trimPath(path)
-	f, err := os.Open(path)
-	if err == nil {
-		return f, path, nil
+
+	if filepath.IsAbs(path) {
+		f, err := os.Open(path)
+		return f, path, err
 	}
 
-	if dir, wderr := os.Getwd(); wderr == nil {
+	// Scan each component of the path
+	for _, dir := range strings.Split(sourcePath, ":") {
+		// Search up for every parent of each possible path.
 		for {
+			filename := filepath.Join(dir, path)
+			if f, err := os.Open(filename); err == nil {
+				return f, filename, nil
+			}
 			parent := filepath.Dir(dir)
 			if parent == dir {
 				break
 			}
-			if f, err := os.Open(filepath.Join(parent, path)); err == nil {
-				return f, filepath.Join(parent, path), nil
-			}
-
 			dir = parent
 		}
 	}
 
-	return nil, path, err
+	return nil, "", fmt.Errorf("Could not find file %s on path %s", path, sourcePath)
 }
 
 // trimPath cleans up a path by removing prefixes that are commonly


### PR DESCRIPTION
Currently pprof will look for source files only on the current directory
and its parents. This makes it hard to examine sources on jobs where
there are multiple source trees (eg from different libraries).

Add a variable to provide a search path for source files. It will default
to the cwd, so there will be no change in behavior by default.