### PR TITLE
Avoid using $HOME when it's empty.

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -277,12 +277,18 @@ func homeEnv() string {
 }
 
 // setTmpDir prepares the directory to use to save profiles retrieved
-// remotely. It is selected from PPROF_TMPDIR, defaults to $HOME/pprof.
+// remotely. It is selected from PPROF_TMPDIR, defaults to $HOME/pprof, and, if
+// $HOME is not set, falls back to os.TempDir().
 func setTmpDir(ui plugin.UI) (string, error) {
+	var dirs []string
 	if profileDir := os.Getenv("PPROF_TMPDIR"); profileDir != "" {
-		return profileDir, nil
+		dirs = append(dirs, profileDir)
 	}
-	for _, tmpDir := range []string{os.Getenv(homeEnv()) + "/pprof", os.TempDir()} {
+	if homeDir := os.Getenv(homeEnv()); homeDir != "" {
+		dirs = append(dirs, filepath.Join(homeDir, "pprof"))
+	}
+	dirs = append(dirs, os.TempDir())
+	for _, tmpDir := range dirs {
 		if err := os.MkdirAll(tmpDir, 0755); err != nil {
 			ui.PrintErr("Could not use temp dir ", tmpDir, ": ", err.Error())
 			continue

--- a/internal/proftest/proftest.go
+++ b/internal/proftest/proftest.go
@@ -103,7 +103,11 @@ func (ui *TestUI) PrintErr(args ...interface{}) {
 		ui.Ignore--
 		return
 	}
-	ui.T.Error(args)
+	// Stringify arguments with fmt.Sprint() to match what default UI
+	// implementation does. Without this Error() calls fmt.Sprintln() which
+	// _always_ adds spaces between arguments, unlike fmt.Sprint() which only
+	// adds them between arguments if neither is string.
+	ui.T.Error(fmt.Sprint(args...))
 }
 
 // IsTerminal indicates if the UI is an interactive terminal.


### PR DESCRIPTION
Without the check, pprof may try using a path like "/pprof" when no
home environment variable is defined.

Fixes #148.