### PR TITLE
Make TestHttpsInsecure test reliably passing on Darwin.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,33 @@
 language: go
-go:
-  - 1.7.x
-  - 1.8.x
-  - master
 
 go_import_path: github.com/google/pprof
 
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - os: linux
+      go: 1.7.x
+    - os: linux
+      go: 1.8.x
+    - os: linux
+      go: master
+    - os: osx
+      osx_image: xcode6.4
+      go: 1.8.x
+    - os: osx
+      osx_image: xcode6.4
+      go: master
+    - os: osx
+      osx_image: xcode7.3
+      go: 1.8.x
+    - os: osx
+      osx_image: xcode7.3
+      go: master
+    - os: osx
+      osx_image: xcode8.3
+      go: 1.8.x
+    - os: osx
+      osx_image: xcode8.3
+      go: master
 
 before_install:
   - go get -u github.com/golang/lint/golint honnef.co/go/tools/cmd/...

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -381,7 +381,9 @@ func TestHttpsInsecure(t *testing.T) {
 	go func() {
 		deadline := time.Now().Add(5 * time.Second)
 		for time.Now().Before(deadline) {
-			// Simulate a hotspot function.
+			// Simulate a hotspot function. Spin in the inner loop for 100M iterations
+			// to ensure we get most of the samples landed here rather than in the
+			// library calls. We assume Go compiler won't elide the empty loop.
 			for i := 0; i < 1e8; i++ {
 			}
 			runtime.Gosched()


### PR DESCRIPTION
TestHttpsInsecure test runs a profiling session and checks that the
results contain expected function name. On OSX prior to 10.11 El Capitan
the SIGPROF signal is delivered to the process rather than to the thread
which skews the results enough for the test to fail.

Relax the check when running on OSX and other operating systems known to
have issues with the profiling signal (the list is taken from
src/runtime/pprof/pprof_test.go in Go source).

Also add the multiple variants of OSX to the continuous testing.

Fixes #146 and fixes #156.