### PR TITLE
Allow profiles with no samples

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -107,10 +107,6 @@ func generateReport(p *profile.Profile, cmd []string, vars variables, o *plugin.
 		}
 	}
 
-	if len(p.Sample) == 0 {
-		return fmt.Errorf("profile is empty")
-	}
-
 	if err := aggregate(p, vars); err != nil {
 		return err
 	}

--- a/profile/legacy_profile.go
+++ b/profile/legacy_profile.go
@@ -446,7 +446,10 @@ func parseCPUSamples(b []byte, parse func(b []byte) (uint64, []byte), adjust boo
 func parseHeap(b []byte) (p *Profile, err error) {
 	s := bufio.NewScanner(bytes.NewBuffer(b))
 	if !s.Scan() {
-		return nil, s.Err()
+		if err := s.Err(); err != nil {
+			return nil, err
+		}
+		return nil, errUnrecognized
 	}
 	p = &Profile{}
 
@@ -660,7 +663,10 @@ func scaleHeapSample(count, size, rate int64) (int64, int64) {
 func parseContention(b []byte) (p *Profile, err error) {
 	s := bufio.NewScanner(bytes.NewBuffer(b))
 	if !s.Scan() {
-		return nil, s.Err()
+		if err := s.Err(); err != nil {
+			return nil, err
+		}
+		return nil, errUnrecognized
 	}
 	line := s.Text()
 
@@ -912,8 +918,8 @@ func parseThreadSample(s *bufio.Scanner) (nextl string, addrs []uint64, err erro
 
 		addrs = append(addrs, parseHexAddresses(line)...)
 	}
-	if s.Err() != nil {
-		return "", nil, s.Err()
+	if err := s.Err(); err != nil {
+		return "", nil, err
 	}
 	if sameAsPrevious {
 		return line, nil, nil

--- a/profile/profile_test.go
+++ b/profile/profile_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/google/pprof/internal/proftest"
@@ -86,6 +87,23 @@ func TestParse(t *testing.T) {
 			}
 			t.Error(source + "\n" + string(d) + "\n" + "gold:\n" + goldFilename +
 				"\nnew profile at:\n" + leaveTempfile([]byte(js)))
+		}
+	}
+}
+
+func TestParseError(t *testing.T) {
+
+	testcases := []string{
+		"",
+		"garbage text",
+		"\x1f\x8b", // truncated gzip header
+		"\x1f\x8b\x08\x08\xbe\xe9\x20\x58\x00\x03\x65\x6d\x70\x74\x79\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", // empty gzipped file
+	}
+
+	for i, input := range testcases {
+		_, err := Parse(strings.NewReader(input))
+		if err == nil {
+			t.Errorf("got nil, want error for input #%d", i)
 		}
 	}
 }


### PR DESCRIPTION
A previous commit tried to eliminate a panic when reading an empty
profile by stopping support for profiles with no samples. That is
unnecessary and it can obstruct some testing.

The panic was caused by the legacy parser returning a nil profile and
no error when processing an empty profile. Detect that situation and
generate a proper profile instead.

Tested by running 'pprof /dev/null'