### PR TITLE
Make [vsyscall] recognized as a not symbolizable mapping.

### DIFF
--- a/profile/profile.go
+++ b/profile/profile.go
@@ -596,10 +596,11 @@ func (p *Profile) HasFileLines() bool {
 }
 
 // Unsymbolizable returns true if a mapping points to a binary for which
-// locations can't be symbolized in principle, at least now.
+// locations can't be symbolized in principle, at least now. Examples are
+// "[vdso]", [vsyscall]" and some others, see the code.
 func (m *Mapping) Unsymbolizable() bool {
 	name := filepath.Base(m.File)
-	return name == "[vdso]" || strings.HasPrefix(name, "linux-vdso") || name == "[heap]" || strings.HasPrefix(m.File, "/dev/dri/")
+	return strings.HasPrefix(name, "[") || strings.HasPrefix(name, "linux-vdso") || strings.HasPrefix(m.File, "/dev/dri/")
 }
 
 // Copy makes a fully independent copy of a profile.


### PR DESCRIPTION
Do so by relaxing the matching to treat all mappings for file names starting with a '[' as not symbolizable.