### PR TITLE
Add a helper function to check if a mapping is unsymbolizable

### DIFF
--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -298,8 +298,7 @@ func newMapping(prof *profile.Profile, obj plugin.ObjTool, ui plugin.UI, force b
 		}
 
 		// Skip well-known system mappings
-		name := filepath.Base(m.File)
-		if name == "[vdso]" || strings.HasPrefix(name, "linux-vdso") {
+		if m.Unsymbolizable() {
 			continue
 		}
 
@@ -310,6 +309,7 @@ func newMapping(prof *profile.Profile, obj plugin.ObjTool, ui plugin.UI, force b
 			}
 		}
 
+		name := filepath.Base(m.File)
 		f, err := obj.Open(m.File, m.Start, m.Limit, m.Offset)
 		if err != nil {
 			ui.PrintErr("Local symbolization failed for ", name, ": ", err)

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -581,6 +582,13 @@ func (p *Profile) HasFileLines() bool {
 		}
 	}
 	return true
+}
+
+// Unsymbolizable returns true if a mapping points to a binary for which
+// locations can't be symbolized in principle, at least now.
+func (m *Mapping) Unsymbolizable() bool {
+	name := filepath.Base(m.File)
+	return name == "[vdso]" || strings.HasPrefix(name, "linux-vdso")
 }
 
 // Copy makes a fully independent copy of a profile.


### PR DESCRIPTION
The local symbolization already skips these mappings. Have the helper which can be used when alternative symbolization flows are used.