### PR TITLE
Improve support for the Comments field

### DIFF
--- a/internal/driver/commands.go
+++ b/internal/driver/commands.go
@@ -86,17 +86,18 @@ var interactiveMode = false
 // pprofCommands are the report generation commands recognized by pprof.
 var pprofCommands = commands{
 	// Commands that require no post-processing.
-	"tags":     {report.Tags, nil, false, "Outputs all tags in the profile", "tags [tag_regex]* [-ignore_regex]* [>file]\nList tags with key:value matching tag_regex and exclude ignore_regex."},
-	"raw":      {report.Raw, nil, false, "Outputs a text representation of the raw profile", ""},
-	"dot":      {report.Dot, nil, false, "Outputs a graph in DOT format", reportHelp("dot", false, true)},
-	"top":      {report.Text, nil, false, "Outputs top entries in text form", reportHelp("top", true, true)},
-	"tree":     {report.Tree, nil, false, "Outputs a text rendering of call graph", reportHelp("tree", true, true)},
-	"text":     {report.Text, nil, false, "Outputs top entries in text form", reportHelp("text", true, true)},
-	"traces":   {report.Traces, nil, false, "Outputs all profile samples in text form", ""},
-	"topproto": {report.TopProto, awayFromTTY("pb.gz"), false, "Outputs top entries in compressed protobuf format", ""},
+	"comments": {report.Comments, nil, false, "Output all profile comments", ""},
 	"disasm":   {report.Dis, nil, true, "Output assembly listings annotated with samples", listHelp("disasm", true)},
+	"dot":      {report.Dot, nil, false, "Outputs a graph in DOT format", reportHelp("dot", false, true)},
 	"list":     {report.List, nil, true, "Output annotated source for functions matching regexp", listHelp("list", false)},
 	"peek":     {report.Tree, nil, true, "Output callers/callees of functions matching regexp", "peek func_regex\nDisplay callers and callees of functions matching func_regex."},
+	"raw":      {report.Raw, nil, false, "Outputs a text representation of the raw profile", ""},
+	"tags":     {report.Tags, nil, false, "Outputs all tags in the profile", "tags [tag_regex]* [-ignore_regex]* [>file]\nList tags with key:value matching tag_regex and exclude ignore_regex."},
+	"text":     {report.Text, nil, false, "Outputs top entries in text form", reportHelp("text", true, true)},
+	"top":      {report.Text, nil, false, "Outputs top entries in text form", reportHelp("top", true, true)},
+	"topproto": {report.TopProto, awayFromTTY("pb.gz"), false, "Outputs top entries in compressed protobuf format", ""},
+	"traces":   {report.Traces, nil, false, "Outputs all profile samples in text form", ""},
+	"tree":     {report.Tree, nil, false, "Outputs a text rendering of call graph", reportHelp("tree", true, true)},
 
 	// Save binary formats to a file
 	"callgrind": {report.Callgrind, awayFromTTY("callgraph.out"), false, "Outputs a graph in callgrind format", reportHelp("callgrind", false, true)},

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -63,6 +63,8 @@ func TestParse(t *testing.T) {
 		{"dot,lines,flat,focus=[12]00", "heap"},
 		{"dot,addresses,flat,ignore=[X3]002,focus=[X1]000", "contention"},
 		{"dot,files,cum", "contention"},
+		{"comments", "cpu"},
+		{"comments", "heap"},
 		{"tags", "cpu"},
 		{"tags,tagignore=tag[13],tagfocus=key[12]", "cpu"},
 		{"tags", "heap"},
@@ -215,7 +217,7 @@ func solutionFilename(source string, f *testFlags) string {
 	name = addString(name, f, []string{"inuse_space", "inuse_objects", "alloc_space", "alloc_objects"})
 	name = addString(name, f, []string{"relative_percentages"})
 	name = addString(name, f, []string{"seconds"})
-	name = addString(name, f, []string{"text", "tree", "callgrind", "dot", "svg", "tags", "dot", "traces", "disasm", "peek", "weblist", "topproto"})
+	name = addString(name, f, []string{"text", "tree", "callgrind", "dot", "svg", "tags", "dot", "traces", "disasm", "peek", "weblist", "topproto", "comments"})
 	if f.strings["focus"] != "" || f.strings["tagfocus"] != "" {
 		name = append(name, "focus")
 	}
@@ -726,6 +728,7 @@ func heapProfile() *profile.Profile {
 	}
 
 	return &profile.Profile{
+		Comments:   []string{"comment", "#hidden comment"},
 		PeriodType: &profile.ValueType{Type: "allocations", Unit: "bytes"},
 		Period:     524288,
 		SampleType: []*profile.ValueType{

--- a/internal/driver/testdata/pprof.heap.comments
+++ b/internal/driver/testdata/pprof.heap.comments
@@ -1,0 +1,2 @@
+comment
+#hidden comment

--- a/internal/driver/testdata/pprof.heap.flat.inuse_space.dot.focus
+++ b/internal/driver/testdata/pprof.heap.flat.inuse_space.dot.focus
@@ -1,6 +1,6 @@
 digraph "unnamed" {
 node [style=filled fillcolor="#f8f8f8"]
-subgraph cluster_L { "Build ID: buildid" [shape=box fontsize=16 label="Build ID: buildid\lType: inuse_space\lShowing nodes accounting for 62.50MB, 63.37% of 98.63MB total\l"] }
+subgraph cluster_L { "Build ID: buildid" [shape=box fontsize=16 label="Build ID: buildid\lcomment\lType: inuse_space\lShowing nodes accounting for 62.50MB, 63.37% of 98.63MB total\l"] }
 N1 [label="line2001\nfile2000.src\n62.50MB (63.37%)" fontsize=24 shape=box tooltip="line2001 testdata/file2000.src (62.50MB)" color="#b21600" fillcolor="#edd8d5"]
 NN1_0 [label = "1.56MB" fontsize=8 shape=box3d tooltip="62.50MB"]
 N1 -> NN1_0 [label=" 62.50MB" weight=100 tooltip="62.50MB" labeltooltip="62.50MB"]

--- a/internal/driver/testdata/pprof.heap.flat.inuse_space.dot.focus.ignore
+++ b/internal/driver/testdata/pprof.heap.flat.inuse_space.dot.focus.ignore
@@ -1,6 +1,6 @@
 digraph "unnamed" {
 node [style=filled fillcolor="#f8f8f8"]
-subgraph cluster_L { "Build ID: buildid" [shape=box fontsize=16 label="Build ID: buildid\lType: inuse_space\lShowing nodes accounting for 36.13MB, 36.63% of 98.63MB total\lDropped 2 nodes (cum <= 4.93MB)\l"] }
+subgraph cluster_L { "Build ID: buildid" [shape=box fontsize=16 label="Build ID: buildid\lcomment\lType: inuse_space\lShowing nodes accounting for 36.13MB, 36.63% of 98.63MB total\lDropped 2 nodes (cum <= 4.93MB)\l"] }
 N1 [label="line3002\nfile3000.src\n31.25MB (31.68%)\nof 32.23MB (32.67%)" fontsize=24 shape=box tooltip="line3002 testdata/file3000.src (32.23MB)" color="#b23200" fillcolor="#eddcd5"]
 NN1_0 [label = "400kB" fontsize=8 shape=box3d tooltip="31.25MB"]
 N1 -> NN1_0 [label=" 31.25MB" weight=100 tooltip="31.25MB" labeltooltip="31.25MB"]

--- a/internal/driver/testdata/pprof.heap.flat.lines.dot.focus
+++ b/internal/driver/testdata/pprof.heap.flat.lines.dot.focus
@@ -1,6 +1,6 @@
 digraph "unnamed" {
 node [style=filled fillcolor="#f8f8f8"]
-subgraph cluster_L { "Build ID: buildid" [shape=box fontsize=16 label="Build ID: buildid\lType: inuse_space\lShowing nodes accounting for 67.38MB, 68.32% of 98.63MB total\l"] }
+subgraph cluster_L { "Build ID: buildid" [shape=box fontsize=16 label="Build ID: buildid\lcomment\lType: inuse_space\lShowing nodes accounting for 67.38MB, 68.32% of 98.63MB total\l"] }
 N1 [label="line3000\nfile3000.src:4\n0 of 67.38MB (68.32%)" fontsize=8 shape=box tooltip="line3000 testdata/file3000.src:4 (67.38MB)" color="#b21300" fillcolor="#edd7d5"]
 N2 [label="line2001\nfile2000.src:2\n62.50MB (63.37%)\nof 63.48MB (64.36%)" fontsize=24 shape=box tooltip="line2001 testdata/file2000.src:2 (63.48MB)" color="#b21600" fillcolor="#edd8d5"]
 NN2_0 [label = "1.56MB" fontsize=8 shape=box3d tooltip="62.50MB"]

--- a/internal/driver/testdata/pprof.heap_alloc.flat.alloc_space.dot.focus
+++ b/internal/driver/testdata/pprof.heap_alloc.flat.alloc_space.dot.focus
@@ -1,6 +1,6 @@
 digraph "unnamed" {
 node [style=filled fillcolor="#f8f8f8"]
-subgraph cluster_L { "Build ID: buildid" [shape=box fontsize=16 label="Build ID: buildid\lType: alloc_space\lShowing nodes accounting for 93.75MB, 95.05% of 98.63MB total\lDropped 1 node (cum <= 4.93MB)\l"] }
+subgraph cluster_L { "Build ID: buildid" [shape=box fontsize=16 label="Build ID: buildid\lcomment\lType: alloc_space\lShowing nodes accounting for 93.75MB, 95.05% of 98.63MB total\lDropped 1 node (cum <= 4.93MB)\l"] }
 N1 [label="line3002\nfile3000.src\n31.25MB (31.68%)\nof 94.73MB (96.04%)" fontsize=20 shape=box tooltip="line3002 testdata/file3000.src (94.73MB)" color="#b20200" fillcolor="#edd5d5"]
 NN1_0 [label = "400kB" fontsize=8 shape=box3d tooltip="31.25MB"]
 N1 -> NN1_0 [label=" 31.25MB" weight=100 tooltip="31.25MB" labeltooltip="31.25MB"]

--- a/internal/driver/testdata/pprof.heap_alloc.flat.alloc_space.dot.hide
+++ b/internal/driver/testdata/pprof.heap_alloc.flat.alloc_space.dot.hide
@@ -1,6 +1,6 @@
 digraph "unnamed" {
 node [style=filled fillcolor="#f8f8f8"]
-subgraph cluster_L { "Build ID: buildid" [shape=box fontsize=16 label="Build ID: buildid\lType: alloc_space\lShowing nodes accounting for 93.75MB, 95.05% of 98.63MB total\lDropped 1 node (cum <= 4.93MB)\l"] }
+subgraph cluster_L { "Build ID: buildid" [shape=box fontsize=16 label="Build ID: buildid\lcomment\lType: alloc_space\lShowing nodes accounting for 93.75MB, 95.05% of 98.63MB total\lDropped 1 node (cum <= 4.93MB)\l"] }
 N1 [label="line3000\nfile3000.src\n62.50MB (63.37%)\nof 98.63MB (100%)" fontsize=24 shape=box tooltip="line3000 testdata/file3000.src (98.63MB)" color="#b20000" fillcolor="#edd5d5"]
 NN1_0 [label = "1.56MB" fontsize=8 shape=box3d tooltip="62.50MB"]
 N1 -> NN1_0 [label=" 62.50MB" weight=100 tooltip="62.50MB" labeltooltip="62.50MB"]

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -391,7 +391,10 @@ func (p *Profile) Aggregate(inlineFrame, function, filename, linenumber, address
 // String dumps a text representation of a profile. Intended mainly
 // for debugging purposes.
 func (p *Profile) String() string {
-	ss := make([]string, 0, len(p.Sample)+len(p.Mapping)+len(p.Location))
+	ss := make([]string, 0, len(p.Comments)+len(p.Sample)+len(p.Mapping)+len(p.Location))
+	for _, c := range p.Comments {
+		ss = append(ss, "Comment: "+c)
+	}
 	if pt := p.PeriodType; pt != nil {
 		ss = append(ss, fmt.Sprintf("PeriodType: %s %s", pt.Type, pt.Unit))
 	}
@@ -430,15 +433,15 @@ func (p *Profile) String() string {
 				ls = append(ls, fmt.Sprintf("%s:%v", k, v))
 			}
 			sort.Strings(ls)
-			ss = append(ss, labelHeader + strings.Join(ls, " "))
+			ss = append(ss, labelHeader+strings.Join(ls, " "))
 		}
 		if len(s.NumLabel) > 0 {
 			ls := []string{}
 			for k, v := range s.NumLabel {
-				ls = append(ls,fmt.Sprintf("%s:%v", k, v))
+				ls = append(ls, fmt.Sprintf("%s:%v", k, v))
 			}
 			sort.Strings(ls)
-			ss = append(ss, labelHeader + strings.Join(ls, " "))
+			ss = append(ss, labelHeader+strings.Join(ls, " "))
 		}
 	}
 


### PR DESCRIPTION
By default hide entries in the comment field that starts with #, and
add a "comments" command to show all comments.

Also sort the command lists and update driver tests to include comments.