### PR TITLE
profile: FilterSamplesByName returns the correct hnm

### DIFF
--- a/profile/filter.go
+++ b/profile/filter.go
@@ -41,10 +41,11 @@ func (p *Profile) FilterSamplesByName(focus, ignore, hide, show *regexp.Regexp) 
 			}
 		}
 		if show != nil {
-			hnm = true
 			l.Line = l.matchedLines(show)
 			if len(l.Line) == 0 {
 				hidden[l.ID] = true
+			} else {
+				hnm = true
 			}
 		}
 	}

--- a/profile/profile_test.go
+++ b/profile/profile_test.go
@@ -591,10 +591,31 @@ func TestFilter(t *testing.T) {
 	}
 
 	for tx, tc := range []filterTestcase{
-		{nil, nil, nil, nil, true, false, false, false},
-		{regexp.MustCompile("notfound"), nil, nil, nil, false, false, false, false},
-		{nil, regexp.MustCompile("foo.c"), nil, nil, true, true, false, false},
-		{nil, nil, regexp.MustCompile("lib.so"), nil, true, false, true, false},
+		{
+			fm: true, // nil focus matches every sample
+		},
+		{
+			focus: regexp.MustCompile("notfound"),
+		},
+		{
+			ignore: regexp.MustCompile("foo.c"),
+			fm:     true,
+			im:     true,
+		},
+		{
+			hide: regexp.MustCompile("lib.so"),
+			fm:   true,
+			hm:   true,
+		},
+		{
+			show: regexp.MustCompile("foo.c"),
+			fm:   true,
+			hnm:  true,
+		},
+		{
+			show: regexp.MustCompile("notfound"),
+			fm:   true,
+		},
 	} {
 		prof := *testProfile1.Copy()
 		gf, gi, gh, gnh := prof.FilterSamplesByName(tc.focus, tc.ignore, tc.hide, tc.show)


### PR DESCRIPTION
FilterSamplesByName should return true for hnm only when
"at least one sample" matched the show regexp.
Before this commit it always returned true
if the show regexp is not nil and p.Location is not empty.