### PR TITLE
Clean-up handling of output flag

### DIFF
--- a/internal/driver/interactive_test.go
+++ b/internal/driver/interactive_test.go
@@ -80,7 +80,7 @@ func TestShell(t *testing.T) {
 }
 
 var testCommands = commands{
-	"check": &command{report.Raw, nil, true, "", ""},
+	"check": &command{report.Raw, nil, nil, true, "", ""},
 }
 
 func testVariables(base variables) variables {

--- a/third_party/svg/svg.go
+++ b/third_party/svg/svg.go
@@ -16,7 +16,6 @@
 package svg
 
 import (
-	"bytes"
 	"regexp"
 	"strings"
 )
@@ -30,9 +29,7 @@ var (
 // Massage enhances the SVG output from DOT to provide better
 // panning inside a web browser. It uses the SVGPan library, which is
 // embedded into the svgPanJS variable.
-func Massage(in bytes.Buffer) string {
-	svg := string(in.Bytes())
-
+func Massage(svg string) string {
 	// Work around for dot bug which misses quoting some ampersands,
 	// resulting on unparsable SVG.
 	svg = strings.Replace(svg, "&;", "&amp;;", -1)


### PR DESCRIPTION
For certain formats (eog, evince, gv, web, weblist), the visualizer
would be invoked regardless of whether the user specified a specific
output file to write to. In order to ensure that output is properly
written, the invokeVisualizer function has a check for whether the
output is os.Stdout and alters behavior based on that. This is the
wrong abstraction layer to do that work.

At the core of the problem is that PostProcess is used to both
do data post-processing that is inherent to the format, and also
to invoke some visualization for the data (to Stdout or browser).
We split these two steps apart and make it obvious which is which
by adding a visualizer field to Command.

This seperation of concerns allows us to simplify the code.