### PR TITLE
Fix unstable nodefraction handling

### DIFF
--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -50,6 +50,8 @@ type DotConfig struct {
 	Total       int64                      // The total weight of the graph, used to compute percentages
 }
 
+const maxNodelets = 4 // Number of nodelets for labels (both numeric and non)
+
 // ComposeDot creates and writes a in the DOT format to the writer, using
 // the configurations given.
 func ComposeDot(w io.Writer, g *Graph, a *DotAttributes, c *DotConfig) {
@@ -204,8 +206,6 @@ func (b *builder) addNode(node *Node, nodeID int, maxFlat float64) {
 
 // addNodelets generates the DOT boxes for the node tags if they exist.
 func (b *builder) addNodelets(node *Node, nodeID int) bool {
-	const maxNodelets = 4    // Number of nodelets for alphanumeric labels
-	const maxNumNodelets = 4 // Number of nodelets for numeric labels
 	var nodelets string
 
 	// Populate two Tag slices, one for LabelTags and one for NumericTags.
@@ -242,12 +242,12 @@ func (b *builder) addNodelets(node *Node, nodeID int) bool {
 		nodelets += fmt.Sprintf(`N%d_%d [label = "%s" fontsize=8 shape=box3d tooltip="%s"]`+"\n", nodeID, i, t.Name, weight)
 		nodelets += fmt.Sprintf(`N%d -> N%d_%d [label=" %s" weight=100 tooltip="%s" labeltooltip="%s"]`+"\n", nodeID, nodeID, i, weight, weight, weight)
 		if nts := lnts[t.Name]; nts != nil {
-			nodelets += b.numericNodelets(nts, maxNumNodelets, flatTags, fmt.Sprintf(`N%d_%d`, nodeID, i))
+			nodelets += b.numericNodelets(nts, maxNodelets, flatTags, fmt.Sprintf(`N%d_%d`, nodeID, i))
 		}
 	}
 
 	if nts := lnts[""]; nts != nil {
-		nodelets += b.numericNodelets(nts, maxNumNodelets, flatTags, fmt.Sprintf(`N%d`, nodeID))
+		nodelets += b.numericNodelets(nts, maxNodelets, flatTags, fmt.Sprintf(`N%d`, nodeID))
 	}
 
 	fmt.Fprint(b, nodelets)

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -209,6 +209,59 @@ func compareGraphs(t *testing.T, got, want []byte) {
 	}
 }
 
+func TestNodeletCountCapping(t *testing.T) {
+	labelTags := make(TagMap)
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("tag-%d", i)
+		labelTags[name] = &Tag{
+			Name: name,
+			Flat: 10,
+			Cum:  10,
+		}
+	}
+	numTags := make(TagMap)
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("num-tag-%d", i)
+		numTags[name] = &Tag{
+			Name:  name,
+			Unit:  "mb",
+			Value: 16,
+			Flat:  10,
+			Cum:   10,
+		}
+	}
+	node1 := &Node{
+		Info:        NodeInfo{Name: "node1-with-tags"},
+		Flat:        10,
+		Cum:         10,
+		NumericTags: map[string]TagMap{"": numTags},
+		LabelTags:   labelTags,
+	}
+	node2 := &Node{
+		Info: NodeInfo{Name: "node2"},
+		Flat: 15,
+		Cum:  15,
+	}
+	node3 := &Node{
+		Info: NodeInfo{Name: "node3"},
+		Flat: 15,
+		Cum:  15,
+	}
+	g := &Graph{
+		Nodes: Nodes{
+			node1,
+			node2,
+			node3,
+		},
+	}
+	for n := 1; n <= 3; n++ {
+		input := maxNodelets + n
+		if got, want := len(g.SelectTopNodes(input, true)), n; got != want {
+			t.Errorf("SelectTopNodes(%d): got %d nodes, want %d", input, got, want)
+		}
+	}
+}
+
 func TestMultilinePrintableName(t *testing.T) {
 	ni := &NodeInfo{
 		Name:    "test1.test2::test3",

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -802,7 +802,11 @@ func (g *Graph) selectTopNodes(maxNodes int, visualMode bool) Nodes {
 			// If generating a visual graph, count tags as nodes. Update
 			// maxNodes to account for them.
 			for i, n := range g.Nodes {
-				if count += countTags(n) + 1; count >= maxNodes {
+				tags := countTags(n)
+				if tags > maxNodelets {
+					tags = maxNodelets
+				}
+				if count += tags + 1; count >= maxNodes {
 					maxNodes = i + 1
 					break
 				}


### PR DESCRIPTION
There is an issue where decreasing nodefraction (which should produce
more nodes) ended up reducing the number of displayed nodes.  This is
because we have an upper limit on number of nodes to display and the
number of node-lets counts against that limit.  This can cause a problem
if a node with large number of node-lets shows up near the front of
the list of nodes (e.g., std::allocator_traits::allocate in a heapz
profile had 102 node-lets, which caused all subsequent nodes to be
dropped).

Fixed by limiting the count of charged node-lets per node to
maxNodelets (4), which is the maximum number of node-lets we
display per node.