### PR TITLE
Stop treating -symbolize=force as the default

### DIFF
--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -472,7 +472,7 @@ func testFetchSymbols(source, post string) ([]byte, error) {
 type testSymbolzSymbolizer struct{}
 
 func (testSymbolzSymbolizer) Symbolize(variables string, sources plugin.MappingSources, p *profile.Profile) error {
-	return symbolz.Symbolize(sources, testFetchSymbols, p, nil)
+	return symbolz.Symbolize(p, false, sources, testFetchSymbols, nil)
 }
 
 func fakeDemangler(name string) string {

--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -42,20 +42,23 @@ type Symbolizer struct {
 // test taps for dependency injection
 var symbolzSymbolize = symbolz.Symbolize
 var localSymbolize = doLocalSymbolize
+var demangleFunction = Demangle
 
 // Symbolize attempts to symbolize profile p. First uses binutils on
 // local binaries; if the source is a URL it attempts to get any
 // missed entries using symbolz.
 func (s *Symbolizer) Symbolize(mode string, sources plugin.MappingSources, p *profile.Profile) error {
-	remote, local, force, demanglerMode := true, true, false, ""
+	remote, local, fast, force, demanglerMode := true, true, false, false, ""
 	for _, o := range strings.Split(strings.ToLower(mode), ":") {
 		switch o {
 		case "":
 			continue
 		case "none", "no":
 			return nil
-		case "local", "fastlocal":
+		case "local":
 			remote, local = false, true
+		case "fastlocal":
+			remote, local, fast = false, true, true
 		case "remote":
 			remote, local = true, false
 		case "force":
@@ -77,7 +80,7 @@ func (s *Symbolizer) Symbolize(mode string, sources plugin.MappingSources, p *pr
 	var err error
 	if local {
 		// Symbolize locally using binutils.
-		if err = localSymbolize(mode, p, s.Obj, s.UI); err != nil {
+		if err = localSymbolize(p, fast, force, s.Obj, s.UI); err != nil {
 			s.UI.PrintErr("local symbolization: " + err.Error())
 		}
 	}
@@ -87,7 +90,7 @@ func (s *Symbolizer) Symbolize(mode string, sources plugin.MappingSources, p *pr
 		}
 	}
 
-	Demangle(p, force, demanglerMode)
+	demangleFunction(p, force, demanglerMode)
 	return nil
 }
 
@@ -136,18 +139,10 @@ func statusCodeError(resp *http.Response) error {
 // doLocalSymbolize adds symbol and line number information to all locations
 // in a profile. mode enables some options to control
 // symbolization.
-func doLocalSymbolize(mode string, prof *profile.Profile, obj plugin.ObjTool, ui plugin.UI) error {
-	force := false
-	// Disable some mechanisms based on mode string.
-	for _, o := range strings.Split(strings.ToLower(mode), ":") {
-		switch {
-		case o == "force":
-			force = true
-		case o == "fastlocal":
-			if bu, ok := obj.(*binutils.Binutils); ok {
-				bu.SetFastSymbolization(true)
-			}
-		default:
+func doLocalSymbolize(prof *profile.Profile, fast, force bool, obj plugin.ObjTool, ui plugin.UI) error {
+	if fast {
+		if bu, ok := obj.(*binutils.Binutils); ok {
+			bu.SetFastSymbolization(true)
 		}
 	}
 

--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -50,13 +50,15 @@ func (s *Symbolizer) Symbolize(mode string, sources plugin.MappingSources, p *pr
 	remote, local, force, demanglerMode := true, true, false, ""
 	for _, o := range strings.Split(strings.ToLower(mode), ":") {
 		switch o {
+		case "":
+			continue
 		case "none", "no":
 			return nil
 		case "local", "fastlocal":
 			remote, local = false, true
 		case "remote":
 			remote, local = true, false
-		case "", "force":
+		case "force":
 			force = true
 		default:
 			switch d := strings.TrimPrefix(o, "demangle="); d {

--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -85,7 +85,7 @@ func (s *Symbolizer) Symbolize(mode string, sources plugin.MappingSources, p *pr
 		}
 	}
 	if remote {
-		if err = symbolzSymbolize(sources, postURL, p, s.UI); err != nil {
+		if err = symbolzSymbolize(p, force, sources, postURL, s.UI); err != nil {
 			return err // Ran out of options.
 		}
 	}

--- a/internal/symbolz/symbolz.go
+++ b/internal/symbolz/symbolz.go
@@ -41,7 +41,8 @@ var (
 // not already marked as HasFunctions.
 func Symbolize(p *profile.Profile, force bool, sources plugin.MappingSources, syms func(string, string) ([]byte, error), ui plugin.UI) error {
 	for _, m := range p.Mapping {
-		if m.HasFunctions && !force {
+		if !force && m.HasFunctions {
+			// symbolz only populates function names, so only check for HasFunctions to decide whether to resymbolize.
 			continue
 		}
 		mappingSources := sources[m.File]

--- a/internal/symbolz/symbolz.go
+++ b/internal/symbolz/symbolz.go
@@ -36,9 +36,9 @@ var (
 
 // Symbolize symbolizes profile p by parsing data returned by a
 // symbolz handler. syms receives the symbolz query (hex addresses
-// separated by '+') and returns the symbolz output in a string. It
-// symbolizes all locations based on their addresses, regardless of
-// mapping.
+// separated by '+') and returns the symbolz output in a string. If
+// force is false, it will only symbolize locations from mappings
+// not already marked as HasFunctions.
 func Symbolize(p *profile.Profile, force bool, sources plugin.MappingSources, syms func(string, string) ([]byte, error), ui plugin.UI) error {
 	for _, m := range p.Mapping {
 		if m.HasFunctions && !force {

--- a/internal/symbolz/symbolz.go
+++ b/internal/symbolz/symbolz.go
@@ -42,7 +42,7 @@ var (
 func Symbolize(p *profile.Profile, force bool, sources plugin.MappingSources, syms func(string, string) ([]byte, error), ui plugin.UI) error {
 	for _, m := range p.Mapping {
 		if !force && m.HasFunctions {
-			// symbolz only populates function names, so only check for HasFunctions to decide whether to resymbolize.
+			// Only check for HasFunctions as symbolz only populates function names.
 			continue
 		}
 		mappingSources := sources[m.File]

--- a/internal/symbolz/symbolz.go
+++ b/internal/symbolz/symbolz.go
@@ -39,9 +39,9 @@ var (
 // separated by '+') and returns the symbolz output in a string. It
 // symbolizes all locations based on their addresses, regardless of
 // mapping.
-func Symbolize(sources plugin.MappingSources, syms func(string, string) ([]byte, error), p *profile.Profile, ui plugin.UI) error {
+func Symbolize(p *profile.Profile, force bool, sources plugin.MappingSources, syms func(string, string) ([]byte, error), ui plugin.UI) error {
 	for _, m := range p.Mapping {
-		if m.HasFunctions {
+		if m.HasFunctions && !force {
 			continue
 		}
 		mappingSources := sources[m.File]

--- a/internal/symbolz/symbolz_test.go
+++ b/internal/symbolz/symbolz_test.go
@@ -60,7 +60,7 @@ func TestSymbolize(t *testing.T) {
 			}
 			var wantSym, wantNoSym []*profile.Location
 			if force || !hasFunctions {
-				wantNoSym = p.Location[1:1]
+				wantNoSym = p.Location[:1]
 				wantSym = p.Location[1:]
 			} else {
 				wantNoSym = p.Location
@@ -99,12 +99,12 @@ func testProfile(hasFunctions bool) *profile.Profile {
 	return p
 }
 
-func checkSymbolized(locs []*profile.Location, hasSymbols bool) error {
+func checkSymbolized(locs []*profile.Location, wantSymbolized bool) error {
 	for _, loc := range locs {
-		if !hasSymbols && len(loc.Line) != 0 {
+		if !wantSymbolized && len(loc.Line) != 0 {
 			return fmt.Errorf("unexpected symbolization for %#x: %v", loc.Address, loc.Line)
 		}
-		if hasSymbols {
+		if wantSymbolized {
 			if len(loc.Line) != 1 {
 				return fmt.Errorf("expected symbolization for %#x: %v", loc.Address, loc.Line)
 			}


### PR DESCRIPTION
The code parsing symbolize options was treating the empty option as
"force", effectively making -symbolize=force the default. This would
unnecessarily symbolize profiles that were already symbolized.