### PR TITLE
Fix unexpected webui permission error on an IPv6 configured machine

### DIFF
--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -105,7 +105,7 @@ func newListenerAndURL(hostport string) (ln net.Listener, url string, isLocal bo
 }
 
 func isLocalhost(host string) bool {
-	for _, v := range []string{"localhost", "127.0.0.1", "[::1]"} {
+	for _, v := range []string{"localhost", "127.0.0.1", "[::1]", "::1"} {
 		if host == v {
 			return true
 		}

--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -17,6 +17,7 @@ package driver
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -233,5 +234,18 @@ func TestNewListenerAndURL(t *testing.T) {
 				t.Errorf("newListenerAndURL(%v) isLocal = %v; want %v", tt.hostport, got, want)
 			}
 		})
+	}
+}
+
+func TestIsLocalHost(t *testing.T) {
+	for _, s := range []string{"localhost:10000", "[::1]:10000", "127.0.0.1:10000"} {
+		host, _, err := net.SplitHostPort(s)
+		if err != nil {
+			t.Error("unexpected error when splitting", s)
+			continue
+		}
+		if !isLocalhost(host) {
+			t.Errorf("host %s from %s not considered local", host, s)
+		}
 	}
 }


### PR DESCRIPTION
When net.SplitHostPort is called, it will return the string "::1",
but the code was only checking for "[::1]".

Fixes #174.