### PR TITLE
Display HTTP errors from server

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -403,8 +403,7 @@ func fetchURL(source string, timeout time.Duration) (io.ReadCloser, error) {
 func statusCodeError(resp *http.Response) error {
 	if resp.Header.Get("X-Go-Pprof") != "" && strings.Contains(resp.Header.Get("Content-Type"), "text/plain") {
 		// error is from pprof endpoint
-		body, err := ioutil.ReadAll(resp.Body)
-		if err == nil {
+		if body, err := ioutil.ReadAll(resp.Body); err == nil {
 			return fmt.Errorf("server response: %s - %s", resp.Status, body)
 		}
 	}

--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -18,12 +18,14 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -391,10 +393,22 @@ func fetchURL(source string, timeout time.Duration) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("http fetch: %v", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server response: %s", resp.Status)
+		defer resp.Body.Close()
+		return nil, statusCodeError(resp)
 	}
 
 	return resp.Body, nil
+}
+
+func statusCodeError(resp *http.Response) error {
+	if resp.Header.Get("X-Go-Pprof") != "" && strings.Contains(resp.Header.Get("Content-Type"), "text/plain") {
+		// error is from pprof endpoint
+		body, err := ioutil.ReadAll(resp.Body)
+		if err == nil {
+			return fmt.Errorf("server response: %s - %s", resp.Status, body)
+		}
+	}
+	return fmt.Errorf("server response: %s", resp.Status)
 }
 
 // isPerfFile checks if a file is in perf.data format. It also returns false

--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -104,8 +104,7 @@ func postURL(source, post string) ([]byte, error) {
 func statusCodeError(resp *http.Response) error {
 	if resp.Header.Get("X-Go-Pprof") != "" && strings.Contains(resp.Header.Get("Content-Type"), "text/plain") {
 		// error is from pprof endpoint
-		body, err := ioutil.ReadAll(resp.Body)
-		if err == nil {
+		if body, err := ioutil.ReadAll(resp.Body); err == nil {
 			return fmt.Errorf("server response: %s - %s", resp.Status, body)
 		}
 	}


### PR DESCRIPTION
Upstreaming change from golang/go@39366326.

HTTP body will be read and displayed when both conditions are true:
* Response includes non-empty header "X-Go-Pprof".
* Content-Type is text/plain.

Would it be acceptable to move the fetch functions into a separate `fetch` package as it is in golang/go? This PR currently duplicates the `statusCodeError()` function in packages `internal/driver` and `internal/symbolizer`. Importing from `internal/driver` into `internal/symbolizer` causes an import cycle. `internal/symbolizer` to `internal/driver` doesn't cause a cycle but seems like a less than ideal structure.