### PR TITLE
Revert "Recognize https+insecure scheme for symbolization POSTs."

### DIFF
--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -16,17 +16,8 @@ package driver
 
 import (
 	"bytes"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"io/ioutil"
-	"math/big"
-	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"regexp"
 	"runtime"
@@ -336,15 +327,6 @@ func (f testFlags) StringList(s, d, c string) *[]*string {
 
 func (f testFlags) Parse(func()) []string {
 	return f.args
-}
-
-func emptyFlags() testFlags {
-	return testFlags{
-		bools:   map[string]bool{},
-		ints:    map[string]int{},
-		floats:  map[string]float64{},
-		strings: map[string]string{},
-	}
 }
 
 func baseFlags() testFlags {
@@ -1039,96 +1021,6 @@ func TestSymbolzAfterMerge(t *testing.T) {
 			t.Errorf("symbolz %#x, got %s, want %s", address, got, want)
 		}
 	}
-}
-
-func TestHttpsInsecure(t *testing.T) {
-	baseVars := pprofVariables
-	pprofVariables = baseVars.makeCopy()
-	defer func() { pprofVariables = baseVars }()
-
-	tlsConfig := &tls.Config{Certificates: []tls.Certificate{selfSignedCert(t)}}
-	donec := make(chan struct{}, 1)
-
-	l, err := tls.Listen("tcp", "localhost:0", tlsConfig)
-	if err != nil {
-		t.Fatalf("net.Listen: got error %v, want no error", err)
-	}
-	defer func() { <-donec }()
-	defer l.Close()
-
-	go func(donec chan<- struct{}) {
-		defer func() { donec <- struct{}{} }()
-		if got, want := http.Serve(l, nil), "use of closed"; !strings.Contains(got.Error(), want) {
-			t.Fatalf("Serve got error %v, want %q", got, want)
-		}
-	}(donec)
-
-	go func() {
-		deadline := time.Now().Add(5 * time.Second)
-		for time.Now().Before(deadline) {
-			// Simulate a hotspot function.
-		}
-	}()
-
-	outputTempFile, err := ioutil.TempFile("", "profile_output")
-	if err != nil {
-		t.Fatalf("Failed to create tempfile: %v", err)
-	}
-	defer os.Remove(outputTempFile.Name())
-	defer outputTempFile.Close()
-
-	f := emptyFlags()
-	o := setDefaults(nil)
-	o.Flagset = &f
-
-	f.args = []string{"https+insecure://" + l.Addr().String() + "/debug/pprof/profile?seconds=5"}
-	addFlags(&f, []string{
-		"top",
-		"symbolize=remote",
-		"output=" + outputTempFile.Name(),
-	})
-
-	if err := PProf(o); err != nil {
-		t.Fatalf("PProf(%v): got error %v, want no error", o, err)
-	}
-
-	b, err := ioutil.ReadFile(outputTempFile.Name())
-	if err != nil {
-		t.Fatalf("ReadFile(%s) got error %v, want no error", outputTempFile.Name(), err)
-	}
-	if got, want := string(b), "TestHttpsInsecure"; !strings.Contains(got, want) {
-		t.Fatalf("Pprof(%v): got %v, want %q substring", o, got, want)
-	}
-}
-
-func selfSignedCert(t *testing.T) tls.Certificate {
-	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("failed to generate private key: %v", err)
-	}
-	b, err := x509.MarshalECPrivateKey(privKey)
-	if err != nil {
-		t.Fatalf("failed to marshal private key: %v", err)
-	}
-	bk := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: b})
-
-	tmpl := x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().Add(10 * time.Minute),
-	}
-
-	b, err = x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, privKey.Public(), privKey)
-	if err != nil {
-		t.Fatalf("failed to create cert: %v", err)
-	}
-	bc := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: b})
-
-	cert, err := tls.X509KeyPair(bc, bk)
-	if err != nil {
-		t.Fatalf("failed to create TLS key pair: %v", err)
-	}
-	return cert
 }
 
 type mockObjTool struct{}

--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -18,7 +18,6 @@
 package symbolizer
 
 import (
-	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -91,26 +90,7 @@ func (s *Symbolizer) Symbolize(mode string, sources plugin.MappingSources, p *pr
 
 // postURL issues a POST to a URL over HTTP.
 func postURL(source, post string) ([]byte, error) {
-	url, err := url.Parse(source)
-	if err != nil {
-		return nil, err
-	}
-
-	var tlsConfig *tls.Config
-	if url.Scheme == "https+insecure" {
-		tlsConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
-		url.Scheme = "https"
-		source = url.String()
-	}
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
-	}
-	resp, err := client.Post(source, "application/octet-stream", strings.NewReader(post))
+	resp, err := http.Post(source, "application/octet-stream", strings.NewReader(post))
 	if err != nil {
 		return nil, fmt.Errorf("http post %s: %v", source, err)
 	}


### PR DESCRIPTION
Reverts google/pprof#111 as the test is reported to fail with Go 1.8.