### PR TITLE
When pruning unsimplified names, don't trim "(anonymous namespace)".

### DIFF
--- a/profile/prune.go
+++ b/profile/prune.go
@@ -24,14 +24,13 @@ import (
 
 var (
 	reservedNames = []string{"(anonymous namespace)", "operator()"}
-	bracketRx     = rx.MustCompile("(" + strings.Replace(strings.Replace(
+	bracketRx     = regexp.MustCompile("(" + strings.Replace(strings.Replace(
 		strings.Join(append(reservedNames, "("), "|"),
 		"(", "\\(", -1), ")", "\\)", -1) + ")")
 )
 
 // simplifyFunc does some primitive simplification of function names.
 func simplifyFunc(f string) string {
-	fmt.Println(rx)
 	// Account for leading '.' on the PPC ELF v1 ABI.
 	funcName := strings.TrimPrefix(f, ".")
 	// Account for unsimplified names -- try  to remove the argument list by trimming

--- a/profile/prune.go
+++ b/profile/prune.go
@@ -41,7 +41,6 @@ func (p *Profile) Prune(dropRx, keepRx *regexp.Regexp) {
 					if !strings.HasPrefix(funcName[index:], "(anonymous namespace)") {
 						funcName = funcName[:index]
 					}
-					funcName = funcName[:index]
 				}
 				if dropRx.MatchString(funcName) {
 					if keepRx == nil || !keepRx.MatchString(funcName) {
@@ -138,7 +137,6 @@ func (p *Profile) PruneFrom(dropRx *regexp.Regexp) {
 					if !strings.HasPrefix(funcName[index:], "(anonymous namespace)") {
 						funcName = funcName[:index]
 					}
-					funcName = funcName[:index]
 				}
 				if dropRx.MatchString(funcName) {
 					// Found matching entry to prune.

--- a/profile/prune.go
+++ b/profile/prune.go
@@ -39,8 +39,8 @@ func simplifyFunc(f string) string {
 	funcName := strings.TrimPrefix(f, ".")
 	// Account for unsimplified names -- try  to remove the argument list by trimming
 	// starting from the first '(', but skipping reserved names that have '('.
-	if indeces := bracketRx.FindAllStringSubmatchIndex(funcName, -1); indeces != nil {
-		for _, ind := range indeces {
+	if indices := bracketRx.FindAllStringSubmatchIndex(funcName, -1); indices != nil {
+		for _, ind := range indices {
 			foundReserved := false
 			for _, res := range reservedNames {
 				if funcName[ind[0]:ind[1]] == res {

--- a/profile/prune.go
+++ b/profile/prune.go
@@ -37,6 +37,10 @@ func (p *Profile) Prune(dropRx, keepRx *regexp.Regexp) {
 				funcName := strings.TrimPrefix(fn.Name, ".")
 				// Account for unsimplified names -- trim starting from the first '('.
 				if index := strings.Index(funcName, "("); index > 0 {
+					// ... unless the thing in brackets is an anonymous namespace marker
+					if !strings.HasPrefix(funcName[index:], "(anonymous namespace)") {
+						funcName = funcName[:index]
+					}
 					funcName = funcName[:index]
 				}
 				if dropRx.MatchString(funcName) {
@@ -130,6 +134,10 @@ func (p *Profile) PruneFrom(dropRx *regexp.Regexp) {
 				funcName := strings.TrimPrefix(fn.Name, ".")
 				// Account for unsimplified names -- trim starting from the first '('.
 				if index := strings.Index(funcName, "("); index > 0 {
+					// ... unless the thing in brackets is an anonymous namespace marker
+					if !strings.HasPrefix(funcName[index:], "(anonymous namespace)") {
+						funcName = funcName[:index]
+					}
 					funcName = funcName[:index]
 				}
 				if dropRx.MatchString(funcName) {

--- a/profile/prune.go
+++ b/profile/prune.go
@@ -39,19 +39,18 @@ func simplifyFunc(f string) string {
 	funcName := strings.TrimPrefix(f, ".")
 	// Account for unsimplified names -- try  to remove the argument list by trimming
 	// starting from the first '(', but skipping reserved names that have '('.
-	if indices := bracketRx.FindAllStringSubmatchIndex(funcName, -1); indices != nil {
-		for _, ind := range indices {
-			foundReserved := false
-			for _, res := range reservedNames {
-				if funcName[ind[0]:ind[1]] == res {
-					foundReserved = true
-					break
-				}
-			}
-			if !foundReserved {
-				funcName = funcName[:ind[0]]
+	indices := bracketRx.FindAllStringSubmatchIndex(funcName, -1)
+	for _, ind := range indices {
+		foundReserved := false
+		for _, res := range reservedNames {
+			if funcName[ind[0]:ind[1]] == res {
+				foundReserved = true
 				break
 			}
+		}
+		if !foundReserved {
+			funcName = funcName[:ind[0]]
+			break
 		}
 	}
 	return funcName

--- a/profile/prune.go
+++ b/profile/prune.go
@@ -24,9 +24,13 @@ import (
 
 var (
 	reservedNames = []string{"(anonymous namespace)", "operator()"}
-	bracketRx     = regexp.MustCompile("(" + strings.Replace(strings.Replace(
-		strings.Join(append(reservedNames, "("), "|"),
-		"(", "\\(", -1), ")", "\\)", -1) + ")")
+	bracketRx     = func() *regexp.Regexp {
+		var quotedNames []string
+		for _, name := range append(reservedNames, "(") {
+			quotedNames = append(quotedNames, regexp.QuoteMeta(name))
+		}
+		return regexp.MustCompile(strings.Join(quotedNames, "|"))
+	}()
 )
 
 // simplifyFunc does some primitive simplification of function names.

--- a/profile/prune.go
+++ b/profile/prune.go
@@ -39,8 +39,7 @@ func simplifyFunc(f string) string {
 	funcName := strings.TrimPrefix(f, ".")
 	// Account for unsimplified names -- try  to remove the argument list by trimming
 	// starting from the first '(', but skipping reserved names that have '('.
-	indices := bracketRx.FindAllStringSubmatchIndex(funcName, -1)
-	for _, ind := range indices {
+	for _, ind := range bracketRx.FindAllStringSubmatchIndex(funcName, -1) {
 		foundReserved := false
 		for _, res := range reservedNames {
 			if funcName[ind[0]:ind[1]] == res {

--- a/profile/prune_test.go
+++ b/profile/prune_test.go
@@ -25,6 +25,7 @@ func TestPrune(t *testing.T) {
 		want string
 	}{
 		{in1, out1},
+		{in2, out2},
 	} {
 		in := test.in.Copy()
 		in.RemoveUninteresting()
@@ -50,6 +51,8 @@ var funs = []*Function{
 	{ID: 4, Name: "fun3", SystemName: "fun3", Filename: "fun.c"},
 	{ID: 5, Name: "fun4", SystemName: "fun4", Filename: "fun.c"},
 	{ID: 6, Name: "fun5", SystemName: "fun5", Filename: "fun.c"},
+	{ID: 7, Name: "unsimplified_fun(int)", SystemName: "unsimplified_fun(int)", Filename: "fun.c"},
+	{ID: 8, Name: "Foo::(anonymous namespace)::Test::Bar", SystemName: "Foo::(anonymous namespace)::Test::Bar", Filename: "fun.c"},
 }
 
 var locs1 = []*Location{
@@ -135,5 +138,65 @@ Locations
      3: 0x0 fun3 fun.c:2 s=0
              fun1 fun.c:1 s=0
      4: 0x0 fun5 fun.c:2 s=0
+Mappings
+`
+
+var locs2 = []*Location{
+	{
+		ID: 1,
+		Line: []Line{
+			{Function: funs[0], Line: 1},
+		},
+	},
+	{
+		ID: 2,
+		Line: []Line{
+			{Function: funs[6], Line: 1},
+		},
+	},
+	{
+		ID: 3,
+		Line: []Line{
+			{Function: funs[7], Line: 1},
+		},
+	},
+}
+
+var in2 = &Profile{
+	PeriodType:    &ValueType{Type: "cpu", Unit: "milliseconds"},
+	Period:        1,
+	DurationNanos: 10e9,
+	SampleType: []*ValueType{
+		{Type: "samples", Unit: "count"},
+		{Type: "cpu", Unit: "milliseconds"},
+	},
+	Sample: []*Sample{
+		{
+			Location: []*Location{locs2[1], locs2[0]},
+			Value:    []int64{1, 1},
+		},
+		{
+			Location: []*Location{locs2[2], locs2[0]},
+			Value:    []int64{1, 1},
+		},
+	},
+	Location: locs2,
+	Function: funs,
+	// Unsimplified name with parameters shouldn't match,
+	// Foo::.*::Bar should (and will be dropped) regardless of the anonymous namespace.
+	DropFrames: `unsimplified_fun\(int\)|Foo::.*::Bar`,
+}
+
+const out2 = `PeriodType: cpu milliseconds
+Period: 1
+Duration: 10s
+Samples:
+samples/count cpu/milliseconds
+          1          1: 2 1
+          1          1: 1
+Locations
+     1: 0x0 main main.c:1 s=0
+     2: 0x0 unsimplified_fun(int) fun.c:1 s=0
+     3: 0x0 Foo::(anonymous namespace)::Test::Bar fun.c:1 s=0
 Mappings
 `


### PR DESCRIPTION
Fixes #139.