### PR TITLE
Honor environment proxy settings

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -478,6 +478,7 @@ var httpGet = func(url string, timeout time.Duration) (*http.Response, error) {
 	client := &http.Client{
 		Transport: &http.Transport{
 			ResponseHeaderTimeout: timeout + 5*time.Second,
+			Proxy: http.ProxyFromEnvironment,
 		},
 	}
 	return client.Get(url)


### PR DESCRIPTION
Allow pulling profiles from a device that is only accessible through a proxy. The proxy is to be specified with the usual HTTP_PROXY environment setting.