### PR TITLE
Add source information to disassembly reports

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -135,10 +135,11 @@ type ObjTool interface {
 
 // An Inst is a single instruction in an assembly listing.
 type Inst struct {
-	Addr uint64 // virtual address of instruction
-	Text string // instruction text
-	File string // source file
-	Line int    // source line
+	Addr     uint64 // virtual address of instruction
+	Text     string // instruction text
+	Function string // function name
+	File     string // source file
+	Line     int    // source line
 }
 
 // An ObjFile is a single object file: a shared library or executable.

--- a/internal/binutils/disasm_test.go
+++ b/internal/binutils/disasm_test.go
@@ -116,10 +116,10 @@ func TestFunctionAssembly(t *testing.T) {
   1003: instruction four
 `,
 			[]plugin.Inst{
-				{0x1000, "instruction one", "", 0},
-				{0x1001, "instruction two", "", 0},
-				{0x1002, "instruction three", "", 0},
-				{0x1003, "instruction four", "", 0},
+				{Addr: 0x1000, Text: "instruction one"},
+				{Addr: 0x1001, Text: "instruction two"},
+				{Addr: 0x1002, Text: "instruction three"},
+				{Addr: 0x1003, Text: "instruction four"},
 			},
 		},
 		{
@@ -128,8 +128,8 @@ func TestFunctionAssembly(t *testing.T) {
   2001: instruction two
 `,
 			[]plugin.Inst{
-				{0x2000, "instruction one", "", 0},
-				{0x2001, "instruction two", "", 0},
+				{Addr: 0x2000, Text: "instruction one"},
+				{Addr: 0x2001, Text: "instruction two"},
 			},
 		},
 	}

--- a/internal/binutils/disasm_test.go
+++ b/internal/binutils/disasm_test.go
@@ -137,17 +137,17 @@ func TestFunctionAssembly(t *testing.T) {
 	const objdump = "testdata/wrapper/objdump"
 
 	for _, tc := range testcases {
-		insns, err := disassemble([]byte(tc.asm))
+		insts, err := disassemble([]byte(tc.asm))
 		if err != nil {
 			t.Fatalf("FunctionAssembly: %v", err)
 		}
 
-		if len(insns) != len(tc.want) {
-			t.Errorf("Unexpected number of assembly instructions %d (want %d)\n", len(insns), len(tc.want))
+		if len(insts) != len(tc.want) {
+			t.Errorf("Unexpected number of assembly instructions %d (want %d)\n", len(insts), len(tc.want))
 		}
-		for i := range insns {
-			if insns[i] != tc.want[i] {
-				t.Errorf("Expected symbol %v, got %v\n", tc.want[i], insns[i])
+		for i := range insts {
+			if insts[i] != tc.want[i] {
+				t.Errorf("Expected symbol %v, got %v\n", tc.want[i], insts[i])
 			}
 		}
 	}

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -1020,18 +1020,18 @@ func (m *mockObjTool) Disasm(file string, start, end uint64) ([]plugin.Inst, err
 	switch start {
 	case 0x1000:
 		return []plugin.Inst{
-			{0x1000, "instruction one", "", 0},
-			{0x1001, "instruction two", "", 0},
-			{0x1002, "instruction three", "", 0},
-			{0x1003, "instruction four", "", 0},
+			{Addr: 0x1000, Text: "instruction one"},
+			{Addr: 0x1001, Text: "instruction two"},
+			{Addr: 0x1002, Text: "instruction three"},
+			{Addr: 0x1003, Text: "instruction four"},
 		}, nil
 	case 0x3000:
 		return []plugin.Inst{
-			{0x3000, "instruction one", "", 0},
-			{0x3001, "instruction two", "", 0},
-			{0x3002, "instruction three", "", 0},
-			{0x3003, "instruction four", "", 0},
-			{0x3004, "instruction five", "", 0},
+			{Addr: 0x3000, Text: "instruction one"},
+			{Addr: 0x3001, Text: "instruction two"},
+			{Addr: 0x3002, Text: "instruction three"},
+			{Addr: 0x3003, Text: "instruction four"},
+			{Addr: 0x3004, Text: "instruction five"},
 		}, nil
 	}
 	return nil, fmt.Errorf("unimplemented")

--- a/internal/driver/testdata/pprof.cpu.flat.addresses.disasm
+++ b/internal/driver/testdata/pprof.cpu.flat.addresses.disasm
@@ -1,14 +1,14 @@
 Total: 1.12s
 ROUTINE ======================== line1000
      1.10s      1.10s (flat, cum) 98.21% of Total
-     1.10s      1.10s       1000: instruction one
+     1.10s      1.10s       1000: instruction one                         ; line1000 file1000.src:1
          .          .       1001: instruction two
          .          .       1002: instruction three
          .          .       1003: instruction four
 ROUTINE ======================== line3000
       10ms      1.12s (flat, cum)   100% of Total
-      10ms      1.01s       3000: instruction one
-         .      100ms       3001: instruction two
-         .       10ms       3002: instruction three
+      10ms      1.01s       3000: instruction one                         ; line3000 file3000.src:6
+         .      100ms       3001: instruction two                         ; line3000 file3000.src:9
+         .       10ms       3002: instruction three                       ; line3000 file3000.src:7
          .          .       3003: instruction four
          .          .       3004: instruction five

--- a/internal/driver/testdata/pprof.cpu.flat.addresses.weblist
+++ b/internal/driver/testdata/pprof.cpu.flat.addresses.weblist
@@ -69,7 +69,7 @@ Type: cpu<br>
 Duration: 10s, Total samples = 1.12s (11.20%)<br>Total: 1.12s</div><h1>line1000</h1>testdata/file1000.src
 <pre onClick="pprof_toggle_asm(event)">
   Total:       1.10s      1.10s (flat, cum) 98.21%
-<span class=line>      1</span> <span class=deadsrc>       1.10s      1.10s line1 </span><span class=asm>               1.10s      1.10s     1000: instruction one                                  <span class=disasmloc>testdata/file1000.src:1</span>
+<span class=line>      1</span> <span class=deadsrc>       1.10s      1.10s line1 </span><span class=asm>               1.10s      1.10s     1000: instruction one                                  <span class=disasmloc>file1000.src:1</span>
                    .          .     1001: instruction two                                  <span class=disasmloc></span>
                    .          .     1002: instruction three                                <span class=disasmloc></span>
                    .          .     1003: instruction four                                 <span class=disasmloc></span>
@@ -88,14 +88,14 @@ Duration: 10s, Total samples = 1.12s (11.20%)<br>Total: 1.12s</div><h1>line1000<
 <span class=line>      3</span> <span class=nop>           .          . line3 </span>
 <span class=line>      4</span> <span class=nop>           .          . line4 </span>
 <span class=line>      5</span> <span class=nop>           .          . line5 </span>
-<span class=line>      6</span> <span class=deadsrc>        10ms      1.01s line6 </span><span class=asm>                10ms      1.01s     3000: instruction one                                  <span class=disasmloc>testdata/file3000.src:6</span>
+<span class=line>      6</span> <span class=deadsrc>        10ms      1.01s line6 </span><span class=asm>                10ms      1.01s     3000: instruction one                                  <span class=disasmloc>file3000.src:6</span>
 </span>
-<span class=line>      7</span> <span class=deadsrc>           .       10ms line7 </span><span class=asm>                   .       10ms     3002: instruction three                                <span class=disasmloc>testdata/file3000.src:7</span>
+<span class=line>      7</span> <span class=deadsrc>           .       10ms line7 </span><span class=asm>                   .       10ms     3002: instruction three                                <span class=disasmloc>file3000.src:7</span>
                    .          .     3003: instruction four                                 <span class=disasmloc></span>
                    .          .     3004: instruction five                                 <span class=disasmloc></span>
 </span>
 <span class=line>      8</span> <span class=nop>           .          . line8 </span>
-<span class=line>      9</span> <span class=deadsrc>           .      100ms line9 </span><span class=asm>                   .      100ms     3001: instruction two                                  <span class=disasmloc>testdata/file3000.src:9</span>
+<span class=line>      9</span> <span class=deadsrc>           .      100ms line9 </span><span class=asm>                   .      100ms     3001: instruction two                                  <span class=disasmloc>file3000.src:9</span>
 </span>
 <span class=line>     10</span> <span class=nop>           .          . line0 </span>
 <span class=line>     11</span> <span class=nop>           .          . line1 </span>

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -110,10 +110,11 @@ type ObjTool interface {
 
 // An Inst is a single instruction in an assembly listing.
 type Inst struct {
-	Addr uint64 // virtual address of instruction
-	Text string // instruction text
-	File string // source file
-	Line int    // source line
+	Addr     uint64 // virtual address of instruction
+	Text     string // instruction text
+	Function string // function name
+	File     string // source file
+	Line     int    // source line
 }
 
 // An ObjFile is a single object file: a shared library or executable.

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -303,12 +303,12 @@ func printAssembly(w io.Writer, rpt *Report, obj plugin.ObjTool) error {
 		flatSum, cumSum := sns.Sum()
 
 		// Get the function assembly.
-		insns, err := obj.Disasm(s.sym.File, s.sym.Start, s.sym.End)
+		insts, err := obj.Disasm(s.sym.File, s.sym.Start, s.sym.End)
 		if err != nil {
 			return err
 		}
 
-		ns := annotateAssembly(insns, sns, s.base)
+		ns := annotateAssembly(insts, sns, s.base)
 
 		fmt.Fprintf(w, "ROUTINE ======================== %s\n", s.sym.Name[0])
 		for _, name := range s.sym.Name[1:] {
@@ -473,9 +473,9 @@ func (a *assemblyInstruction) cumValue() int64 {
 // annotateAssembly annotates a set of assembly instructions with a
 // set of samples. It returns a set of nodes to display. base is an
 // offset to adjust the sample addresses.
-func annotateAssembly(insns []plugin.Inst, samples graph.Nodes, base uint64) []assemblyInstruction {
+func annotateAssembly(insts []plugin.Inst, samples graph.Nodes, base uint64) []assemblyInstruction {
 	// Add end marker to simplify printing loop.
-	insns = append(insns, plugin.Inst{
+	insts = append(insts, plugin.Inst{
 		Addr: ^uint64(0),
 	})
 
@@ -483,8 +483,8 @@ func annotateAssembly(insns []plugin.Inst, samples graph.Nodes, base uint64) []a
 	samples.Sort(graph.AddressOrder)
 
 	s := 0
-	asm := make([]assemblyInstruction, 0, len(insns))
-	for ix, in := range insns[:len(insns)-1] {
+	asm := make([]assemblyInstruction, 0, len(insts))
+	for ix, in := range insts[:len(insts)-1] {
 		n := assemblyInstruction{
 			address:     in.Addr,
 			instruction: in.Text,
@@ -497,7 +497,7 @@ func annotateAssembly(insns []plugin.Inst, samples graph.Nodes, base uint64) []a
 
 		// Sum all the samples until the next instruction (to account
 		// for samples attributed to the middle of an instruction).
-		for next := insns[ix+1].Addr; s < len(samples) && samples[s].Info.Address-base < next; s++ {
+		for next := insts[ix+1].Addr; s < len(samples) && samples[s].Info.Address-base < next; s++ {
 			sample := samples[s]
 			n.flatDiv += sample.FlatDiv
 			n.flat += sample.Flat

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -204,7 +204,7 @@ func printWebSource(w io.Writer, rpt *Report, obj plugin.ObjTool) error {
 
 // sourceCoordinates returns the lowest and highest line numbers from
 // a set of assembly statements.
-func sourceCoordinates(asm map[int]graph.Nodes) (start, end int) {
+func sourceCoordinates(asm map[int][]assemblyInstruction) (start, end int) {
 	for l := range asm {
 		if start == 0 || l < start {
 			start = l
@@ -219,8 +219,8 @@ func sourceCoordinates(asm map[int]graph.Nodes) (start, end int) {
 // assemblyPerSourceLine disassembles the binary containing a symbol
 // and classifies the assembly instructions according to its
 // corresponding source line, annotating them with a set of samples.
-func assemblyPerSourceLine(objSyms []*objSymbol, rs graph.Nodes, src string, obj plugin.ObjTool) map[int]graph.Nodes {
-	assembly := make(map[int]graph.Nodes)
+func assemblyPerSourceLine(objSyms []*objSymbol, rs graph.Nodes, src string, obj plugin.ObjTool) map[int][]assemblyInstruction {
+	assembly := make(map[int][]assemblyInstruction)
 	// Identify symbol to use for this collection of samples.
 	o := findMatchingSymbol(objSyms, rs)
 	if o == nil {
@@ -237,8 +237,8 @@ func assemblyPerSourceLine(objSyms []*objSymbol, rs graph.Nodes, src string, obj
 	anodes := annotateAssembly(insns, rs, o.base)
 	var lineno = 0
 	for _, an := range anodes {
-		if filepath.Base(an.Info.File) == srcBase {
-			lineno = an.Info.Lineno
+		if filepath.Base(an.file) == srcBase {
+			lineno = an.line
 		}
 		if lineno != 0 {
 			assembly[lineno] = append(assembly[lineno], an)
@@ -290,7 +290,7 @@ func printFunctionHeader(w io.Writer, name, path string, flatSum, cumSum int64, 
 }
 
 // printFunctionSourceLine prints a source line and the corresponding assembly.
-func printFunctionSourceLine(w io.Writer, fn *graph.Node, assembly graph.Nodes, rpt *Report) {
+func printFunctionSourceLine(w io.Writer, fn *graph.Node, assembly []assemblyInstruction, rpt *Report) {
 	if len(assembly) == 0 {
 		fmt.Fprintf(w,
 			"<span class=line> %6d</span> <span class=nop>  %10s %10s %s </span>\n",
@@ -309,16 +309,23 @@ func printFunctionSourceLine(w io.Writer, fn *graph.Node, assembly graph.Nodes, 
 	for _, an := range assembly {
 		var fileline string
 		class := "disasmloc"
-		if an.Info.File != "" {
-			fileline = fmt.Sprintf("%s:%d", template.HTMLEscapeString(an.Info.File), an.Info.Lineno)
-			if an.Info.Lineno != fn.Info.Lineno {
+		if an.file != "" {
+			fileline = fmt.Sprintf("%s:%d", template.HTMLEscapeString(an.file), an.line)
+			if an.line != fn.Info.Lineno {
 				class = "unimportant"
 			}
 		}
+		flat, cum := an.flat, an.cum
+		if an.flatDiv != 0 {
+			flat = flat / an.flatDiv
+		}
+		if an.cumDiv != 0 {
+			cum = cum / an.cumDiv
+		}
 		fmt.Fprintf(w, " %8s %10s %10s %8x: %-48s <span class=%s>%s</span>\n", "",
-			valueOrDot(an.Flat, rpt), valueOrDot(an.Cum, rpt),
-			an.Info.Address,
-			template.HTMLEscapeString(an.Info.Name),
+			valueOrDot(flat, rpt), valueOrDot(cum, rpt),
+			an.address,
+			template.HTMLEscapeString(an.instruction),
 			class,
 			template.HTMLEscapeString(fileline))
 	}
@@ -411,14 +418,22 @@ func getSourceFromFile(file, sourcePath string, fns graph.Nodes, start, end int)
 
 // getMissingFunctionSource creates a dummy function body to point to
 // the source file and annotates it with the samples in asm.
-func getMissingFunctionSource(filename string, asm map[int]graph.Nodes, start, end int) (graph.Nodes, string) {
+func getMissingFunctionSource(filename string, asm map[int][]assemblyInstruction, start, end int) (graph.Nodes, string) {
 	var fnodes graph.Nodes
 	for i := start; i <= end; i++ {
-		lrs := asm[i]
-		if len(lrs) == 0 {
+		insns := asm[i]
+		if len(insns) == 0 {
 			continue
 		}
-		flat, cum := lrs.Sum()
+		var group assemblyInstruction
+		for _, insn := range insns {
+			group.flat += insn.flat
+			group.cum += insn.cum
+			group.flatDiv += insn.flatDiv
+			group.cumDiv += insn.cumDiv
+		}
+		flat := group.flatValue()
+		cum := group.cumValue()
 		fnodes = append(fnodes, &graph.Node{
 			Info: graph.NodeInfo{
 				Name:   "???",

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -228,13 +228,13 @@ func assemblyPerSourceLine(objSyms []*objSymbol, rs graph.Nodes, src string, obj
 	}
 
 	// Extract assembly for matched symbol
-	insns, err := obj.Disasm(o.sym.File, o.sym.Start, o.sym.End)
+	insts, err := obj.Disasm(o.sym.File, o.sym.Start, o.sym.End)
 	if err != nil {
 		return assembly
 	}
 
 	srcBase := filepath.Base(src)
-	anodes := annotateAssembly(insns, rs, o.base)
+	anodes := annotateAssembly(insts, rs, o.base)
 	var lineno = 0
 	for _, an := range anodes {
 		if filepath.Base(an.file) == srcBase {
@@ -421,12 +421,12 @@ func getSourceFromFile(file, sourcePath string, fns graph.Nodes, start, end int)
 func getMissingFunctionSource(filename string, asm map[int][]assemblyInstruction, start, end int) (graph.Nodes, string) {
 	var fnodes graph.Nodes
 	for i := start; i <= end; i++ {
-		insns := asm[i]
-		if len(insns) == 0 {
+		insts := asm[i]
+		if len(insts) == 0 {
 			continue
 		}
 		var group assemblyInstruction
-		for _, insn := range insns {
+		for _, insn := range insts {
 			group.flat += insn.flat
 			group.cum += insn.cum
 			group.flatDiv += insn.flatDiv


### PR DESCRIPTION
Disassembly reports generated by pprof -disasm will now include line number
information as generated by objdump. This will make the generated assembly more
readable.

As part of this I've introduced a new assemblyInstruction struct. Previously
the code was reusing the graph.Node to represent assembly instructions but it
seems better to have a dedicated type for this.