### PR TITLE
internal/driver: avoid using $HOME directly

### DIFF
--- a/doc/pprof.md
+++ b/doc/pprof.md
@@ -84,7 +84,7 @@ pprof text reports show the location hierarchy in text format.
 
 * **-text:** Prints the location entries, one per line, including the flat and cum
   values.
-* **-tree:** Prints each location entry with its predecessors and successors. 
+* **-tree:** Prints each location entry with its predecessors and successors.
 * **-peek= _regex_:** Print the location entry with all its predecessors and
   successors, without trimming any entries.
 * **-traces:** Prints each sample with a location per line.
@@ -120,9 +120,10 @@ profile must contain data with the appropriate level of detail.
 
 pprof will look for source files on its current working directory and all its
 ancestors. pprof will look for binaries on the directories specified in the
-`$PPROF_BINARY_PATH` environment variable, by default `$HOME/pprof/binaries`. It
-will look binaries up by name, and if the profile includes linker build ids, it
-will also search for them in a directory named as the build id.
+`$PPROF_BINARY_PATH` environment variable, by default `$HOME/pprof/binaries`
+(`%USERPROFILE%\pprof\binaries` on Windows). It will look binaries up by name,
+and if the profile includes linker build ids, it will also search for them in
+a directory named as the build id.
 
 pprof uses the binutils tools to examine and disassemble the binaries. By
 default it will search for those tools in the current path, but it can also

--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -268,4 +268,5 @@ var usageMsgVars = "\n\n" +
 	"   PPROF_TOOLS        Search path for object-level tools\n" +
 	"   PPROF_BINARY_PATH  Search path for local binary files\n" +
 	"                      default: $HOME/pprof/binaries\n" +
-	"                      finds binaries by $name and $buildid/$name\n"
+	"                      finds binaries by $name and $buildid/$name\n" +
+	"   * On Windows, %USERPROFILE% is used instead of $HOME"


### PR DESCRIPTION
Not all OSes have $HOME variable.
Use appropriate variables per OS.

Fixes https://github.com/golang/go/issues/18864