### PR TITLE
Do not honor call_tree option when generating non-visual reports.

### DIFF
--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -49,7 +49,7 @@ func TestParse(t *testing.T) {
 	}{
 		{"text,functions,flat", "cpu"},
 		{"tree,addresses,flat,nodecount=4", "cpusmall"},
-		{"text,functions,flat", "unknown"},
+		{"text,functions,flat,nodecount=5,call_tree", "unknown"},
 		{"text,alloc_objects,flat", "heap_alloc"},
 		{"text,files,flat", "heap"},
 		{"text,inuse_objects,flat", "heap"},
@@ -59,8 +59,10 @@ func TestParse(t *testing.T) {
 		{"tree,lines,cum,focus=[24]00", "heap"},
 		{"tree,relative_percentages,cum,focus=[24]00", "heap"},
 		{"callgrind", "cpu"},
+		{"callgrind,call_tree", "cpu"},
 		{"callgrind", "heap"},
 		{"dot,functions,flat", "cpu"},
+		{"dot,functions,flat,call_tree", "cpu"},
 		{"dot,lines,flat,focus=[12]00", "heap"},
 		{"dot,addresses,flat,ignore=[X3]002,focus=[X1]000", "contention"},
 		{"dot,files,cum", "contention"},
@@ -222,6 +224,7 @@ func solutionFilename(source string, f *testFlags) string {
 	name = addString(name, f, []string{"inuse_space", "inuse_objects", "alloc_space", "alloc_objects"})
 	name = addString(name, f, []string{"relative_percentages"})
 	name = addString(name, f, []string{"seconds"})
+	name = addString(name, f, []string{"call_tree"})
 	name = addString(name, f, []string{"text", "tree", "callgrind", "dot", "svg", "tags", "dot", "traces", "disasm", "peek", "weblist", "topproto", "comments"})
 	if f.strings["focus"] != "" || f.strings["tagfocus"] != "" {
 		name = append(name, "focus")

--- a/internal/driver/testdata/pprof.cpu.call_tree.callgrind
+++ b/internal/driver/testdata/pprof.cpu.call_tree.callgrind
@@ -1,0 +1,99 @@
+positions: instr line
+events: cpu(ms)
+
+ob=(1) /path/to/testbinary
+fl=(1) testdata/file1000.src
+fn=(1) line1000
+0x1000 1 1000
+* 1 100
+
+ob=(1)
+fl=(2) testdata/file2000.src
+fn=(2) line2001
++4096 9 10
+
+ob=(1)
+fl=(3) testdata/file3000.src
+fn=(3) line3002
++4096 2 10
+cfl=(2)
+cfn=(4) line2000 [1/2]
+calls=0 * 4
+* * 1000
+
+ob=(1)
+fl=(2)
+fn=(5) line2000
+-4096 4 0
+cfl=(2)
+cfn=(6) line2001 [2/2]
+calls=0 -4096 9
+* * 1000
+* 4 0
+cfl=(2)
+cfn=(7) line2001 [1/2]
+calls=0 * 9
+* * 10
+
+ob=(1)
+fl=(2)
+fn=(2)
+* 9 0
+cfl=(1)
+cfn=(8) line1000 [1/2]
+calls=0 -4096 1
+* * 1000
+
+ob=(1)
+fl=(3)
+fn=(9) line3000
++4096 6 0
+cfl=(3)
+cfn=(10) line3001 [1/2]
+calls=0 +4096 5
+* * 1010
+
+ob=(1)
+fl=(3)
+fn=(11) line3001
+* 5 0
+cfl=(3)
+cfn=(12) line3002 [1/2]
+calls=0 * 2
+* * 1010
+
+ob=(1)
+fl=(3)
+fn=(9)
++1 9 0
+cfl=(3)
+cfn=(13) line3001 [2/2]
+calls=0 +1 8
+* * 100
+
+ob=(1)
+fl=(3)
+fn=(11)
+* 8 0
+cfl=(1)
+cfn=(14) line1000 [2/2]
+calls=0 -8193 1
+* * 100
+
+ob=(1)
+fl=(3)
+fn=(9)
++1 9 0
+cfl=(3)
+cfn=(15) line3002 [2/2]
+calls=0 +1 5
+* * 10
+
+ob=(1)
+fl=(3)
+fn=(3)
+* 5 0
+cfl=(2)
+cfn=(16) line2000 [2/2]
+calls=0 -4098 4
+* * 10

--- a/internal/driver/testdata/pprof.cpu.flat.functions.call_tree.dot
+++ b/internal/driver/testdata/pprof.cpu.flat.functions.call_tree.dot
@@ -1,0 +1,21 @@
+digraph "testbinary" {
+node [style=filled fillcolor="#f8f8f8"]
+subgraph cluster_L { "File: testbinary" [shape=box fontsize=16 label="File: testbinary\lType: cpu\lDuration: 10s, Total samples = 1.12s (11.20%)\lShowing nodes accounting for 1.11s, 99.11% of 1.12s total\lDropped 3 nodes (cum <= 0.06s)\l"] }
+N1 [label="line1000\nfile1000.src\n1s (89.29%)" fontsize=24 shape=box tooltip="line1000 testdata/file1000.src (1s)" color="#b20500" fillcolor="#edd6d5"]
+N1_0 [label = "key1:tag1\nkey2:tag1" fontsize=8 shape=box3d tooltip="1s"]
+N1 -> N1_0 [label=" 1s" weight=100 tooltip="1s" labeltooltip="1s"]
+N2 [label="line3000\nfile3000.src\n0 of 1.12s (100%)" fontsize=8 shape=box tooltip="line3000 testdata/file3000.src (1.12s)" color="#b20000" fillcolor="#edd5d5"]
+N3 [label="line3001\nfile3000.src\n0 of 1.11s (99.11%)" fontsize=8 shape=box tooltip="line3001 testdata/file3000.src (1.11s)" color="#b20000" fillcolor="#edd5d5"]
+N4 [label="line1000\nfile1000.src\n0.10s (8.93%)" fontsize=14 shape=box tooltip="line1000 testdata/file1000.src (0.10s)" color="#b28b62" fillcolor="#ede8e2"]
+N4_0 [label = "key1:tag2\nkey3:tag2" fontsize=8 shape=box3d tooltip="0.10s"]
+N4 -> N4_0 [label=" 0.10s" weight=100 tooltip="0.10s" labeltooltip="0.10s"]
+N5 [label="line3002\nfile3000.src\n0.01s (0.89%)\nof 1.01s (90.18%)" fontsize=10 shape=box tooltip="line3002 testdata/file3000.src (1.01s)" color="#b20500" fillcolor="#edd6d5"]
+N6 [label="line2000\nfile2000.src\n0 of 1s (89.29%)" fontsize=8 shape=box tooltip="line2000 testdata/file2000.src (1s)" color="#b20500" fillcolor="#edd6d5"]
+N7 [label="line2001\nfile2000.src\n0 of 1s (89.29%)" fontsize=8 shape=box tooltip="line2001 testdata/file2000.src (1s)" color="#b20500" fillcolor="#edd6d5"]
+N2 -> N3 [label=" 1.11s\n (inline)" weight=100 penwidth=5 color="#b20000" tooltip="line3000 testdata/file3000.src -> line3001 testdata/file3000.src (1.11s)" labeltooltip="line3000 testdata/file3000.src -> line3001 testdata/file3000.src (1.11s)"]
+N3 -> N5 [label=" 1.01s\n (inline)" weight=91 penwidth=5 color="#b20500" tooltip="line3001 testdata/file3000.src -> line3002 testdata/file3000.src (1.01s)" labeltooltip="line3001 testdata/file3000.src -> line3002 testdata/file3000.src (1.01s)"]
+N6 -> N7 [label=" 1s\n (inline)" weight=90 penwidth=5 color="#b20500" tooltip="line2000 testdata/file2000.src -> line2001 testdata/file2000.src (1s)" labeltooltip="line2000 testdata/file2000.src -> line2001 testdata/file2000.src (1s)"]
+N7 -> N1 [label=" 1s" weight=90 penwidth=5 color="#b20500" tooltip="line2001 testdata/file2000.src -> line1000 testdata/file1000.src (1s)" labeltooltip="line2001 testdata/file2000.src -> line1000 testdata/file1000.src (1s)"]
+N5 -> N6 [label=" 1s" weight=90 penwidth=5 color="#b20500" tooltip="line3002 testdata/file3000.src -> line2000 testdata/file2000.src (1s)" labeltooltip="line3002 testdata/file3000.src -> line2000 testdata/file2000.src (1s)"]
+N3 -> N4 [label=" 0.10s" weight=9 color="#b28b62" tooltip="line3001 testdata/file3000.src -> line1000 testdata/file1000.src (0.10s)" labeltooltip="line3001 testdata/file3000.src -> line1000 testdata/file1000.src (0.10s)"]
+}

--- a/internal/driver/testdata/pprof.unknown.flat.functions.call_tree.text
+++ b/internal/driver/testdata/pprof.unknown.flat.functions.call_tree.text
@@ -1,8 +1,8 @@
 Showing nodes accounting for 1.12s, 100% of 1.12s total
+Showing top 5 nodes out of 6
       flat  flat%   sum%        cum   cum%
      1.10s 98.21% 98.21%      1.10s 98.21%  line1000 testdata/file1000.src
      0.01s  0.89% 99.11%      1.01s 90.18%  line2001 testdata/file2000.src (inline)
      0.01s  0.89%   100%      1.02s 91.07%  line3002 testdata/file3000.src (inline)
          0     0%   100%      1.01s 90.18%  line2000 testdata/file2000.src
          0     0%   100%      1.12s   100%  line3000 testdata/file3000.src
-         0     0%   100%      1.11s 99.11%  line3001 testdata/file3000.src (inline)

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -125,6 +125,9 @@ func (rpt *Report) newTrimmedGraph() (g *graph.Graph, origCount, droppedNodes, d
 	visualMode := o.OutputFormat == Dot
 	cumSort := o.CumSort
 
+	// The call_tree option is only honored when generating visual representations of the callgraph.
+	callTree := o.CallTree && (o.OutputFormat == Dot || o.OutputFormat == Callgrind)
+
 	// First step: Build complete graph to identify low frequency nodes, based on their cum weight.
 	g = rpt.newGraph(nil)
 	totalValue, _ := g.Nodes.Sum()
@@ -133,7 +136,7 @@ func (rpt *Report) newTrimmedGraph() (g *graph.Graph, origCount, droppedNodes, d
 
 	// Filter out nodes with cum value below nodeCutoff.
 	if nodeCutoff > 0 {
-		if o.CallTree {
+		if callTree {
 			if nodesKept := g.DiscardLowFrequencyNodePtrs(nodeCutoff); len(g.Nodes) != len(nodesKept) {
 				droppedNodes = len(g.Nodes) - len(nodesKept)
 				g.TrimTree(nodesKept)
@@ -154,7 +157,7 @@ func (rpt *Report) newTrimmedGraph() (g *graph.Graph, origCount, droppedNodes, d
 		// Remove low frequency tags and edges as they affect selection.
 		g.TrimLowFrequencyTags(nodeCutoff)
 		g.TrimLowFrequencyEdges(edgeCutoff)
-		if o.CallTree {
+		if callTree {
 			if nodesKept := g.SelectTopNodePtrs(nodeCount, visualMode); len(g.Nodes) != len(nodesKept) {
 				g.TrimTree(nodesKept)
 				g.SortNodes(cumSort, visualMode)


### PR DESCRIPTION
There is a check to only honor the call_tree option when generating non-visual
reports, but it wasn't being checked in all appropriate places, causing a
mismatch that triggered a panic.

This fixes #103
