### PR TITLE
Fix issues reported by govet

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -42,12 +42,12 @@ func (o *Options) InternalOptions() *plugin.Options {
 		sym = &internalSymbolizer{o.Sym}
 	}
 	return &plugin.Options{
-		o.Writer,
-		o.Flagset,
-		o.Fetch,
-		sym,
-		obj,
-		o.UI,
+		Writer: o.Writer,
+		Flagset: o.Flagset,
+		Fetch: o.Fetch,
+		Sym: sym,
+		Obj: obj,
+		UI: o.UI,
 	}
 }
 

--- a/internal/binutils/addr2liner.go
+++ b/internal/binutils/addr2liner.go
@@ -164,7 +164,10 @@ func (d *addr2Liner) readFrame() (plugin.Frame, bool) {
 		}
 	}
 
-	return plugin.Frame{funcname, fileline, linenumber}, false
+	return plugin.Frame{
+		Func: funcname,
+		File: fileline,
+		Line: linenumber}, false
 }
 
 // addrInfo returns the stack frame information for a specific program

--- a/internal/binutils/addr2liner_llvm.go
+++ b/internal/binutils/addr2liner_llvm.go
@@ -121,7 +121,7 @@ func (d *llvmSymbolizer) readFrame() (plugin.Frame, bool) {
 
 	fileline, err := d.readString()
 	if err != nil {
-		return plugin.Frame{funcname, "", 0}, true
+		return plugin.Frame{Func: funcname}, true
 	}
 
 	linenumber := 0
@@ -144,7 +144,7 @@ func (d *llvmSymbolizer) readFrame() (plugin.Frame, bool) {
 		}
 	}
 
-	return plugin.Frame{funcname, fileline, linenumber}, false
+	return plugin.Frame{Func: funcname, File: fileline, Line: linenumber}, false
 }
 
 // addrInfo returns the stack frame information for a specific program

--- a/internal/binutils/binutils_test.go
+++ b/internal/binutils/binutils_test.go
@@ -49,7 +49,7 @@ func TestAddr2Liner(t *testing.T) {
 		}
 		for l, f := range s {
 			level := (len(s) - l) * 1000
-			want := plugin.Frame{functionName(level), fmt.Sprintf("file%d", level), level}
+			want := plugin.Frame{Func: functionName(level), File: fmt.Sprintf("file%d", level), Line: level}
 
 			if f != want {
 				t.Errorf("AddrInfo(%#x)[%d]: = %+v, want %+v", addr, l, f, want)

--- a/internal/binutils/disasm.go
+++ b/internal/binutils/disasm.go
@@ -46,7 +46,7 @@ func findSymbols(syms []byte, file string, r *regexp.Regexp, address uint64) ([]
 			continue
 		}
 		if match := matchSymbol(names, start, symAddr-1, r, address); match != nil {
-			symbols = append(symbols, &plugin.Sym{match, file, start, symAddr - 1})
+			symbols = append(symbols, &plugin.Sym{Name: match, File: file, Start: start, End: symAddr - 1})
 		}
 		names, start = []string{name}, symAddr
 	}

--- a/internal/binutils/disasm_test.go
+++ b/internal/binutils/disasm_test.go
@@ -46,16 +46,16 @@ func TestFindSymbols(t *testing.T) {
 			"line.*[AC]",
 			testsyms,
 			[]plugin.Sym{
-				{[]string{"lineA001"}, "object.o", 0x1000, 0x1FFF},
-				{[]string{"line200A"}, "object.o", 0x2000, 0x2FFF},
-				{[]string{"lineB00C"}, "object.o", 0x3000, 0x3FFF},
+				{Name: []string{"lineA001"}, File: "object.o", Start: 0x1000, End: 0x1FFF},
+				{Name: []string{"line200A"}, File: "object.o", Start: 0x2000, End: 0x2FFF},
+				{Name: []string{"lineB00C"}, File: "object.o", Start: 0x3000, End: 0x3FFF},
 			},
 		},
 		{
 			"Dumb::operator",
 			testsyms,
 			[]plugin.Sym{
-				{[]string{"Dumb::operator()(char const*) const"}, "object.o", 0x3000, 0x3FFF},
+				{Name: []string{"Dumb::operator()(char const*) const"}, File: "object.o", Start: 0x3000, End: 0x3FFF},
 			},
 		},
 	}
@@ -109,7 +109,7 @@ func TestFunctionAssembly(t *testing.T) {
 	}
 	testcases := []testcase{
 		{
-			plugin.Sym{[]string{"symbol1"}, "", 0x1000, 0x1FFF},
+			plugin.Sym{Name: []string{"symbol1"}, Start: 0x1000, End: 0x1FFF},
 			`  1000: instruction one
   1001: instruction two
   1002: instruction three
@@ -123,7 +123,7 @@ func TestFunctionAssembly(t *testing.T) {
 			},
 		},
 		{
-			plugin.Sym{[]string{"symbol2"}, "", 0x2000, 0x2FFF},
+			plugin.Sym{Name: []string{"symbol2"}, Start: 0x2000, End: 0x2FFF},
 			`  2000: instruction one
   2001: instruction two
 `,

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -105,7 +105,7 @@ func TestCollectMappingSources(t *testing.T) {
 		}
 		got := collectMappingSources(p, url)
 		if !reflect.DeepEqual(got, tc.want) {
-			t.Errorf("%s:%s, want %s, got %s", tc.file, tc.buildID, tc.want, got)
+			t.Errorf("%s:%s, want %v, got %v", tc.file, tc.buildID, tc.want, got)
 		}
 	}
 }

--- a/internal/driver/options.go
+++ b/internal/driver/options.go
@@ -47,7 +47,7 @@ func setDefaults(o *plugin.Options) *plugin.Options {
 		d.UI = &stdUI{r: bufio.NewReader(os.Stdin)}
 	}
 	if d.Sym == nil {
-		d.Sym = &symbolizer.Symbolizer{d.Obj, d.UI}
+		d.Sym = &symbolizer.Symbolizer{Obj: d.Obj, UI: d.UI}
 	}
 	return d
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -230,7 +230,7 @@ func TestDisambiguation(t *testing.T) {
 		sibling: "sibling",
 	}
 
-	g := &graph.Graph{n}
+	g := &graph.Graph{Nodes: n}
 
 	names := getDisambiguatedNames(g)
 

--- a/internal/symbolizer/symbolizer_test.go
+++ b/internal/symbolizer/symbolizer_test.go
@@ -207,11 +207,18 @@ func checkSymbolizedLocation(a uint64, got []profile.Line) error {
 }
 
 var mockAddresses = map[uint64][]plugin.Frame{
-	1000: []plugin.Frame{{"fun11", "file11.src", 10}},
-	2000: []plugin.Frame{{"fun21", "file21.src", 20}, {"fun22", "file22.src", 20}},
-	3000: []plugin.Frame{{"fun31", "file31.src", 30}, {"fun32", "file32.src", 30}, {"fun33", "file33.src", 30}},
-	4000: []plugin.Frame{{"fun41", "file41.src", 40}, {"fun42", "file42.src", 40}, {"fun43", "file43.src", 40}, {"fun44", "file44.src", 40}},
-	5000: []plugin.Frame{{"fun51", "file51.src", 50}, {"fun52", "file52.src", 50}, {"fun53", "file53.src", 50}, {"fun54", "file54.src", 50}, {"fun55", "file55.src", 50}},
+	1000: []plugin.Frame{frame("fun11", "file11.src", 10)},
+	2000: []plugin.Frame{frame("fun21", "file21.src", 20), frame("fun22", "file22.src", 20)},
+	3000: []plugin.Frame{frame("fun31", "file31.src", 30), frame("fun32", "file32.src", 30), frame("fun33", "file33.src", 30)},
+	4000: []plugin.Frame{frame("fun41", "file41.src", 40), frame("fun42", "file42.src", 40), frame("fun43", "file43.src", 40), frame("fun44", "file44.src", 40)},
+	5000: []plugin.Frame{frame("fun51", "file51.src", 50), frame("fun52", "file52.src", 50), frame("fun53", "file53.src", 50), frame("fun54", "file54.src", 50), frame("fun55", "file55.src", 50)},
+}
+
+func frame(fname, file string, line int) plugin.Frame {
+	return plugin.Frame{
+		Func: fname,
+		File: file,
+		Line: line}
 }
 
 type mockObjTool struct{}


### PR DESCRIPTION
Mainly use imported structs by field and update a mismatch printf
string on a test error message.

As requested at https://github.com/golang/go/issues/19322