### PR TITLE
Keep more residual edges

### DIFF
--- a/internal/driver/testdata/pprof.heap.flat.inuse_space.dot.focus.ignore
+++ b/internal/driver/testdata/pprof.heap.flat.inuse_space.dot.focus.ignore
@@ -12,4 +12,5 @@ N4 -> NN4_0 [label=" 3.91MB" weight=100 tooltip="3.91MB" labeltooltip="3.91MB"]
 N2 -> N3 [label=" 36.13MB\n (inline)" weight=37 penwidth=2 color="#b22e00" tooltip="line3000 testdata/file3000.src -> line3001 testdata/file3000.src (36.13MB)" labeltooltip="line3000 testdata/file3000.src -> line3001 testdata/file3000.src (36.13MB)"]
 N3 -> N1 [label=" 32.23MB\n (inline)" weight=33 penwidth=2 color="#b23200" tooltip="line3001 testdata/file3000.src -> line3002 testdata/file3000.src (32.23MB)" labeltooltip="line3001 testdata/file3000.src -> line3002 testdata/file3000.src (32.23MB)"]
 N3 -> N4 [label=" 3.91MB" weight=4 color="#b2a58f" tooltip="line3001 testdata/file3000.src -> line1000 testdata/file1000.src (3.91MB)" labeltooltip="line3001 testdata/file3000.src -> line1000 testdata/file1000.src (3.91MB)"]
+N1 -> N4 [label=" 0.98MB" color="#b2b0a9" tooltip="line3002 testdata/file3000.src ... line1000 testdata/file1000.src (0.98MB)" labeltooltip="line3002 testdata/file3000.src ... line1000 testdata/file1000.src (0.98MB)" style="dotted" minlen=2]
 }

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -859,7 +859,7 @@ func (g *Graph) RemoveRedundantEdges() {
 				// avoid potential confusion.
 				break
 			}
-			if isRedundant(e) {
+			if isRedundantEdge(e) {
 				delete(e.Src.Out, e.Dest)
 				delete(e.Dest.In, e.Src)
 			}
@@ -867,26 +867,10 @@ func (g *Graph) RemoveRedundantEdges() {
 	}
 }
 
-// isRedundant determines if an edge can be removed without impacting
-// connectivity of the whole graph. This is implemented by checking if the
-// nodes have a common ancestor after removing the edge.
-func isRedundant(e *Edge) bool {
-	destPred := predecessors(e, e.Dest)
-	if len(destPred) == 1 {
-		return false
-	}
-	srcPred := predecessors(e, e.Src)
-
-	for n := range srcPred {
-		if destPred[n] && n != e.Dest {
-			return true
-		}
-	}
-	return false
-}
-
-// predecessors collects all the predecessors to node n, excluding edge e.
-func predecessors(e *Edge, n *Node) map[*Node]bool {
+// isRedundantEdge determines if there is a path that allows e.Src
+// to reach e.Dest after removing e.
+func isRedundantEdge(e *Edge) bool {
+	src, n := e.Src, e.Dest
 	seen := map[*Node]bool{n: true}
 	queue := Nodes{n}
 	for len(queue) > 0 {
@@ -896,11 +880,14 @@ func predecessors(e *Edge, n *Node) map[*Node]bool {
 			if e == ie || seen[ie.Src] {
 				continue
 			}
+			if ie.Src == src {
+				return true
+			}
 			seen[ie.Src] = true
 			queue = append(queue, ie.Src)
 		}
 	}
-	return seen
+	return false
 }
 
 // nodeSorter is a mechanism used to allow a report to be sorted


### PR DESCRIPTION
Do not remove a residual edge between A and B if there isn't another path
going between A and B. We previously would remove it if A and B had a common
ancestor, but that caused some value duplication as A could become a leaf
but its value would still be accounted for in B.