### PR TITLE
Populate more carefully the profile.proto in the topproto output

### DIFF
--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -236,3 +236,27 @@ func TestDisambiguation(t *testing.T) {
 		}
 	}
 }
+
+func TestFunctionMap(t *testing.T) {
+
+	fm := make(functionMap)
+	nodes := []graph.NodeInfo{
+		{Name: "fun1"},
+		{Name: "fun2", File: "filename"},
+		{Name: "fun1"},
+		{Name: "fun2", File: "filename2"},
+	}
+
+	want := []profile.Function{
+		{ID: 1, Name: "fun1"},
+		{ID: 2, Name: "fun2", Filename: "filename"},
+		{ID: 1, Name: "fun1"},
+		{ID: 3, Name: "fun2", Filename: "filename2"},
+	}
+
+	for i, tc := range nodes {
+		if got, want := fm.FindOrAdd(tc), want[i]; *got != want {
+			t.Errorf("%d: want %v, got %v", i, want, got)
+		}
+	}
+}


### PR DESCRIPTION
Instead of putting a pretty-printed string on the function.name,
populate the function.name, .file and location line with the
information from the node. This will help more easily extract this
information.

Also add some cachign to reuse functions and added a small test.