### PR TITLE
Add "options" command

### DIFF
--- a/internal/driver/commands.go
+++ b/internal/driver/commands.go
@@ -536,6 +536,7 @@ func (vars variables) set(name, value string) error {
 	case floatKind:
 		_, err = strconv.ParseFloat(value, 64)
 	case stringKind:
+		// Remove quotes, particularly useful for empty values.
 		if len(value) > 1 && strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
 			value = value[1 : len(value)-1]
 		}

--- a/internal/driver/commands.go
+++ b/internal/driver/commands.go
@@ -268,6 +268,7 @@ func usage(commandLine bool) string {
 		help = "  Output formats (select only one):\n"
 	} else {
 		help = "  Commands:\n"
+		commands = append(commands, fmtHelp("o/options", "List options and their current values"))
 		commands = append(commands, fmtHelp("quit/exit/^D", "Exit pprof"))
 	}
 
@@ -534,6 +535,10 @@ func (vars variables) set(name, value string) error {
 		_, err = strconv.Atoi(value)
 	case floatKind:
 		_, err = strconv.ParseFloat(value, 64)
+	case stringKind:
+		if len(value) > 1 && strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
+			value = value[1 : len(value)-1]
+		}
 	}
 	if err != nil {
 		return err

--- a/internal/driver/interactive.go
+++ b/internal/driver/interactive.go
@@ -26,6 +26,8 @@ import (
 	"github.com/google/pprof/profile"
 )
 
+var commentStart = "//:" // Sentinel for comments on options
+
 // interactive starts a shell to read pprof commands.
 func interactive(p *profile.Profile, o *plugin.Options) error {
 	// Enter command processing loop.
@@ -40,7 +42,7 @@ func interactive(p *profile.Profile, o *plugin.Options) error {
 
 	greetings(p, o.UI)
 	for {
-		input, err := o.UI.ReadLine(pprofPrompt(p))
+		input, err := o.UI.ReadLine("(pprof) ")
 		if err != nil {
 			if err != io.EOF {
 				return err
@@ -54,13 +56,30 @@ func interactive(p *profile.Profile, o *plugin.Options) error {
 			// Process assignments of the form variable=value
 			if s := strings.SplitN(input, "=", 2); len(s) > 0 {
 				name := strings.TrimSpace(s[0])
-
+				var value string
+				if len(s) == 2 {
+					value = s[1]
+					if comment := strings.LastIndex(value, commentStart); comment != -1 {
+						value = value[:comment]
+					}
+					value = strings.TrimSpace(value)
+				}
 				if v := pprofVariables[name]; v != nil {
-					var value string
-					if len(s) == 2 {
-						value = strings.TrimSpace(s[1])
+					if name == "sample_index" {
+						index, err := locateSampleIndex(p, value)
+						if err != nil {
+							o.UI.PrintErr(err)
+							continue
+						}
+						value = p.SampleType[index].Type
 					}
 					if err := pprofVariables.set(name, value); err != nil {
+						o.UI.PrintErr(err)
+					}
+					continue
+				}
+				if v := pprofVariables[value]; v != nil && v.group == name {
+					if err := pprofVariables.set(value, ""); err != nil {
 						o.UI.PrintErr(err)
 					}
 					continue
@@ -73,6 +92,9 @@ func interactive(p *profile.Profile, o *plugin.Options) error {
 			}
 
 			switch tokens[0] {
+			case "o", "options":
+				printCurrentOptions(p, o.UI)
+				continue
 			case "exit", "quit":
 				return nil
 			case "help":
@@ -100,9 +122,8 @@ func greetings(p *profile.Profile, ui plugin.UI) {
 	ropt, err := reportOptions(p, pprofVariables)
 	if err == nil {
 		ui.Print(strings.Join(report.ProfileLabels(report.New(p, ropt)), "\n"))
-		ui.Print(fmt.Sprintf("Sample types: %v\n", sampleTypes(p)))
 	}
-	ui.Print("Entering interactive mode (type \"help\" for commands)")
+	ui.Print("Entering interactive mode (type \"help\" for commands, \"o\" for options)")
 }
 
 // shortcuts represents composite commands that expand into a sequence
@@ -110,6 +131,7 @@ func greetings(p *profile.Profile, ui plugin.UI) {
 type shortcuts map[string][]string
 
 func (a shortcuts) expand(input string) []string {
+	input = strings.TrimSpace(input)
 	if a != nil {
 		if r, ok := a[input]; ok {
 			return r
@@ -135,45 +157,54 @@ func profileShortcuts(p *profile.Profile) shortcuts {
 	return s
 }
 
-// pprofPrompt returns the prompt displayed to accept commands.
-// hides some default values to reduce clutter.
-func pprofPrompt(p *profile.Profile) string {
+func printCurrentOptions(p *profile.Profile, ui plugin.UI) {
 	var args []string
+	type groupInfo struct {
+		set    string
+		values []string
+	}
+	groups := make(map[string]*groupInfo)
 	for n, o := range pprofVariables {
 		v := o.stringValue()
-		if v == "" {
+		comment := ""
+		if g := o.group; g != "" {
+			gi, ok := groups[g]
+			if !ok {
+				gi = &groupInfo{}
+				groups[g] = gi
+			}
+			if o.boolValue() {
+				gi.set = n
+			}
+			gi.values = append(gi.values, n)
 			continue
 		}
-		// Do not show some default values.
 		switch {
-		case n == "unit" && v == "minimum":
-			continue
-		case n == "divide_by" && v == "1":
-			continue
-		case n == "nodecount" && v == "-1":
-			continue
 		case n == "sample_index":
-			index, err := locateSampleIndex(p, v)
-			if err != nil {
-				v = "ERROR: " + err.Error()
-			} else {
-				v = fmt.Sprintf("%s (%d)", p.SampleType[index].Type, index)
+			st := sampleTypes(p)
+			if v == "" {
+				v = st[len(st)-1]
 			}
-		case n == "trim" || n == "compact_labels":
-			if o.boolValue() == true {
-				continue
-			}
-		case o.kind == boolKind:
-			if o.boolValue() == false {
-				continue
-			}
+			comment = "[" + strings.Join(st, " | ") + "]"
 		case n == "source_path":
 			continue
+		case n == "nodecount" && v == "-1":
+			comment = "default"
+		case v == "":
+			v = `""`
 		}
-		args = append(args, fmt.Sprintf("  %-25s : %s", n, v))
+		if comment != "" {
+			comment = commentStart + " " + comment
+		}
+		args = append(args, fmt.Sprintf("  %-25s = %-20s %s", n, v, comment))
+	}
+	for g, vars := range groups {
+		sort.Strings(vars.values)
+		comment := commentStart + " [" + strings.Join(vars.values, " | ") + "]"
+		args = append(args, fmt.Sprintf("  %-25s = %-20s %s", g, vars.set, comment))
 	}
 	sort.Strings(args)
-	return "Options:\n" + strings.Join(args, "\n") + "\nPPROF>"
+	ui.PrintErr(strings.Join(args, "\n"))
 }
 
 // parseCommandLine parses a command and returns the pprof command to

--- a/internal/driver/interactive.go
+++ b/internal/driver/interactive.go
@@ -66,6 +66,7 @@ func interactive(p *profile.Profile, o *plugin.Options) error {
 				}
 				if v := pprofVariables[name]; v != nil {
 					if name == "sample_index" {
+						// Error check sample_index=xxx to ensure xxx is a valid sample type.
 						index, err := locateSampleIndex(p, value)
 						if err != nil {
 							o.UI.PrintErr(err)
@@ -78,6 +79,7 @@ func interactive(p *profile.Profile, o *plugin.Options) error {
 					}
 					continue
 				}
+				// Allow group=variable syntax by converting into variable="".
 				if v := pprofVariables[value]; v != nil && v.group == name {
 					if err := pprofVariables.set(value, ""); err != nil {
 						o.UI.PrintErr(err)
@@ -183,14 +185,17 @@ func printCurrentOptions(p *profile.Profile, ui plugin.UI) {
 		case n == "sample_index":
 			st := sampleTypes(p)
 			if v == "" {
+				// Apply default (last sample index).
 				v = st[len(st)-1]
 			}
+			// Add comments for all sample types in profile.
 			comment = "[" + strings.Join(st, " | ") + "]"
 		case n == "source_path":
 			continue
 		case n == "nodecount" && v == "-1":
 			comment = "default"
 		case v == "":
+			// Add quotes for empty values.
 			v = `""`
 		}
 		if comment != "" {
@@ -204,7 +209,7 @@ func printCurrentOptions(p *profile.Profile, ui plugin.UI) {
 		args = append(args, fmt.Sprintf("  %-25s = %-20s %s", g, vars.set, comment))
 	}
 	sort.Strings(args)
-	ui.PrintErr(strings.Join(args, "\n"))
+	ui.Print(strings.Join(args, "\n"))
 }
 
 // parseCommandLine parses a command and returns the pprof command to


### PR DESCRIPTION
Instead of showing all active options on the command prompt, add an "options" command that
shows the currently active options.

Before:
Type: cpu
Sample types: [samples cpu]
Entering interactive mode (type "help" for commands)
Options:
  edgefraction              : 0.001
  flat                      : true
  functions                 : true
  nodefraction              : 0.005
PPROF>top 3
Showing nodes accounting for 40.08mins, 17.35% of 230.99mins total
Dropped 11940 nodes (cum <= 1.15mins)
Showing top 3 nodes out of 263
      flat  flat%   sum%        cum   cum%
 25.96mins 11.24% 11.24%  25.96mins 11.24%  bar
  7.47mins  3.24% 14.47%   7.52mins  3.26%  foo
  6.65mins  2.88% 17.35%   6.65mins  2.88%  tee
Options:
  edgefraction              : 0.001
  flat                      : true
  functions                 : true
  nodefraction              : 0.005
PPROF>

After:
(pprof) top 3
Showing nodes accounting for 40.08mins, 17.35% of 230.99mins total
Dropped 11940 nodes (cum <= 1.15mins)
Showing top 3 nodes out of 263
      flat  flat%   sum%        cum   cum%
 25.96mins 11.24% 11.24%  25.96mins 11.24%  bar
  7.47mins  3.24% 14.47%   7.52mins  3.26%  foo
  6.65mins  2.88% 17.35%   6.65mins  2.88%  tee
(pprof) o
  call_tree                 = false                
  compact_labels            = true                 
  cumulative                = flat                 //: [cum | flat]
  divide_by                 = 1                    
  drop_negative             = false                
  edgefraction              = 0.001                
  focus                     = ""                   
  granularity               = functions            //: [addresses | addressnoinlines | files | functionnameonly | functions | lines | noinlines]
  hide                      = ""                   
  ignore                    = ""                   
  mean                      = false                
  nodecount                 = -1                   //: default
  nodefraction              = 0.005                
  output                    = ""                   
  positive_percentages      = false                
  prune_from                = ""                   
  relative_percentages      = false                
  sample_index              = cpu                  //: [samples | cpu]
  show                      = ""                   
  tagfocus                  = ""                   
  taghide                   = ""                   
  tagignore                 = ""                   
  tagshow                   = ""                   
  trim                      = true                 
  unit                      = minimum              
