### PR TITLE
Do not hide allocation frames under call32/call64.

### DIFF
--- a/profile/legacy_profile.go
+++ b/profile/legacy_profile.go
@@ -1174,6 +1174,9 @@ var allocSkipRxStr = strings.Join([]string{
 	// Preserve Go runtime frames that appear in the middle/bottom of
 	// the stack.
 	`runtime\.panic`,
+	// See https://github.com/google/pprof/issues/54.
+	`runtime\.call32`,
+	`runtime\.call64`,
 }, `|`)
 
 var cpuProfilerRxStr = strings.Join([]string{


### PR DESCRIPTION
See https://github.com/google/pprof/issues/54. Frames under
call32/call64 may be user code frames so should be shown to avoid
confusing re-attribution of allocations to the calling system frames.