### PR TITLE
Improve newline handling for html generation

### DIFF
--- a/internal/driver/testdata/pprof.cpu.flat.addresses.weblist
+++ b/internal/driver/testdata/pprof.cpu.flat.addresses.weblist
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html>
 <head>
@@ -69,7 +68,8 @@ Type: cpu<br>
 Duration: 10s, Total samples = 1.12s (11.20%)<br>Total: 1.12s</div><h1>line1000</h1>testdata/file1000.src
 <pre onClick="pprof_toggle_asm(event)">
   Total:       1.10s      1.10s (flat, cum) 98.21%
-<span class=line>      1</span> <span class=deadsrc>       1.10s      1.10s line1 </span><span class=asm>               1.10s      1.10s     1000: instruction one                                  <span class=disasmloc>file1000.src:1</span>
+<span class=line>      1</span> <span class=deadsrc>       1.10s      1.10s line1 </span>
+<span class=asm>               1.10s      1.10s     1000: instruction one                                  <span class=disasmloc>file1000.src:1</span>
                    .          .     1001: instruction two                                  <span class=disasmloc></span>
                    .          .     1002: instruction three                                <span class=disasmloc></span>
                    .          .     1003: instruction four                                 <span class=disasmloc></span>
@@ -88,14 +88,17 @@ Duration: 10s, Total samples = 1.12s (11.20%)<br>Total: 1.12s</div><h1>line1000<
 <span class=line>      3</span> <span class=nop>           .          . line3 </span>
 <span class=line>      4</span> <span class=nop>           .          . line4 </span>
 <span class=line>      5</span> <span class=nop>           .          . line5 </span>
-<span class=line>      6</span> <span class=deadsrc>        10ms      1.01s line6 </span><span class=asm>                10ms      1.01s     3000: instruction one                                  <span class=disasmloc>file3000.src:6</span>
+<span class=line>      6</span> <span class=deadsrc>        10ms      1.01s line6 </span>
+<span class=asm>                10ms      1.01s     3000: instruction one                                  <span class=disasmloc>file3000.src:6</span>
 </span>
-<span class=line>      7</span> <span class=deadsrc>           .       10ms line7 </span><span class=asm>                   .       10ms     3002: instruction three                                <span class=disasmloc>file3000.src:7</span>
+<span class=line>      7</span> <span class=deadsrc>           .       10ms line7 </span>
+<span class=asm>                   .       10ms     3002: instruction three                                <span class=disasmloc>file3000.src:7</span>
                    .          .     3003: instruction four                                 <span class=disasmloc></span>
                    .          .     3004: instruction five                                 <span class=disasmloc></span>
 </span>
 <span class=line>      8</span> <span class=nop>           .          . line8 </span>
-<span class=line>      9</span> <span class=deadsrc>           .      100ms line9 </span><span class=asm>                   .      100ms     3001: instruction two                                  <span class=disasmloc>file3000.src:9</span>
+<span class=line>      9</span> <span class=deadsrc>           .      100ms line9 </span>
+<span class=asm>                   .      100ms     3001: instruction two                                  <span class=disasmloc>file3000.src:9</span>
 </span>
 <span class=line>     10</span> <span class=nop>           .          . line0 </span>
 <span class=line>     11</span> <span class=nop>           .          . line1 </span>
@@ -106,4 +109,3 @@ Duration: 10s, Total samples = 1.12s (11.20%)<br>Total: 1.12s</div><h1>line1000<
 
 </body>
 </html>
-

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -301,7 +301,7 @@ func printFunctionSourceLine(w io.Writer, fn *graph.Node, assembly []assemblyIns
 	}
 
 	fmt.Fprintf(w,
-		"<span class=line> %6d</span> <span class=deadsrc>  %10s %10s %s </span>",
+		"<span class=line> %6d</span> <span class=deadsrc>  %10s %10s %s </span>\n",
 		fn.Info.Lineno,
 		valueOrDot(fn.Flat, rpt), valueOrDot(fn.Cum, rpt),
 		template.HTMLEscapeString(fn.Info.Name))

--- a/internal/report/source_html.go
+++ b/internal/report/source_html.go
@@ -14,8 +14,8 @@
 
 package report
 
-const weblistPageHeader = `
-<!DOCTYPE html>
+const weblistPageHeader =
+`<!DOCTYPE html>
 <html>
 <head>
 <title>Pprof listing</title>
@@ -83,5 +83,4 @@ function pprof_toggle_asm(e) {
 
 const weblistPageClosing = `
 </body>
-</html>
-`
+</html>`


### PR DESCRIPTION
Generate newlines consistently on the pprof html output for the weblist command.