### PR TITLE
Parse correctly mappings where the binary has been deleted

### DIFF
--- a/profile/legacy_profile.go
+++ b/profile/legacy_profile.go
@@ -57,12 +57,12 @@ var (
 	cHex           = `(?:0x)?([[:xdigit:]]+)`
 	cHexRange      = `\s*` + cHex + `[\s-]?` + oSpace + cHex + `:?`
 	cSpaceString   = `(?:\s+(\S+))?`
-	cSpaceHex      = `\s+([[:xdigit:]]+)`
+	cSpaceHex      = `(?:\s+([[:xdigit:]]+))?`
 	cSpaceAtOffset = `(?:\s+\(@([[:xdigit:]]+)\))?`
 	cPerm          = `(?:\s+([-rwxp]+))?`
 
-	procMapsRE  = regexp.MustCompile(`^` + cHexRange + cPerm + cSpaceHex + hexPair + spaceDigits + cSpaceString + `\s*$`)
-	briefMapsRE = regexp.MustCompile(`^` + cHexRange + cPerm + cSpaceString + cSpaceAtOffset + cSpaceString + `\s*$`)
+	procMapsRE  = regexp.MustCompile(`^` + cHexRange + cPerm + cSpaceHex + hexPair + spaceDigits + cSpaceString)
+	briefMapsRE = regexp.MustCompile(`^` + cHexRange + cPerm + cSpaceString + cSpaceAtOffset + cSpaceHex)
 )
 
 func isSpaceOrComment(line string) bool {

--- a/profile/legacy_profile_test.go
+++ b/profile/legacy_profile_test.go
@@ -158,6 +158,14 @@ func TestParseMappingEntry(t *testing.T) {
 			},
 		},
 		{
+			entry: "  02e00000-02e8a000: /foo/bin (deleted)",
+			want: &Mapping{
+				Start: 0x2e00000,
+				Limit: 0x2e8a000,
+				File:  "/foo/bin",
+			},
+		},
+		{
 			entry: "  02e00000-02e8a000: /foo/bin",
 			want: &Mapping{
 				Start: 0x2e00000,
@@ -218,7 +226,7 @@ func TestParseMappingEntry(t *testing.T) {
 	} {
 		got, err := parseMappingEntry(test.entry)
 		if err != nil {
-			t.Error(err)
+			t.Errorf("%s: %v", test.entry, err)
 		}
 		if !reflect.DeepEqual(test.want, got) {
 			t.Errorf("%s want=%v got=%v", test.entry, test.want, got)


### PR DESCRIPTION
Entry mappings of the form:
 "  02e00000-02e8a000: /foo/bin (deleted)"
are currently resulting in "(deleted)" being set as the build id.
Enforce the build id to be hex, and allow unrecognized junk to
be at the end of the mapping.