### PR TITLE
Remove source from fetch error message

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -388,7 +388,7 @@ func fetch(source string, duration, timeout time.Duration, ui plugin.UI) (p *pro
 func fetchURL(source string, timeout time.Duration) (io.ReadCloser, error) {
 	resp, err := httpGet(source, timeout)
 	if err != nil {
-		return nil, fmt.Errorf("http fetch %s: %v", source, err)
+		return nil, fmt.Errorf("http fetch: %v", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("server response: %s", resp.Status)


### PR DESCRIPTION
The source is already included in the error, so it is redundant, eg:

pprof http://nowhere.nothere
Currently produces:
http://nowhere.nothere: http fetch http://nowhere.nothere: Get http://nowhere.nothere: dial tcp: lookup nowhere.nothere: no such host

With this commit:
http://nowhere.nothere: http fetch: Get http://nowhere.nothere: dial tcp: lookup nowhere.nothere: no such host