### PR TITLE
Allow -http to accept host:port

### DIFF
--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -29,10 +29,10 @@ type source struct {
 	BuildID  string
 	Base     []string
 
-	Seconds   int
-	Timeout   int
-	Symbolize string
-	HTTPPort  int
+	Seconds      int
+	Timeout      int
+	Symbolize    string
+	HTTPHostPort string
 }
 
 // Parse parses the command lines through the specified flags package
@@ -59,7 +59,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 	flagTools := flag.String("tools", os.Getenv("PPROF_TOOLS"), "Path for object tool pathnames")
 
 	flagTimeout := flag.Int("timeout", -1, "Timeout in seconds for fetching a profile")
-	flagHTTPPort := flag.Int("http", 0, "Present interactive web based UI at the specified http port")
+	flagHTTP := flag.String("http", "", "Present interactive web based UI at the specified http host:port")
 
 	// Flags used during command processing
 	installedFlags := installFlags(flag)
@@ -108,7 +108,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	if cmd != nil && *flagHTTPPort != 0 {
+	if cmd != nil && *flagHTTP != "" {
 		return nil, nil, fmt.Errorf("--http is not compatible with an output format on the command line")
 	}
 
@@ -127,13 +127,13 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 	}
 
 	source := &source{
-		Sources:   args,
-		ExecName:  execName,
-		BuildID:   *flagBuildID,
-		Seconds:   *flagSeconds,
-		Timeout:   *flagTimeout,
-		Symbolize: *flagSymbolize,
-		HTTPPort:  *flagHTTPPort,
+		Sources:      args,
+		ExecName:     execName,
+		BuildID:      *flagBuildID,
+		Seconds:      *flagSeconds,
+		Timeout:      *flagTimeout,
+		Symbolize:    *flagSymbolize,
+		HTTPHostPort: *flagHTTP,
 	}
 
 	for _, s := range *flagBase {
@@ -285,7 +285,7 @@ var usageMsgSrc = "\n\n" +
 
 var usageMsgVars = "\n\n" +
 	"  Misc options:\n" +
-	"   -http port             Provide web based interface at port\n" +
+	"   -http host:port        Provide web based interface at host:port\n" +
 	"   -tools                 Search path for object tools\n" +
 	"\n" +
 	"  Environment Variables:\n" +

--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -32,7 +32,7 @@ type source struct {
 	Seconds      int
 	Timeout      int
 	Symbolize    string
-	HTTPHostPort string
+	HTTPHostport string
 }
 
 // Parse parses the command lines through the specified flags package
@@ -133,7 +133,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 		Seconds:      *flagSeconds,
 		Timeout:      *flagTimeout,
 		Symbolize:    *flagSymbolize,
-		HTTPHostPort: *flagHTTP,
+		HTTPHostport: *flagHTTP,
 	}
 
 	for _, s := range *flagBase {

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -52,8 +52,8 @@ func PProf(eo *plugin.Options) error {
 		return generateReport(p, cmd, pprofVariables, o)
 	}
 
-	if src.HTTPPort > 0 {
-		return serveWebInterface(src.HTTPPort, p, o)
+	if src.HTTPHostPort != "" {
+		return serveWebInterface(src.HTTPHostPort, p, o)
 	}
 	return interactive(p, o)
 }

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -52,8 +52,8 @@ func PProf(eo *plugin.Options) error {
 		return generateReport(p, cmd, pprofVariables, o)
 	}
 
-	if src.HTTPHostPort != "" {
-		return serveWebInterface(src.HTTPHostPort, p, o)
+	if src.HTTPHostport != "" {
+		return serveWebInterface(src.HTTPHostport, p, o)
 	}
 	return interactive(p, o)
 }

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -86,7 +86,7 @@ func serveWebInterface(hostport string, p *profile.Profile, o *plugin.Options) e
 	return s.Serve(ln)
 }
 
-func openBrowser(url string, o *plugin.Options) {
+var openBrowser = func(url string, o *plugin.Options) {
 	// Construct URL.
 	u, _ := gourl.Parse(url)
 	q := u.Query()

--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -189,22 +189,27 @@ func TestNewListenerAndURL(t *testing.T) {
 		hostport  string
 		wantErr   bool
 		wantURLRe *regexp.Regexp
+		wantLocal bool
 	}{
 		{
 			hostport:  ":",
 			wantURLRe: regexp.MustCompile(`http://localhost:\d+`),
+			wantLocal: true,
 		},
 		{
 			hostport:  "localhost:",
 			wantURLRe: regexp.MustCompile(`http://localhost:\d+`),
+			wantLocal: true,
 		},
 		{
 			hostport:  "127.0.0.1:",
 			wantURLRe: regexp.MustCompile(`http://127\.0\.0\.1:\d+`),
+			wantLocal: true,
 		},
 		{
 			hostport:  "localhost:12344",
 			wantURLRe: regexp.MustCompile(`http://localhost:12344`),
+			wantLocal: true,
 		},
 		{
 			hostport: "http://localhost:12345",
@@ -214,7 +219,7 @@ func TestNewListenerAndURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.hostport, func(t *testing.T) {
-			_, url, err := newListenerAndURL(tt.hostport)
+			_, url, isLocal, err := newListenerAndURL(tt.hostport)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("newListenerAndURL(%v) want error; got none", tt.hostport)
@@ -226,6 +231,9 @@ func TestNewListenerAndURL(t *testing.T) {
 			}
 			if !tt.wantURLRe.MatchString(url) {
 				t.Errorf("newListenerAndURL(%v) URL = %v; want URL matching %v", tt.hostport, url, tt.wantURLRe)
+			}
+			if got, want := isLocal, tt.wantLocal; got != want {
+				t.Errorf("newListenerAndURL(%v) isLocal = %v; want %v", tt.hostport, got, want)
 			}
 		})
 	}

--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -239,7 +239,7 @@ func TestServeWebInterface(t *testing.T) {
 			}
 			resp, err := http.Get(url)
 			if err != nil {
-				t.Errorf("%v: cannot GET %v: %v", tt.hostport, url, err)
+				t.Fatalf("%v: cannot GET %v: %v", tt.hostport, url, err)
 			}
 			defer resp.Body.Close()
 			if got, want := resp.StatusCode, http.StatusOK; got != want {

--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -237,6 +237,14 @@ func TestServeWebInterface(t *testing.T) {
 			if !tt.wantURLRe.MatchString(url) {
 				t.Errorf("%v: serveWebInterface() opened %v; want URL matching %v", tt.hostport, url, tt.wantURLRe)
 			}
+			resp, err := http.Get(url)
+			if err != nil {
+				t.Errorf("%v: cannot GET %v: %v", tt.hostport, url, err)
+			}
+			defer resp.Body.Close()
+			if got, want := resp.StatusCode, http.StatusOK; got != want {
+				t.Errorf("%v: got status code = %v; want %v", tt.hostport, got, want)
+			}
 		})
 	}
 }

--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -192,19 +192,19 @@ func TestNewListenerAndURL(t *testing.T) {
 	}{
 		{
 			hostport:  ":",
-			wantURLRe: regexp.MustCompile("http://localhost:\\d+"),
+			wantURLRe: regexp.MustCompile(`http://localhost:\d+`),
 		},
 		{
 			hostport:  "localhost:",
-			wantURLRe: regexp.MustCompile("http://localhost:\\d+"),
+			wantURLRe: regexp.MustCompile(`http://localhost:\d+`),
 		},
 		{
 			hostport:  "127.0.0.1:",
-			wantURLRe: regexp.MustCompile("http://127\\.0\\.0\\.1:\\d+"),
+			wantURLRe: regexp.MustCompile(`http://127\.0\.0\.1:\d+`),
 		},
 		{
 			hostport:  "localhost:12344",
-			wantURLRe: regexp.MustCompile("http://localhost:12344"),
+			wantURLRe: regexp.MustCompile(`http://localhost:12344`),
 		},
 		{
 			hostport: "http://localhost:12345",


### PR DESCRIPTION
If non-local hosts are provided, localhost-only authorization is skipped.