### PR TITLE
Speed up profile encode/decode

### DIFF
--- a/profile/encode.go
+++ b/profile/encode.go
@@ -70,9 +70,9 @@ func (p *Profile) preEncode() {
 				)
 			}
 		}
-		s.locationIDX = nil
-		for _, l := range s.Location {
-			s.locationIDX = append(s.locationIDX, l.ID)
+		s.locationIDX = make([]uint64, len(s.Location))
+		for i, loc := range s.Location {
+			s.locationIDX[i] = loc.ID
 		}
 	}
 
@@ -177,9 +177,13 @@ var profileDecoder = []decoder{
 	// repeated Location location = 4
 	func(b *buffer, m message) error {
 		x := new(Location)
+		x.Line = make([]Line, 0, 8) // Pre-allocate Line buffer
 		pp := m.(*Profile)
 		pp.Location = append(pp.Location, x)
-		return decodeMessage(b, x)
+		err := decodeMessage(b, x)
+		var tmp []Line
+		x.Line = append(tmp, x.Line...) // Shrink to allocated size
+		return err
 	},
 	// repeated Function function = 5
 	func(b *buffer, m message) error {
@@ -282,9 +286,9 @@ func (p *Profile) postDecode() error {
 		if len(numLabels) > 0 {
 			s.NumLabel = numLabels
 		}
-		s.Location = nil
-		for _, lid := range s.locationIDX {
-			s.Location = append(s.Location, locations[lid])
+		s.Location = make([]*Location, len(s.locationIDX))
+		for i, lid := range s.locationIDX {
+			s.Location[i] = locations[lid]
 		}
 		s.locationIDX = nil
 	}

--- a/profile/proto.go
+++ b/profile/proto.go
@@ -290,6 +290,7 @@ func decodeInt64s(b *buffer, x *[]int64) error {
 	if b.typ == 2 {
 		// Packed encoding
 		data := b.data
+		tmp := make([]int64, 0, len(data)) // Maximally sized
 		for len(data) > 0 {
 			var u uint64
 			var err error
@@ -297,8 +298,9 @@ func decodeInt64s(b *buffer, x *[]int64) error {
 			if u, data, err = decodeVarint(data); err != nil {
 				return err
 			}
-			*x = append(*x, int64(u))
+			tmp = append(tmp, int64(u))
 		}
+		*x = append(*x, tmp...)
 		return nil
 	}
 	var i int64
@@ -321,6 +323,7 @@ func decodeUint64s(b *buffer, x *[]uint64) error {
 	if b.typ == 2 {
 		data := b.data
 		// Packed encoding
+		tmp := make([]uint64, 0, len(data)) // Maximally sized
 		for len(data) > 0 {
 			var u uint64
 			var err error
@@ -328,8 +331,9 @@ func decodeUint64s(b *buffer, x *[]uint64) error {
 			if u, data, err = decodeVarint(data); err != nil {
 				return err
 			}
-			*x = append(*x, u)
+			tmp = append(tmp, u)
 		}
+		*x = append(*x, tmp...)
 		return nil
 	}
 	var u uint64


### PR DESCRIPTION
Preallocate arrays to avoid repeated growth during profile encode/decode