### PR TITLE
More careful handling of temporary directories

### DIFF
--- a/internal/driver/commands.go
+++ b/internal/driver/commands.go
@@ -411,7 +411,7 @@ func invokeVisualizer(format PostProcessor, suffix string, visualizers []string)
 			return err
 		}
 
-		tempFile, err := newTempFile(os.Getenv("PPROF_TMPDIR"), "pprof", "."+suffix)
+		tempFile, err := newTempFile(os.TempDir(), "pprof", "."+suffix)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Only create $HOME/pprof if a profile is stored remotely
and must be stored. Also, create non-profile temps on
os.TempDir() instead of $HOME/pprof or /tmp.