### PR TITLE
internal/driver: use homeEnv function in tests

### DIFF
--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -38,7 +38,7 @@ func TestSymbolizationPath(t *testing.T) {
 	}
 
 	// Save environment variables to restore after test
-	saveHome := os.Getenv("HOME")
+	saveHome := os.Getenv(homeEnv())
 	savePath := os.Getenv("PPROF_BINARY_PATH")
 
 	tempdir, err := ioutil.TempDir("", "home")
@@ -50,7 +50,7 @@ func TestSymbolizationPath(t *testing.T) {
 	os.Create(filepath.Join(tempdir, "pprof", "binaries", "abcde10001", "binary"))
 
 	obj := testObj{tempdir}
-	os.Setenv("HOME", tempdir)
+	os.Setenv(homeEnv(), tempdir)
 	for _, tc := range []struct {
 		env, file, buildID, want string
 		msgCount                 int
@@ -79,7 +79,7 @@ func TestSymbolizationPath(t *testing.T) {
 			t.Errorf("%s:%s:%s, want %s, got %s", tc.env, tc.file, tc.buildID, tc.want, file)
 		}
 	}
-	os.Setenv("HOME", saveHome)
+	os.Setenv(homeEnv(), saveHome)
 	os.Setenv("PPROF_BINARY_PATH", savePath)
 }
 


### PR DESCRIPTION
In changeset f90721db3d, fetch.go was changed to handle
the correct home directory environment variable on Plan 9
and Windows, but the tests were still using the $HOME
environment variable.

We change the tests to use the homeEnv function instead
of the $HOME environment variable.

Fixes #100.