### PR TITLE
Search files under PPROF_BINARY_PATH using both its basename and its …

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -344,8 +344,13 @@ mapping:
 					fileNames = append(fileNames, matches...)
 				}
 			}
-			if baseName != "" {
-				fileNames = append(fileNames, filepath.Join(path, baseName))
+			if m.File != "" {
+				// Try both the basename and the full path, to support the same directory
+				// structure as the perf symfs option.
+				if baseName != "" {
+					fileNames = append(fileNames, filepath.Join(path, baseName))
+				}
+				fileNames = append(fileNames, filepath.Join(path, m.File))
 			}
 			for _, name := range fileNames {
 				if f, err := obj.Open(name, m.Start, m.Limit, m.Offset); err == nil {

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -57,6 +57,7 @@ func TestSymbolizationPath(t *testing.T) {
 	}{
 		{"", "/usr/bin/binary", "", "/usr/bin/binary", 0},
 		{"", "/usr/bin/binary", "fedcb10000", "/usr/bin/binary", 0},
+		{"/usr", "/bin/binary", "", "/usr/bin/binary", 0},
 		{"", "/prod/path/binary", "abcde10001", filepath.Join(tempdir, "pprof/binaries/abcde10001/binary"), 0},
 		{"/alternate/architecture", "/usr/bin/binary", "", "/alternate/architecture/binary", 0},
 		{"/alternate/architecture", "/usr/bin/binary", "abcde10001", "/alternate/architecture/binary", 0},


### PR DESCRIPTION
…full path

This allows pointing PPROF_BINARY_PATH to the root of the filesystem containing
the binaries of interest, similar to perf symfs.

This fixes #96