### PR TITLE
Do not attempt to symbolize /dev/dri/* and [heap] files.

### DIFF
--- a/profile/profile.go
+++ b/profile/profile.go
@@ -599,7 +599,7 @@ func (p *Profile) HasFileLines() bool {
 // locations can't be symbolized in principle, at least now.
 func (m *Mapping) Unsymbolizable() bool {
 	name := filepath.Base(m.File)
-	return name == "[vdso]" || strings.HasPrefix(name, "linux-vdso")
+	return name == "[vdso]" || strings.HasPrefix(name, "linux-vdso") || name == "[heap]" || strings.HasPrefix(m.File, "/dev/dri/")
 }
 
 // Copy makes a fully independent copy of a profile.


### PR DESCRIPTION
Trying to symbolize files like /dev/dri/renderD128 makes pprof hang as
it tries to read from this device file. So do not attempt the symbolization.

Skip [heap] file, too - the profile from issue #78 has a couple samples
in the heap (perhaps some generated code) and trying to locate a file
with that name can't succeed.

Fixes #78.