### PR TITLE
Clarify that Go 1.7 or newer is required.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: go
 go:
-  - 1.6.x
   - 1.7.x
   - 1.8.x

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/google/pprof.svg?branch=master)](https://travis-ci.org/google/pprof)
+
 # Introduction
 
 pprof is a tool for visualization and analysis of profiling data.
@@ -24,7 +26,7 @@ them through the use of the native binutils tools (addr2line and nm).
 
 Prerequisites:
 
-- Go development kit. Known to work with Go 1.5.
+- Go development kit. Requires Go 1.7 or newer.
   Follow [these instructions](http://golang.org/doc/code.html) to install the 
   go tool and set up GOPATH.
 


### PR DESCRIPTION
Go 1.6 currently fails the tests with build error

`profile/legacy_profile_test.go:309: t.Run undefined (type *testing.T has no field or method Run)`

Alternatively, we can fix it but I am not sure there is a strong reason
to support Go 1.6 or older.

Also add build status badge in the README.md file.