### PR TITLE
pprof: fix tests on Windows

### DIFF
--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -161,6 +162,10 @@ func TestParse(t *testing.T) {
 		if err != nil {
 			t.Errorf("reading solution file %s: %v", solution, err)
 			continue
+		}
+		if runtime.GOOS == "windows" {
+			sbuf = bytes.Replace(sbuf, []byte("testdata/"), []byte("testdata\\"), -1)
+			sbuf = bytes.Replace(sbuf, []byte("/path/to/"), []byte("\\path\\to\\"), -1)
 		}
 
 		if flags[0] == "svg" {

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"testing"
 	"time"
 
@@ -32,6 +33,10 @@ import (
 )
 
 func TestSymbolizationPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test assumes Unix paths")
+	}
+
 	// Save environment variables to restore after test
 	saveHome := os.Getenv("HOME")
 	savePath := os.Getenv("PPROF_BINARY_PATH")

--- a/internal/proftest/proftest.go
+++ b/internal/proftest/proftest.go
@@ -52,6 +52,10 @@ func Diff(b1, b2 []byte) (data []byte, err error) {
 		// Ignore that failure as long as we get output.
 		err = nil
 	}
+	if err != nil {
+		data = []byte(fmt.Sprintf("diff failed: %v\nb1: %q\nb2: %q\n", err, b1, b2))
+		err = nil
+	}
 	return
 }
 

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"regexp"
+	"runtime"
 	"testing"
 
 	"github.com/google/pprof/internal/binutils"
@@ -75,6 +76,9 @@ func TestSource(t *testing.T) {
 		gold, err := ioutil.ReadFile(tc.want)
 		if err != nil {
 			t.Fatalf("%s: %v", tc.want, err)
+		}
+		if runtime.GOOS == "windows" {
+			gold = bytes.Replace(gold, []byte("testdata/"), []byte("testdata\\"), -1)
 		}
 		if string(b.String()) != string(gold) {
 			d, err := proftest.Diff(gold, b.Bytes())


### PR DESCRIPTION
Skip TestSymbolizationPath (seems too Unix-specific).
Fix others with golden output to adjust for Windows file name syntax.