### PR TITLE
Update docs to reflect the changes for the -http flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ Type 'help' for available commands/options.
 
 ## Run pprof via a web interface
 
-If the `-http=port` option is specified, pprof starts a web server at
-the specified port that provides an interactive web-based interface to pprof.
+If the `-http="host:port"` option is specified, pprof starts a web server at
+the specified host:port that provides an interactive web-based interface to pprof.
 
 ```
-pprof -http=[port] [main_binary] profile.pb.gz
+pprof -http=[host:port] [main_binary] profile.pb.gz
 ```
 
 The preceding command should automatically open your web browser at

--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -265,10 +265,10 @@ to generate various views of a profile
    pprof [options] [binary] <source> ...
 
 Omit the format and provide the "-http" flag to get an interactive web
-interface at the specified port that can be used to navigate through
+interface at the specified host:port that can be used to navigate through
 various views of a profile.
 
-   pprof -http <port> [options] [binary] <source> ...
+   pprof -http <host:port> [options] [binary] <source> ...
 
 Details:
 `


### PR DESCRIPTION
Docs are stale, -http flag now supports host:port.