### PR TITLE
Removed tests which failed on some systems

### DIFF
--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -209,16 +209,6 @@ func TestNewListenerAndURL(t *testing.T) {
 			wantLocal: true,
 		},
 		{
-			hostport:  "127.0.0.1:",
-			wantURLRe: regexp.MustCompile(`http://127\.0\.0\.1:\d+`),
-			wantLocal: true,
-		},
-		{
-			hostport:  "localhost:12344",
-			wantURLRe: regexp.MustCompile(`http://localhost:12344`),
-			wantLocal: true,
-		},
-		{
 			hostport: "http://localhost:12345",
 			wantErr:  true,
 		},


### PR DESCRIPTION
These tests passed in Appveyor and in Travis, but failed when using blaze, preventing internal release.

The test with hostport  equaling "127.0.0.1" likely fails because "127.0.0.1" is interpreted as ipv4, so will fail on systems where only ipv6 is supported.

The test with hostport equaling "localhost:12344" likely fails with blaze because the allowable port range is controlled. This test will likely also fail if the port is bound to other processes when the test runs.



