### PR TITLE
Fix segfault in webui when there is no authorization wrapper

### DIFF
--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -73,9 +73,13 @@ func serveWebInterface(hostport string, p *profile.Profile, o *plugin.Options) e
 
 	// authorization wrapper
 	wrap := o.HTTPWrapper
-	if wrap == nil && isLocal {
-		// Only allow requests from local host.
-		wrap = checkLocalHost
+	if wrap == nil {
+		if isLocal {
+			// Only allow requests from local host.
+			wrap = checkLocalHost
+		} else {
+			wrap = func(h http.Handler) http.Handler { return h }
+		}
 	}
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
When wrap is nil but isLocal is false, we segfault when we attempt to wrap mux handlers.