### PR TITLE
Ignore system name when merging nodes

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -584,7 +584,7 @@ func printTraces(w io.Writer, rpt *Report) error {
 
 	const separator = "-----------+-------------------------------------------------------"
 
-	_, locations := graph.CreateNodes(prof, false, nil)
+	_, locations := graph.CreateNodes(prof, &graph.Options{})
 	for _, sample := range prof.Sample {
 		var stack graph.Nodes
 		for _, loc := range sample.Location {


### PR DESCRIPTION
This will allow merging nodes for multiple instantiations of
C++ templates. A graph option is introduced to preserve older
behavior.

To implement this the full Option struct is plumbed through to the nodeInfo
function, which creates the graph Node from the profile Location. Previously
some members of that struct were passed separately.