### PR TITLE
pprof/internal/symbolizer: do not recognize C:\foo\bar.exe as a URL

### DIFF
--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -314,7 +314,7 @@ func newMapping(prof *profile.Profile, obj plugin.ObjTool, ui plugin.UI, force b
 
 		// Skip mappings pointing to a source URL
 		if m.BuildID == "" {
-			if u, err := url.Parse(m.File); err == nil && u.IsAbs() {
+			if u, err := url.Parse(m.File); err == nil && u.IsAbs() && strings.Contains(strings.ToLower(u.Scheme), "http") {
 				continue
 			}
 		}


### PR DESCRIPTION
Fixes executables named on the command line on Windows.
Fixes the build failure on https://go-review.googlesource.com/#/c/36798 patch set 6.