### PR TITLE
Reset mapping file to empty string if it was patched to be the source URL

### DIFF
--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -297,6 +298,13 @@ func newMapping(prof *profile.Profile, obj plugin.ObjTool, ui plugin.UI, force b
 		name := filepath.Base(m.File)
 		if name == "[vdso]" || strings.HasPrefix(name, "linux-vdso") {
 			continue
+		}
+
+		// Skip mappings pointing to a source URL
+		if m.BuildID == "" {
+			if u, err := url.Parse(m.File); err == nil && u.IsAbs() {
+				continue
+			}
 		}
 
 		f, err := obj.Open(m.File, m.Start, m.Limit, m.Offset)


### PR DESCRIPTION
When the source is remote and a mapping doesn't have either build ID or
file field set, the file field is set to the source URL so that the
proper source from the source mapping is used during symbolz processing.
Before this change, the file field would continue to point to the URL
producing the URL in pprof output which confuses users.

With the change it resets the file field back to the empty string. It
also now skips the URL-like paths during local symbolization as
reading at that path is not going to succeed.

We discussed switching to generating more unique IDs. On the second
thought, I propose leaving these to be URLs as that seems unique enough
and in case this field leaks into the tool or log output seeing the URL
seems still friendlier than some arbitrarily prefixed string.