### PR TITLE
Add symbolization support for Mach-O

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -273,12 +273,18 @@ func collectMappingSources(p *profile.Profile, source string) plugin.MappingSour
 		}{
 			source, m.Start,
 		}
-		if key := m.BuildID; key != "" {
-			ms[key] = append(ms[key], src)
+		key := m.BuildID
+		if key == "" {
+			key = m.File
 		}
-		if key := m.File; key != "" {
-			ms[key] = append(ms[key], src)
+		if key == "" {
+			// If there is no build id or source file, use the source as the
+			// mapping file. This will enable remote symbolization for this
+			// mapping, in particular for Go profiles on the legacy format.
+			m.File = source
+			key = source
 		}
+		ms[key] = append(ms[key], src)
 	}
 	return ms
 }


### PR DESCRIPTION
This will enable symbolization support for Go on Mac OS
It re-enables symbolization using debug/pprof/symbol on
Go profiles in the legacy format, and implements basic
mach-O support on the binutils package.

This should help address #12
I've only tested it with Go binaries