### PR TITLE
Upstream minor changes from golang version of pprof

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -123,7 +123,7 @@ type MappingSources map[string][]struct {
 
 // An ObjTool inspects shared libraries and executable files.
 type ObjTool interface {
-	// Open opens the named object file.  If the object is a shared
+	// Open opens the named object file. If the object is a shared
 	// library, start/limit/offset are the addresses where it is mapped
 	// into memory in the address space being inspected.
 	Open(file string, start, limit, offset uint64) (ObjFile, error)

--- a/internal/binutils/addr2liner.go
+++ b/internal/binutils/addr2liner.go
@@ -129,7 +129,7 @@ func (d *addr2Liner) readFrame() (plugin.Frame, bool) {
 	}
 	if strings.HasPrefix(funcname, "0x") {
 		// If addr2line returns a hex address we can assume it is the
-		// sentinel.  Read and ignore next two lines of output from
+		// sentinel. Read and ignore next two lines of output from
 		// addr2line
 		d.readString()
 		d.readString()
@@ -204,7 +204,7 @@ func (d *addr2Liner) addrInfo(addr uint64) ([]plugin.Frame, error) {
 		nm, err := d.nm.addrInfo(addr)
 		if err == nil && len(nm) > 0 {
 			// Last entry in frame list should match since
-			// it is non-inlined.  As a simple heuristic,
+			// it is non-inlined. As a simple heuristic,
 			// we only switch to the nm-based name if it
 			// is longer.
 			nmName := nm[len(nm)-1].Func

--- a/internal/binutils/binutils.go
+++ b/internal/binutils/binutils.go
@@ -164,10 +164,10 @@ func (b *Binutils) openELF(name string, start, limit, offset uint64) (plugin.Obj
 	var pageAligned = func(addr uint64) bool { return addr%4096 == 0 }
 	if strings.Contains(name, "vmlinux") || !pageAligned(start) || !pageAligned(limit) || !pageAligned(offset) {
 		// Reading all Symbols is expensive, and we only rarely need it so
-		// we don't want to do it every time.  But if _stext happens to be
+		// we don't want to do it every time. But if _stext happens to be
 		// page-aligned but isn't the same as Vaddr, we would symbolize
-		// wrong.  So if the name the addresses aren't page aligned, or if
-		// the name is "vmlinux" we read _stext.  We can be wrong if: (1)
+		// wrong. So if the name the addresses aren't page aligned, or if
+		// the name is "vmlinux" we read _stext. We can be wrong if: (1)
 		// someone passes a kernel path that doesn't contain "vmlinux" AND
 		// (2) _stext is page-aligned AND (3) _stext is not at Vaddr
 		symbols, err := ef.Symbols()

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -107,6 +107,10 @@ func generateReport(p *profile.Profile, cmd []string, vars variables, o *plugin.
 		}
 	}
 
+	if len(p.Sample) == 0 {
+		return fmt.Errorf("profile is empty")
+	}
+
 	if err := aggregate(p, vars); err != nil {
 		return err
 	}

--- a/internal/driver/testdata/pprof.cpu.flat.addresses.weblist
+++ b/internal/driver/testdata/pprof.cpu.flat.addresses.weblist
@@ -67,7 +67,7 @@ function pprof_toggle_asm(e) {
 <div class="legend">File: testbinary<br>
 Type: cpu<br>
 Duration: 10s, Total samples = 1.12s (11.20%)<br>Total: 1.12s</div><h1>line1000</h1>testdata/file1000.src
-<pre onClick="pprof_toggle_asm()">
+<pre onClick="pprof_toggle_asm(event)">
   Total:       1.10s      1.10s (flat, cum) 98.21%
 <span class=line>      1</span> <span class=deadsrc>       1.10s      1.10s line1 </span><span class=asm>               1.10s      1.10s     1000: instruction one                                  <span class=disasmloc>testdata/file1000.src:1</span>
                    .          .     1001: instruction two                                  <span class=disasmloc></span>
@@ -81,7 +81,7 @@ Duration: 10s, Total samples = 1.12s (11.20%)<br>Total: 1.12s</div><h1>line1000<
 <span class=line>      6</span> <span class=nop>           .          . line6 </span>
 </pre>
 <h1>line3000</h1>testdata/file3000.src
-<pre onClick="pprof_toggle_asm()">
+<pre onClick="pprof_toggle_asm(event)">
   Total:        10ms      1.12s (flat, cum)   100%
 <span class=line>      1</span> <span class=nop>           .          . line1 </span>
 <span class=line>      2</span> <span class=nop>           .          . line2 </span>

--- a/internal/elfexec/elfexec.go
+++ b/internal/elfexec/elfexec.go
@@ -166,10 +166,10 @@ func GetBuildID(binary io.ReaderAt) ([]byte, error) {
 }
 
 // GetBase determines the base address to subtract from virtual
-// address to get symbol table address.  For an executable, the base
-// is 0.  Otherwise, it's a shared library, and the base is the
-// address where the mapping starts.  The kernel is special, and may
-// use the address of the _stext symbol as the mmap start.  _stext
+// address to get symbol table address. For an executable, the base
+// is 0. Otherwise, it's a shared library, and the base is the
+// address where the mapping starts. The kernel is special, and may
+// use the address of the _stext symbol as the mmap start. _stext
 // offset can be obtained with `nm vmlinux | grep _stext`
 func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint64, start, limit, offset uint64) (uint64, error) {
 	const (
@@ -193,8 +193,8 @@ func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint6
 			return 0, nil
 		}
 		if start == 0 && limit != 0 {
-			// ChromeOS remaps its kernel to 0.  Nothing else should come
-			// down this path.  Empirical values:
+			// ChromeOS remaps its kernel to 0. Nothing else should come
+			// down this path. Empirical values:
 			//       VADDR=0xffffffff80200000
 			// stextOffset=0xffffffff80200198
 			if stextOffset != nil {
@@ -217,7 +217,7 @@ func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint6
 			//      Offset=0 (0xc000000000000000 for PowerPC64)
 			// So the base should be:
 			if stextOffset != nil && (start%pageSize) == (*stextOffset%pageSize) {
-				// perf uses the address of _stext as start.  Some tools may
+				// perf uses the address of _stext as start. Some tools may
 				// adjust for this before calling GetBase, in which case the the page
 				// alignment should be different from that of stextOffset.
 				return start - *stextOffset, nil
@@ -225,8 +225,8 @@ func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint6
 
 			return start - loadSegment.Vaddr, nil
 		} else if start < loadSegment.Vaddr && start%pageSize != 0 && stextOffset != nil && *stextOffset%pageSize == start%pageSize {
-			// ChromeOS remaps its kernel to 0 + start%pageSize.  Nothing
-			// else should come down this path.  Empirical values:
+			// ChromeOS remaps its kernel to 0 + start%pageSize. Nothing
+			// else should come down this path. Empirical values:
 			//       start=0x198 limit=0x2f9fffff offset=0
 			//       VADDR=0xffffffff81000000
 			// stextOffset=0xffffffff81000198

--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -313,7 +313,7 @@ func (b *builder) addEdge(edge *Edge, from, to int, hasNodelets bool) {
 
 // dotColor returns a color for the given score (between -1.0 and
 // 1.0), with -1.0 colored red, 0.0 colored grey, and 1.0 colored
-// green.  If isBackground is true, then a light (low-saturation)
+// green. If isBackground is true, then a light (low-saturation)
 // color is returned (suitable for use as a background color);
 // otherwise, a darker color is returned (suitable for use as a
 // foreground color).

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -55,7 +55,7 @@ type Node struct {
 	// Info describes the source location associated to this node.
 	Info NodeInfo
 
-	// Function represents the function that this node belongs to.  On
+	// Function represents the function that this node belongs to. On
 	// graphs with sub-function resolution (eg line number or
 	// addresses), two nodes in a NodeMap that are part of the same
 	// function have the same value of Node.Function. If the Node
@@ -508,7 +508,7 @@ func isNegative(n *Node) bool {
 	}
 }
 
-// CreateNodes creates graph nodes for all locations in a profile.  It
+// CreateNodes creates graph nodes for all locations in a profile. It
 // returns set of all nodes, plus a mapping of each location to the
 // set of corresponding nodes (one per location.Line). If kept is
 // non-nil, only nodes in that set are included; nodes that do not

--- a/internal/measurement/measurement.go
+++ b/internal/measurement/measurement.go
@@ -115,7 +115,7 @@ func compatibleValueTypes(v1, v2 *profile.ValueType) bool {
 }
 
 // Scale a measurement from an unit to a different unit and returns
-// the scaled value and the target unit.  The returned target unit
+// the scaled value and the target unit. The returned target unit
 // will be empty if uninteresting (could be skipped).
 func Scale(value int64, fromUnit, toUnit string) (float64, string) {
 	// Avoid infinite recursion on overflow.

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -73,7 +73,7 @@ type FlagSet interface {
 	Parse(usage func()) []string
 }
 
-// A Fetcher reads and returns the profile named by src.  src can be a
+// A Fetcher reads and returns the profile named by src. src can be a
 // local file path or a URL. duration and timeout are units specified
 // by the end user, or 0 by default. duration refers to the length of
 // the profile collection, if applicable, and timeout is the amount of
@@ -98,7 +98,7 @@ type MappingSources map[string][]struct {
 
 // An ObjTool inspects shared libraries and executable files.
 type ObjTool interface {
-	// Open opens the named object file.  If the object is a shared
+	// Open opens the named object file. If the object is a shared
 	// library, start/limit/offset are the addresses where it is mapped
 	// into memory in the address space being inspected.
 	Open(file string, start, limit, offset uint64) (ObjFile, error)

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -281,7 +281,7 @@ func printHeader(w io.Writer, rpt *Report) {
 // printFunctionHeader prints a function header for a weblist report.
 func printFunctionHeader(w io.Writer, name, path string, flatSum, cumSum int64, rpt *Report) {
 	fmt.Fprintf(w, `<h1>%s</h1>%s
-<pre onClick="pprof_toggle_asm()">
+<pre onClick="pprof_toggle_asm(event)">
   Total:  %10s %10s (flat, cum) %s
 `,
 		template.HTMLEscapeString(name), template.HTMLEscapeString(path),

--- a/internal/symbolz/symbolz.go
+++ b/internal/symbolz/symbolz.go
@@ -36,7 +36,7 @@ var (
 
 // Symbolize symbolizes profile p by parsing data returned by a
 // symbolz handler. syms receives the symbolz query (hex addresses
-// separated by '+') and returns the symbolz output in a string.  It
+// separated by '+') and returns the symbolz output in a string. It
 // symbolizes all locations based on their addresses, regardless of
 // mapping.
 func Symbolize(sources plugin.MappingSources, syms func(string, string) ([]byte, error), p *profile.Profile, ui plugin.UI) error {

--- a/pprof.go
+++ b/pprof.go
@@ -26,5 +26,6 @@ import (
 func main() {
 	if err := driver.PProf(&driver.Options{}); err != nil {
 		fmt.Fprintf(os.Stderr, "pprof: %v\n", err)
+		os.Exit(2)
 	}
 }

--- a/profile/encode.go
+++ b/profile/encode.go
@@ -24,7 +24,7 @@ func (p *Profile) decoder() []decoder {
 }
 
 // preEncode populates the unexported fields to be used by encode
-// (with suffix X) from the corresponding exported fields.  The
+// (with suffix X) from the corresponding exported fields. The
 // exported fields are cleared up to facilitate testing.
 func (p *Profile) preEncode() {
 	strings := make(map[string]int)

--- a/profile/legacy_profile.go
+++ b/profile/legacy_profile.go
@@ -78,7 +78,7 @@ func parseGoCount(b []byte) (*Profile, error) {
 	if m == nil {
 		return nil, errUnrecognized
 	}
-	profileType := string(m[1])
+	profileType := m[1]
 	p := &Profile{
 		PeriodType: &ValueType{Type: profileType, Unit: "count"},
 		Period:     1,
@@ -103,11 +103,11 @@ func parseGoCount(b []byte) (*Profile, error) {
 		if m == nil {
 			return nil, errMalformed
 		}
-		n, err := strconv.ParseInt(string(m[1]), 0, 64)
+		n, err := strconv.ParseInt(m[1], 0, 64)
 		if err != nil {
 			return nil, errMalformed
 		}
-		fields := strings.Fields(string(m[2]))
+		fields := strings.Fields(m[2])
 		locs := make([]*Location, 0, len(fields))
 		for _, stk := range fields {
 			addr, err := strconv.ParseUint(stk, 0, 64)
@@ -407,7 +407,7 @@ func cleanupDuplicateLocations(p *Profile) {
 //   3rd word -- 0
 //
 // Addresses from stack traces may point to the next instruction after
-// each call.  Optionally adjust by -1 to land somewhere on the actual
+// each call. Optionally adjust by -1 to land somewhere on the actual
 // call (except for the leaf, which is not a call).
 func parseCPUSamples(b []byte, parse func(b []byte) (uint64, []byte), adjust bool, p *Profile) ([]byte, map[uint64]*Location, error) {
 	locs := make(map[uint64]*Location)
@@ -444,7 +444,7 @@ func parseCPUSamples(b []byte, parse func(b []byte) (uint64, []byte), adjust boo
 		}
 		p.Sample = append(p.Sample,
 			&Sample{
-				Value:    []int64{int64(count), int64(count) * int64(p.Period)},
+				Value:    []int64{int64(count), int64(count) * p.Period},
 				Location: sloc,
 			})
 	}
@@ -526,7 +526,7 @@ func parseHeap(b []byte) (p *Profile, err error) {
 		var sloc []*Location
 		for _, addr := range addrs {
 			// Addresses from stack traces point to the next instruction after
-			// each call.  Adjust by -1 to land somewhere on the actual call.
+			// each call. Adjust by -1 to land somewhere on the actual call.
 			addr--
 			loc := locs[addr]
 			if locs[addr] == nil {
@@ -542,7 +542,7 @@ func parseHeap(b []byte) (p *Profile, err error) {
 		p.Sample = append(p.Sample, &Sample{
 			Value:    value,
 			Location: sloc,
-			NumLabel: map[string][]int64{"bytes": []int64{blocksize}},
+			NumLabel: map[string][]int64{"bytes": {blocksize}},
 		})
 	}
 
@@ -559,7 +559,7 @@ func parseHeapHeader(line string) (sampling string, period int64, hasAlloc bool,
 	}
 
 	if len(header[6]) > 0 {
-		if period, err = strconv.ParseInt(string(header[6]), 10, 64); err != nil {
+		if period, err = strconv.ParseInt(header[6], 10, 64); err != nil {
 			return "", 0, false, errUnrecognized
 		}
 	}
@@ -765,7 +765,7 @@ func parseContention(b []byte) (p *Profile, err error) {
 		var sloc []*Location
 		for _, addr := range addrs {
 			// Addresses from stack traces point to the next instruction after
-			// each call.  Adjust by -1 to land somewhere on the actual call.
+			// each call. Adjust by -1 to land somewhere on the actual call.
 			addr--
 			loc := locs[addr]
 			if locs[addr] == nil {
@@ -905,7 +905,7 @@ func parseThread(b []byte) (*Profile, error) {
 		var sloc []*Location
 		for i, addr := range addrs {
 			// Addresses from stack traces point to the next instruction after
-			// each call.  Adjust by -1 to land somewhere on the actual call
+			// each call. Adjust by -1 to land somewhere on the actual call
 			// (except for the leaf, which is not a call).
 			if i > 0 {
 				addr--

--- a/profile/merge.go
+++ b/profile/merge.go
@@ -61,7 +61,7 @@ func Merge(srcs []*Profile) (*Profile, error) {
 
 		if len(pm.mappings) == 0 && len(src.Mapping) > 0 {
 			// The Mapping list has the property that the first mapping
-			// represents the main binary.  Take the first Mapping we see,
+			// represents the main binary. Take the first Mapping we see,
 			// otherwise the operations below will add mappings in an
 			// arbitrary order.
 			pm.mapMapping(srcs[0].Mapping[0])

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -128,7 +128,7 @@ type Function struct {
 	filenameX   int64
 }
 
-// Parse parses a profile and checks for its validity.  The input
+// Parse parses a profile and checks for its validity. The input
 // may be a gzip-compressed encoded protobuf or one of many legacy
 // profile formats which may be unsupported in the future.
 func Parse(r io.Reader) (*Profile, error) {
@@ -280,7 +280,7 @@ func (p *Profile) WriteUncompressed(w io.Writer) error {
 	return err
 }
 
-// CheckValid tests whether the profile is valid.  Checks include, but are
+// CheckValid tests whether the profile is valid. Checks include, but are
 // not limited to:
 //   - len(Profile.Sample[n].value) == len(Profile.value_unit)
 //   - Sample.id has a corresponding Profile.Location

--- a/profile/profile_test.go
+++ b/profile/profile_test.go
@@ -91,7 +91,7 @@ func TestParse(t *testing.T) {
 }
 
 // leaveTempfile leaves |b| in a temporary file on disk and returns the
-// temp filename.  This is useful to recover a profile when the test
+// temp filename. This is useful to recover a profile when the test
 // fails.
 func leaveTempfile(b []byte) string {
 	f1, err := ioutil.TempFile("", "profile_test")
@@ -508,28 +508,28 @@ func TestFilter(t *testing.T) {
 }
 
 func TestTagFilter(t *testing.T) {
-     // Perform several forms of tag filtering on the test profile.
+	// Perform several forms of tag filtering on the test profile.
 
 	type filterTestcase struct {
 		include, exclude *regexp.Regexp
-		im, em bool
-		count int
+		im, em           bool
+		count            int
 	}
 
-	countTags := func (p *Profile) map[string]bool {
-		  tags := make(map[string]bool)
+	countTags := func(p *Profile) map[string]bool {
+		tags := make(map[string]bool)
 
-		  for _, s := range p.Sample {
-		      for l := range s.Label {
-		      	  tags[l] = true
-		      }		      
-		      for l := range s.NumLabel {
-		      	  tags[l] = true
-		      }		      
-		  }
-		  return tags
-	}	
-	
+		for _, s := range p.Sample {
+			for l := range s.Label {
+				tags[l] = true
+			}
+			for l := range s.NumLabel {
+				tags[l] = true
+			}
+		}
+		return tags
+	}
+
 	for tx, tc := range []filterTestcase{
 		{nil, nil, true, false, 3},
 		{regexp.MustCompile("notfound"), nil, false, false, 0},
@@ -538,15 +538,15 @@ func TestTagFilter(t *testing.T) {
 	} {
 		prof := testProfile.Copy()
 		gim, gem := prof.FilterTagsByName(tc.include, tc.exclude)
-		if  gim != tc.im {
+		if gim != tc.im {
 			t.Errorf("Filter #%d, got include match=%v, want %v", tx, gim, tc.im)
-		}		
-		if  gem != tc.em {
+		}
+		if gem != tc.em {
 			t.Errorf("Filter #%d, got exclude match=%v, want %v", tx, gem, tc.em)
-		}		
-		if  tags := countTags(prof) ; len(tags) != tc.count {
+		}
+		if tags := countTags(prof); len(tags) != tc.count {
 			t.Errorf("Filter #%d, got %d tags[%v], want %d", tx, len(tags), tags, tc.count)
-		}		
+		}
 	}
 }
 

--- a/profile/prune.go
+++ b/profile/prune.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Prune removes all nodes beneath a node matching dropRx, and not
-// matching keepRx.  If the root node of a Sample matches, the sample
+// matching keepRx. If the root node of a Sample matches, the sample
 // will have an empty stack.
 func (p *Profile) Prune(dropRx, keepRx *regexp.Regexp) {
 	prune := make(map[uint64]bool)


### PR DESCRIPTION
- Remove dead code, unnecessary conversions
- Consistently use a single space after period