### PR TITLE
profile.parseGoCount: accept non-space characters in profile type.

### DIFF
--- a/profile/legacy_profile.go
+++ b/profile/legacy_profile.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	countStartRE = regexp.MustCompile(`\A(\w+) profile: total \d+\z`)
+	countStartRE = regexp.MustCompile(`\A(\S+) profile: total \d+\z`)
 	countRE      = regexp.MustCompile(`\A(\d+) @(( 0x[0-9a-f]+)+)\z`)
 
 	heapHeaderRE = regexp.MustCompile(`heap profile: *(\d+): *(\d+) *\[ *(\d+): *(\d+) *\] *@ *(heap[_a-z0-9]*)/?(\d*)`)

--- a/profile/legacy_profile_test.go
+++ b/profile/legacy_profile_test.go
@@ -264,3 +264,41 @@ func TestParseMappingEntry(t *testing.T) {
 		}
 	}
 }
+
+func TestParseGoCount(t *testing.T) {
+	for _, test := range []struct {
+		in  string
+		typ string
+	}{
+		{
+			in: `# ignored comment
+
+threadcreate profile: total 123
+`,
+			typ: "threadcreate",
+		},
+		{
+			in: `
+# ignored comment
+goroutine profile: total 123456
+`,
+			typ: "goroutine",
+		},
+		{
+			in: `
+sub/dir-ect_o.ry profile: total 999
+`,
+			typ: "sub/dir-ect_o.ry",
+		},
+	} {
+		t.Run(test.typ, func(t *testing.T) {
+			p, err := parseGoCount([]byte(test.in))
+			if err != nil {
+				t.Fatalf("parseGoCount(%q) = %v", test.in, err)
+			}
+			if typ := p.PeriodType.Type; typ != test.typ {
+				t.Fatalf("parseGoCount(%q).PeriodType.Type = %q want %q", test.in, typ, test.typ)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In addition to the "goroutine" and "threadcreate" profiles,
Go code can generate custom profiles using the runtime/pprof package.
The user must name these profiles, and the docs recommend using the
convention "import/path" to avoid namespace conflicts.  This CL
updates the pprof tool to be able to parse legacy profiles whose types
contain slashes and other non-space characters.

This is the upstream fix for https://github.com/golang/go/issues/13195.
This change will need to be mirrored to
github.com/golang/go/src/cmd/pprof/internal/profile/legacy_profile.go