### PR TITLE
Add mechanism for extensions to set variable defaults

### DIFF
--- a/internal/driver/commands.go
+++ b/internal/driver/commands.go
@@ -68,6 +68,14 @@ func AddCommand(cmd string, format int, post PostProcessor, desc, usage string) 
 	pprofCommands[cmd] = &command{format, post, false, desc, usage}
 }
 
+// SetDefault sets the default value for a pprof variable. This enables
+// extensions to set their own default values for variables.
+func SetVariableDefault(variable, value string) {
+	if v := pprofVariables[variable]; v != nil {
+		v.value = value
+	}
+}
+
 // PostProcessor is a function that applies post-processing to the report output
 type PostProcessor func(input []byte, output io.Writer, ui plugin.UI) error
 

--- a/internal/driver/commands.go
+++ b/internal/driver/commands.go
@@ -68,8 +68,8 @@ func AddCommand(cmd string, format int, post PostProcessor, desc, usage string) 
 	pprofCommands[cmd] = &command{format, post, false, desc, usage}
 }
 
-// SetDefault sets the default value for a pprof variable. This enables
-// extensions to set their own default values for variables.
+// SetVariableDefault sets the default value for a pprof
+// variable. This enables extensions to set their own defaults.
 func SetVariableDefault(variable, value string) {
 	if v := pprofVariables[variable]; v != nil {
 		v.value = value


### PR DESCRIPTION
This enables pprof extensions to update the default for a variable
before the command line is processed.