### PR TITLE
Extend web UI to contain a tabular "top" display

### DIFF
--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -195,7 +195,6 @@ Functions
 </div>
 </div>
 
-{{if (eq .Type "dot")}}
 <div class="menu-header">
 Refine
 <div class="menu">
@@ -205,7 +204,6 @@ Refine
 <button title="{{.Help.show}}" id="show">Show</button>
 </div>
 </div>
-{{end}}
 
 <input id="searchbox" type="text" placeholder="Search regexp" autocomplete="off" autocapitalize="none" size=40>
 
@@ -234,7 +232,7 @@ Refine
 
 </div>
 {{template "script" .}}
-<script>viewer({{.Nodes}})</script>
+<script>viewer({{.BaseURL}}, {{.Nodes}})</script>
 </body>
 </html>
 {{end}}
@@ -457,7 +455,7 @@ function initPanAndZoom(svg, clickHandler) {
   svg.addEventListener("wheel", handleWheel, true)
 }
 
-function viewer(nodes) {
+function viewer(baseUrl, nodes) {
   'use strict';
 
   // Elements
@@ -482,16 +480,16 @@ function viewer(nodes) {
     if (detailsText != null) detailsText.style.display = "none"
   }
 
-  function handleReset() { window.location.href = "/" }
+  function handleReset() { window.location.href = baseUrl }
   function handleTop() { navigate("/top", "f", false) }
   function handleGraph() { navigate("/", "f", false) }
   function handleList() { navigate("/weblist", "f", true) }
   function handleDisasm() { navigate("/disasm", "f", true) }
   function handlePeek() { navigate("/peek", "f", true) }
-  function handleFocus() { navigate("/", "f", false) }
-  function handleShow() { navigate("/", "s", false) }
-  function handleIgnore() { navigate("/", "i", false) }
-  function handleHide() { navigate("/", "h", false) }
+  function handleFocus() { navigate(baseUrl, "f", false) }
+  function handleShow() { navigate(baseUrl, "s", false) }
+  function handleIgnore() { navigate(baseUrl, "i", false) }
+  function handleHide() { navigate(baseUrl, "h", false) }
 
   function handleKey(e) {
     if (e.keyCode != 13) return
@@ -760,7 +758,7 @@ function viewer(nodes) {
 </div>
 
 {{template "script" .}}
-<script>viewer({{.Nodes}})</script>
+<script>viewer({{.BaseURL}}, {{.Nodes}})</script>
 </body>
 </html>
 {{end}}

--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -144,9 +144,8 @@ button {
   text-align: right;
   padding-left: 1em;
 }
-#toptable tr th:nth-child(6) {
-  text-align: left;
-}
+#toptable tr th:nth-child(6) { text-align: left; }
+#toptable tr th:nth-child(7) { text-align: left; }
 #toptable tr td {
   padding-left: 1em;
   font: monospace;
@@ -154,9 +153,8 @@ button {
   white-space: nowrap;
   cursor: default;
 }
-#toptable tr td:nth-child(6) {
-  text-align: left;
-}
+#toptable tr td:nth-child(6) { text-align: left; }
+#toptable tr td:nth-child(7) { text-align: left; }
 .hilite {
   background-color: #ccf;
 }
@@ -182,7 +180,6 @@ View
 {{end}}
 <hr>
 <button title="{{.Help.details}}" id="details">Details</button>
-<button title="{{.Help.reset}}" id="reset">Reset</button>
 </div>
 </div>
 
@@ -202,6 +199,8 @@ Refine
 <button title="{{.Help.ignore}}" id="ignore">Ignore</button>
 <button title="{{.Help.hide}}" id="hide">Hide</button>
 <button title="{{.Help.show}}" id="show">Show</button>
+<hr>
+<button title="{{.Help.reset}}" id="reset">Reset</button>
 </div>
 </div>
 
@@ -586,11 +585,7 @@ function viewer(baseUrl, nodes) {
   function setBackground(elem, set) {
     // Handle table row highlighting.
     if (elem.nodeName == "TR") {
-      if (set) {
-        elem.classList.add("hilite")
-      } else {
-        elem.classList.remove("hilite")
-      }
+      elem.classList.toggle("hilite", set)
       return
     }
 
@@ -617,7 +612,7 @@ function viewer(baseUrl, nodes) {
 
   // convert a string to a regexp that matches that string.
   function quotemeta(str) {
-    return str.replace(/([\\\.?+*\[\](){}])/g, '\\$1')
+    return str.replace(/([\\\.?+*\[\](){}|^$])/g, '\\$1')
   }
 
   // Navigate to specified path with current selection reflected
@@ -662,8 +657,7 @@ function viewer(baseUrl, nodes) {
     while (elem != null && elem.nodeName != "TR") {
       elem = elem.parentElement
     }
-    if (elem == null) return
-    if (elem.children.length != 6) return
+    if (elem == null || elem.children.length < 6) return
 
     e.preventDefault()
     const tr = elem
@@ -750,9 +744,9 @@ function viewer(baseUrl, nodes) {
 
 <div id="topcontainer">
 <table id="toptable">
-<tr><th>Flat<th>Flat%<th>Sum%<th>Cum<th>Cum%<th>Name</tr>
+<tr><th>Flat<th>Flat%<th>Sum%<th>Cum<th>Cum%<th>Name<th>Inlined?</tr>
 {{range $i,$e := .Top}}
-  <tr id="node{{$i}}"><td>{{$e.Flat}}<td>{{$e.FlatPercent}}<td>{{$e.SumPercent}}<td>{{$e.Cum}}<td>{{$e.CumPercent}}<td>{{$e.Name}}</tr>
+  <tr id="node{{$i}}"><td>{{$e.Flat}}<td>{{$e.FlatPercent}}<td>{{$e.SumPercent}}<td>{{$e.Cum}}<td>{{$e.CumPercent}}<td>{{$e.Name}}<td>{{$e.InlineLabel}}</tr>
 {{end}}
 </table>
 </div>

--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -49,52 +49,73 @@ button {
   margin-top: 5px;
   margin-bottom: 5px;
 }
-#reset {
-  margin-left: 10px;
-}
 #detailtext {
   display: none;
-  position: absolute;
+  position: fixed;
+  top: 20px;
+  right: 10px;
   background-color: #ffffff;
   min-width: 160px;
-  border-top: 1px solid black;
-  box-shadow: 2px 2px 2px 0px #aaa;
+  border: 1px solid #888;
+  box-shadow: 4px 4px 4px 0px rgba(0,0,0,0.2);
   z-index: 1;
 }
-#actionbox {
-  display: none;
-  position: fixed;
-  background-color: #ffffff;
-  border: 1px solid black;
-  box-shadow: 2px 2px 2px 0px #aaa;
-  top: 20px;
-  right: 20px;
-  z-index: 1;
+#closedetails {
+  display: inline;
+  float: right;
+  margin: 2px;
 }
-.actionhdr {
-  background-color: #ddd;
+#home {
+  font-size: 14pt;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  float: right;
+}
+.menubar {
+  display: inline-block;
+  background-color: #f8f8f8;
+  border: 1px solid #ccc;
   width: 100%;
-  border-bottom: 1px solid black;
-  border-top: 1px solid black;
+}
+.menu-header {
+  position: relative;
+  display: inline-block;
+  padding: 2px 2px;
+  cursor: default;
   font-size: 14pt;
 }
-#actionbox > button {
+.menu {
+  display: none;
+  position: absolute;
+  background-color: #f8f8f8;
+  border: 1px solid #888;
+  box-shadow: 4px 4px 4px 0px rgba(0,0,0,0.2);
+  z-index: 1;
+  margin-top: 2px;
+  left: 0px;
+  min-width: 5em;
+}
+.menu button {
   display: block;
   width: 100%;
   margin: 0px;
   text-align: left;
-  padding-left: 0.5em;
+  padding-left: 2px;
   background-color: #fff;
-  border: none;
   font-size: 12pt;
+  border: none;
 }
-#actionbox > button:hover {
-  background-color: #ddd;
+.menu-header:hover {
+  background-color: #ccc;
 }
-#home {
-  font-size: 20pt;
-  padding-left: 0.5em;
-  padding-right: 0.5em;
+.menu-header:hover .menu {
+  display: block;
+}
+.menu button:hover {
+  background-color: #ccc;
+}
+#searchbox {
+  margin-left: 10pt;
 }
 </style>
 {{end}}
@@ -109,34 +130,51 @@ button {
 </head>
 <body>
 
-<button id="details">&#x25b7; Details</button>
 <div id="detailtext">
+<button id="closedetails">Close</button>
 {{range .Legend}}<div>{{.}}</div>{{end}}
 </div>
 
-<button id="reset">Reset</button>
+<div class="menubar">
+
+<div class="menu-header">
+View
+<div class="menu">
+<button title="{{.Help.details}}" id="details">Details</button>
+<button title="{{.Help.reset}}" id="reset">Reset</button>
+</div>
+</div>
+
+<div class="menu-header">
+Functions
+<div class="menu">
+<button title="{{.Help.peek}}" id="peek">Peek</button>
+<button title="{{.Help.list}}" id="list">List</button>
+<button title="{{.Help.disasm}}" id="disasm">Disassemble</button>
+</div>
+</div>
+
+<div class="menu-header">
+Refine
+<div class="menu">
+<button title="{{.Help.focus}}" id="focus">Focus</button>
+<button title="{{.Help.ignore}}" id="ignore">Ignore</button>
+<button title="{{.Help.hide}}" id="hide">Hide</button>
+<button title="{{.Help.show}}" id="show">Show</button>
+</div>
+</div>
+
+<input id="searchbox" type="text" placeholder="Search regexp" autocomplete="off" autocapitalize="none" size=40>
 
 <span id="home">{{.Title}}</span>
 
-<input id="searchbox" type="text" placeholder="Search regexp" autocomplete="off" autocapitalize="none" size=40>
+</div>
 
 <div id="page">
 
 <div id="errors">{{range .Errors}}<div>{{.}}</div>{{end}}</div>
 
 <div id="graph">
-
-<div id="actionbox">
-<div class="actionhdr">Refine graph</div>
-<button title="{{.Help.focus}}" id="focus">Focus</button>
-<button title="{{.Help.ignore}}" id="ignore">Ignore</button>
-<button title="{{.Help.hide}}" id="hide">Hide</button>
-<button title="{{.Help.show}}" id="show">Show</button>
-<div class="actionhdr">Show Functions</div>
-<button title="{{.Help.peek}}" id="peek">Peek</button>
-<button title="{{.Help.list}}" id="list">List</button>
-<button title="{{.Help.disasm}}" id="disasm">Disassemble</button>
-</div>
 
 {{.Svg}}
 </div>
@@ -369,17 +407,6 @@ function dotviewer(nodes) {
   'use strict';
 
   // Elements
-  const detailsButton = document.getElementById("details")
-  const detailsText = document.getElementById("detailtext")
-  const actionBox = document.getElementById("actionbox")
-  const listButton = document.getElementById("list")
-  const disasmButton = document.getElementById("disasm")
-  const resetButton = document.getElementById("reset")
-  const peekButton = document.getElementById("peek")
-  const focusButton = document.getElementById("focus")
-  const showButton = document.getElementById("show")
-  const ignoreButton = document.getElementById("ignore")
-  const hideButton = document.getElementById("hide")
   const search = document.getElementById("searchbox")
   const graph0 = document.getElementById("graph0")
   const svg = graph0.parentElement
@@ -391,13 +418,13 @@ function dotviewer(nodes) {
   let buttonsEnabled = true
 
   function handleDetails() {
-    if (detailtext.style.display == "block") {
-      detailtext.style.display = "none"
-      detailsButton.innerText = "\u25b7 Details"
-    } else {
-      detailtext.style.display = "block"
-      detailsButton.innerText = "\u25bd Details"
-    }
+    const detailsText = document.getElementById("detailtext")
+    if (detailsText != null) detailsText.style.display = "block"
+  }
+
+  function handleCloseDetails() {
+    const detailsText = document.getElementById("detailtext")
+    if (detailsText != null) detailsText.style.display = "none"
   }
 
   function handleReset() { window.location.href = "/" }
@@ -562,7 +589,12 @@ function dotviewer(nodes) {
     const enable = (search.value != "" || selected.size != 0)
     if (buttonsEnabled == enable) return
     buttonsEnabled = enable
-    actionBox.style.display = enable ? "block" : "none"
+    for (const id of ["peek", "list", "disasm", "focus", "ignore", "hide", "show"]) {
+      const btn = document.getElementById(id)
+      if (btn != null) {
+        btn.disabled = !enable
+      }
+    }
   }
 
   // Initialize button states
@@ -570,20 +602,27 @@ function dotviewer(nodes) {
 
   // Setup event handlers
   initPanAndZoom(svg, toggleSelect)
-  
-  function bindButtons(evt) {
-    detailsButton.addEventListener(evt, handleDetails)
-    resetButton.addEventListener(evt, handleReset)
-    listButton.addEventListener(evt, handleList)
-    disasmButton.addEventListener(evt, handleDisasm)
-    peekButton.addEventListener(evt, handlePeek)
-    focusButton.addEventListener(evt, handleFocus)
-    showButton.addEventListener(evt, handleShow)
-    ignoreButton.addEventListener(evt, handleIgnore)
-    hideButton.addEventListener(evt, handleHide)
+
+  // Bind action to button with specified id.
+  function addAction(id, action) {
+    const btn = document.getElementById(id)
+    if (btn != null) {
+      btn.addEventListener("click", action)
+      btn.addEventListener("touchstart", action)
+    }
   }
-  bindButtons("click")
-  bindButtons("touchstart")
+
+  addAction("details", handleDetails)
+  addAction("closedetails", handleCloseDetails)
+  addAction("reset", handleReset)
+  addAction("peek", handlePeek)
+  addAction("list", handleList)
+  addAction("disasm", handleDisasm)
+  addAction("focus", handleFocus)
+  addAction("ignore", handleIgnore)
+  addAction("hide", handleHide)
+  addAction("show", handleShow)
+
   search.addEventListener("input", handleSearch)
   search.addEventListener("keydown", handleKey)
 }

--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -69,7 +69,6 @@ button {
   z-index: 1;
 }
 #closedetails {
-  display: inline;
   float: right;
   margin: 2px;
 }

--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -16,12 +16,8 @@ package driver
 
 import "html/template"
 
-var graphTemplate = template.Must(template.New("graph").Parse(
-	`<!DOCTYPE html>
-<html>
-<head>
-<meta charset="utf-8">
-<title>{{.Title}}</title>
+var webTemplate = template.Must(template.New("web").Parse(`
+{{define "css"}}
 <style type="text/css">
 html, body {
   height: 100%;
@@ -101,6 +97,15 @@ button {
   padding-right: 0.5em;
 }
 </style>
+{{end}}
+
+{{define "graph" -}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{.Title}}</title>
+{{template "css" .}}
 </head>
 <body>
 
@@ -137,6 +142,12 @@ button {
 </div>
 
 </div>
+{{template "graphjs" .}}
+</body>
+</html>
+{{end}}
+
+{{define "graphjs"}}
 <script>
 // Make svg pannable and zoomable.
 // Call clickHandler(t) if a click event is caught by the pan event handlers.
@@ -579,6 +590,5 @@ function dotviewer(nodes) {
 
 dotviewer({{.Nodes}})
 </script>
-</body>
-</html>
+{{end}}
 `))

--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -753,8 +753,15 @@ function viewer(nodes) {
 <div id="topcontainer">
 <table id="toptable">
 <tr><th>Flat<th>Flat%<th>Sum%<th>Cum<th>Cum%<th>Name</tr>
-{{range .Top}}
-<tr><td>{{.Flat}}<td>{{.FlatPercent}}<td>{{.SumPercent}}<td>{{.Cum}}<td>{{.CumPercent}}<td>{{.Name}}</tr>
+{{range $i,$e := .Top}}
+  <tr id="node{{$i}}">
+  <td>{{$e.Flat}}
+  <td>{{$e.FlatPercent}}
+  <td>{{$e.SumPercent}}
+  <td>{{$e.Cum}}
+  <td>{{$e.CumPercent}}
+  <td>{{$e.Name}}
+  </tr>
 {{end}}
 </table>
 </div>

--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -754,14 +754,7 @@ function viewer(nodes) {
 <table id="toptable">
 <tr><th>Flat<th>Flat%<th>Sum%<th>Cum<th>Cum%<th>Name</tr>
 {{range $i,$e := .Top}}
-  <tr id="node{{$i}}">
-  <td>{{$e.Flat}}
-  <td>{{$e.FlatPercent}}
-  <td>{{$e.SumPercent}}
-  <td>{{$e.Cum}}
-  <td>{{$e.CumPercent}}
-  <td>{{$e.Name}}
-  </tr>
+  <tr id="node{{$i}}"><td>{{$e.Flat}}<td>{{$e.FlatPercent}}<td>{{$e.SumPercent}}<td>{{$e.Cum}}<td>{{$e.CumPercent}}<td>{{$e.Name}}</tr>
 {{end}}
 </table>
 </div>

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -283,7 +283,7 @@ func (ui *webInterface) top(w http.ResponseWriter, req *http.Request) {
 	top, legend := report.TextItems(rpt)
 
 	// Get regular expression for each item.
-	nodes := []string{""}
+	var nodes []string
 	for _, item := range top {
 		nodes = append(nodes, item.Name)
 	}

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -24,7 +24,6 @@ import (
 	gourl "net/url"
 	"os"
 	"os/exec"
-	"regexp"
 	"strings"
 	"time"
 
@@ -52,6 +51,7 @@ func (ec *errorCatcher) PrintErr(args ...interface{}) {
 	ec.UI.PrintErr(args...)
 }
 
+// webArgs contains arguments passed to templates in webhtml.go.
 type webArgs struct {
 	Type   string
 	Title  string
@@ -115,7 +115,7 @@ func newListenerAndURL(hostport string) (ln net.Listener, url string, isLocal bo
 	if ln, err = net.Listen("tcp", hostport); err != nil {
 		return nil, "", false, err
 	}
-	url = fmt.Sprint("http://", net.JoinHostPort(host, fmt.Sprint(ln.Addr().(*net.TCPAddr).Port)))
+	url = fmt.Sprint("http://", net.JoinHostPort(host, fmt.Sprint(ln.Addr().(*net.TCPAddr).Port)), "/top")
 	return ln, url, isLocalhost(host), nil
 }
 
@@ -216,7 +216,7 @@ func (ui *webInterface) dot(w http.ResponseWriter, req *http.Request) {
 	// Get regular expression for each node.
 	nodes := []string{""}
 	for _, n := range g.Nodes {
-		nodes = append(nodes, regexp.QuoteMeta(n.Info.Name))
+		nodes = append(nodes, n.Info.Name)
 	}
 
 	// Embed in html.
@@ -285,7 +285,7 @@ func (ui *webInterface) top(w http.ResponseWriter, req *http.Request) {
 	// Get regular expression for each item.
 	nodes := []string{""}
 	for _, item := range top {
-		nodes = append(nodes, regexp.QuoteMeta(item.Name))
+		nodes = append(nodes, item.Name)
 	}
 
 	// Embed in html.

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -65,6 +65,9 @@ func serveWebInterface(hostport string, p *profile.Profile, o *plugin.Options) e
 	for n, v := range pprofVariables {
 		ui.help[n] = v.help
 	}
+	ui.help["details"] = "Show information about the profile and this view"
+	ui.help["graph"] = "Display profile as a directed graph"
+	ui.help["reset"] = "Show the entire profile"
 
 	ln, url, isLocal, err := newListenerAndURL(hostport)
 	if err != nil {

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -53,14 +53,15 @@ func (ec *errorCatcher) PrintErr(args ...interface{}) {
 
 // webArgs contains arguments passed to templates in webhtml.go.
 type webArgs struct {
-	Type   string
-	Title  string
-	Errors []string
-	Legend []string
-	Help   map[string]string
-	Nodes  []string
-	Svg    template.HTML
-	Top    []report.TextItem
+	BaseURL string
+	Type    string
+	Title   string
+	Errors  []string
+	Legend  []string
+	Help    map[string]string
+	Nodes   []string
+	Svg     template.HTML
+	Top     []report.TextItem
 }
 
 func serveWebInterface(hostport string, p *profile.Profile, o *plugin.Options) error {
@@ -228,13 +229,14 @@ func (ui *webInterface) dot(w http.ResponseWriter, req *http.Request) {
 	file := getFromLegend(legend, "File: ", "unknown")
 	profile := getFromLegend(legend, "Type: ", "unknown")
 	data := webArgs{
-		Type:   "dot",
-		Title:  file + " " + profile,
-		Errors: catcher.errors,
-		Svg:    template.HTML(string(svg)),
-		Legend: legend,
-		Nodes:  nodes,
-		Help:   ui.help,
+		BaseURL: "/",
+		Type:    "dot",
+		Title:   file + " " + profile,
+		Errors:  catcher.errors,
+		Svg:     template.HTML(string(svg)),
+		Legend:  legend,
+		Nodes:   nodes,
+		Help:    ui.help,
 	}
 	html := &bytes.Buffer{}
 	if err := webTemplate.ExecuteTemplate(html, "graph", data); err != nil {
@@ -293,13 +295,14 @@ func (ui *webInterface) top(w http.ResponseWriter, req *http.Request) {
 	file := getFromLegend(legend, "File: ", "unknown")
 	profile := getFromLegend(legend, "Type: ", "unknown")
 	data := webArgs{
-		Type:   "top",
-		Title:  file + " " + profile,
-		Errors: catcher.errors,
-		Legend: legend,
-		Help:   ui.help,
-		Top:    top,
-		Nodes:  nodes,
+		BaseURL: "/top",
+		Type:    "top",
+		Title:   file + " " + profile,
+		Errors:  catcher.errors,
+		Legend:  legend,
+		Help:    ui.help,
+		Top:     top,
+		Nodes:   nodes,
 	}
 	html := &bytes.Buffer{}
 	if err := webTemplate.ExecuteTemplate(html, "top", data); err != nil {

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -115,7 +115,7 @@ func newListenerAndURL(hostport string) (ln net.Listener, url string, isLocal bo
 	if ln, err = net.Listen("tcp", hostport); err != nil {
 		return nil, "", false, err
 	}
-	url = fmt.Sprint("http://", net.JoinHostPort(host, fmt.Sprint(ln.Addr().(*net.TCPAddr).Port)), "/top")
+	url = fmt.Sprint("http://", net.JoinHostPort(host, fmt.Sprint(ln.Addr().(*net.TCPAddr).Port)))
 	return ln, url, isLocalhost(host), nil
 }
 

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -275,7 +275,7 @@ func (ui *webInterface) top(w http.ResponseWriter, req *http.Request) {
 	// Generate top report
 	args := []string{"top"}
 	vars := varsFromURL(req.URL)
-	vars["nodecount"].value = "50"
+	vars["nodecount"].value = "500"
 	_, rpt, err := generateRawReport(ui.prof, args, vars, &options)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -223,7 +223,7 @@ func (ui *webInterface) dot(w http.ResponseWriter, req *http.Request) {
 		Help:   ui.help,
 	}
 	html := &bytes.Buffer{}
-	if err := graphTemplate.Execute(html, data); err != nil {
+	if err := webTemplate.ExecuteTemplate(html, "graph", data); err != nil {
 		http.Error(w, "internal template error", http.StatusInternalServerError)
 		ui.options.UI.PrintErr(err)
 		return

--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -43,6 +43,8 @@ func TestWebInterface(t *testing.T) {
 			switch r.URL.Path {
 			case "/":
 				ui.dot(w, r)
+			case "/top":
+				ui.top(w, r)
 			case "/disasm":
 				ui.disasm(w, r)
 			case "/peek":
@@ -65,6 +67,7 @@ func TestWebInterface(t *testing.T) {
 	}
 	testcases := []testCase{
 		{"/", []string{"F1", "F2", "F3", "testbin", "cpu"}, true},
+		{"/top", []string{"Flat", "200ms.*100%.*F2"}, false},
 		{"/weblist?f=" + url.QueryEscape("F[12]"),
 			[]string{"F1", "F2", "300ms line1"}, false},
 		{"/peek?f=" + url.QueryEscape("F[12]"),

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -683,16 +683,22 @@ func printComments(w io.Writer, rpt *Report) error {
 	return nil
 }
 
-// printText prints a flat text report for a profile.
-func printText(w io.Writer, rpt *Report) error {
+// TextItem holds a single text report entry.
+type TextItem struct {
+	Name              string
+	Flat, FlatPercent string
+	SumPercent        string
+	Cum, CumPercent   string
+}
+
+// TextItems returns a list of text items from the report and a list
+// of labels that describe the report.
+func TextItems(rpt *Report) ([]TextItem, []string) {
 	g, origCount, droppedNodes, _ := rpt.newTrimmedGraph()
 	rpt.selectOutputUnit(g)
+	labels := reportLabels(rpt, g, origCount, droppedNodes, 0, false)
 
-	fmt.Fprintln(w, strings.Join(reportLabels(rpt, g, origCount, droppedNodes, 0, false), "\n"))
-
-	fmt.Fprintf(w, "%10s %5s%% %5s%% %10s %5s%%\n",
-		"flat", "flat", "sum", "cum", "cum")
-
+	var items []TextItem
 	var flatSum int64
 	for _, n := range g.Nodes {
 		name, flat, cum := n.Info.PrintableName(), n.FlatValue(), n.CumValue()
@@ -715,13 +721,30 @@ func printText(w io.Writer, rpt *Report) error {
 		}
 
 		flatSum += flat
+		items = append(items, TextItem{
+			Name:        name,
+			Flat:        rpt.formatValue(flat),
+			FlatPercent: percentage(flat, rpt.total),
+			SumPercent:  percentage(flatSum, rpt.total),
+			Cum:         rpt.formatValue(cum),
+			CumPercent:  percentage(cum, rpt.total),
+		})
+	}
+	return items, labels
+}
+
+// printText prints a flat text report for a profile.
+func printText(w io.Writer, rpt *Report) error {
+	items, labels := TextItems(rpt)
+	fmt.Fprintln(w, strings.Join(labels, "\n"))
+	fmt.Fprintf(w, "%10s %5s%% %5s%% %10s %5s%%\n",
+		"flat", "flat", "sum", "cum", "cum")
+	for _, item := range items {
 		fmt.Fprintf(w, "%10s %s %s %10s %s  %s\n",
-			rpt.formatValue(flat),
-			percentage(flat, rpt.total),
-			percentage(flatSum, rpt.total),
-			rpt.formatValue(cum),
-			percentage(cum, rpt.total),
-			name)
+			item.Flat, item.FlatPercent,
+			item.SumPercent,
+			item.Cum, item.CumPercent,
+			item.Name)
 	}
 	return nil
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -686,6 +686,7 @@ func printComments(w io.Writer, rpt *Report) error {
 // TextItem holds a single text report entry.
 type TextItem struct {
 	Name              string
+	InlineLabel       string // Not empty if inlined
 	Flat, FlatPercent string
 	SumPercent        string
 	Cum, CumPercent   string
@@ -712,17 +713,19 @@ func TextItems(rpt *Report) ([]TextItem, []string) {
 			}
 		}
 
+		var inl string
 		if inline {
 			if noinline {
-				name = name + " (partial-inline)"
+				inl = "(partial-inline)"
 			} else {
-				name = name + " (inline)"
+				inl = "(inline)"
 			}
 		}
 
 		flatSum += flat
 		items = append(items, TextItem{
 			Name:        name,
+			InlineLabel: inl,
 			Flat:        rpt.formatValue(flat),
 			FlatPercent: percentage(flat, rpt.total),
 			SumPercent:  percentage(flatSum, rpt.total),
@@ -740,11 +743,15 @@ func printText(w io.Writer, rpt *Report) error {
 	fmt.Fprintf(w, "%10s %5s%% %5s%% %10s %5s%%\n",
 		"flat", "flat", "sum", "cum", "cum")
 	for _, item := range items {
-		fmt.Fprintf(w, "%10s %s %s %10s %s  %s\n",
+		inl := item.InlineLabel
+		if inl != "" {
+			inl = " " + inl
+		}
+		fmt.Fprintf(w, "%10s %s %s %10s %s  %s%s\n",
 			item.Flat, item.FlatPercent,
 			item.SumPercent,
 			item.Cum, item.CumPercent,
-			item.Name)
+			item.Name, inl)
 	}
 	return nil
 }


### PR DESCRIPTION
Details:

* New /top URL that generates a tabular display.
* Split-up template into reusable templates (shared by / and /top).
* Sanitized web page header to contain a single menubar.
* Fixed bug in javascript node name handling (names were regexp-quoted, but were being treated as plain strings).

Attached zip file contains sample output.
[sample.zip](https://github.com/google/pprof/files/1236737/sample.zip)
