### PR TITLE
Use common header for remaining web views (source code, disassembly, peek)

### DIFF
--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -16,7 +16,7 @@ package driver
 
 import "html/template"
 
-// addTemplates add a set of template defintions to templates.
+// addTemplates adds a set of template definitions to templates.
 func addTemplates(templates *template.Template) {
 	template.Must(templates.Parse(`
 {{define "css"}}

--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -471,16 +471,16 @@ function viewer(baseUrl, nodes) {
     if (detailsText != null) detailsText.style.display = "none"
   }
 
-  function handleReset() { window.location.href = baseUrl }
-  function handleTop() { navigate("/top", "f", false) }
-  function handleGraph() { navigate("/", "f", false) }
-  function handleList() { navigate("/source", "f", false) }
-  function handleDisasm() { navigate("/disasm", "f", false) }
-  function handlePeek() { navigate("/peek", "f", false) }
-  function handleFocus() { navigate(baseUrl, "f", false) }
-  function handleShow() { navigate(baseUrl, "s", false) }
-  function handleIgnore() { navigate(baseUrl, "i", false) }
-  function handleHide() { navigate(baseUrl, "h", false) }
+  function handleReset(e) { window.location.href = baseUrl }
+  function handleTop(e) { navigate("/top", "f") }
+  function handleGraph(e) { navigate("/", "f") }
+  function handleList(e) { navigate("/source", "f") }
+  function handleDisasm(e) { navigate("/disasm", "f") }
+  function handlePeek(e) { navigate("/peek", "f") }
+  function handleFocus(e) { navigate(baseUrl, "f") }
+  function handleShow(e) { navigate(baseUrl, "s") }
+  function handleIgnore(e) { navigate(baseUrl, "i") }
+  function handleHide(e) { navigate(baseUrl, "h") }
 
   function handleKey(e) {
     if (e.keyCode != 13) return
@@ -609,7 +609,7 @@ function viewer(baseUrl, nodes) {
 
   // Navigate to specified path with current selection reflected
   // in the named parameter.
-  function navigate(path, param, newWindow) {
+  function navigate(path, param) {
     // The selection can be in one of two modes: regexp-based or
     // list-based.  Construct regular expression depending on mode.
     let re = regexpActive ? search.value : ""
@@ -636,11 +636,7 @@ function viewer(baseUrl, nodes) {
       params.set(param, re)
     }
 
-    if (newWindow) {
-      window.open(url.toString(), "_blank")
-    } else {
-      window.location.href = url.toString()
-    }
+    window.location.href = url.toString()
   }
 
   function handleTopClick(e) {

--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -471,16 +471,16 @@ function viewer(baseUrl, nodes) {
     if (detailsText != null) detailsText.style.display = "none"
   }
 
-  function handleReset(e) { window.location.href = baseUrl }
-  function handleTop(e) { navigate("/top", "f") }
-  function handleGraph(e) { navigate("/", "f") }
-  function handleList(e) { navigate("/source", "f") }
-  function handleDisasm(e) { navigate("/disasm", "f") }
-  function handlePeek(e) { navigate("/peek", "f") }
-  function handleFocus(e) { navigate(baseUrl, "f") }
-  function handleShow(e) { navigate(baseUrl, "s") }
-  function handleIgnore(e) { navigate(baseUrl, "i") }
-  function handleHide(e) { navigate(baseUrl, "h") }
+  function handleReset() { window.location.href = baseUrl }
+  function handleTop() { navigate("/top", "f") }
+  function handleGraph() { navigate("/", "f") }
+  function handleList() { navigate("/source", "f") }
+  function handleDisasm() { navigate("/disasm", "f") }
+  function handlePeek() { navigate("/peek", "f") }
+  function handleFocus() { navigate(baseUrl, "f") }
+  function handleShow() { navigate(baseUrl, "s") }
+  function handleIgnore() { navigate(baseUrl, "i") }
+  function handleHide() { navigate(baseUrl, "h") }
 
   function handleKey(e) {
     if (e.keyCode != 13) return
@@ -714,6 +714,12 @@ function viewer(baseUrl, nodes) {
 
   search.addEventListener("input", handleSearch)
   search.addEventListener("keydown", handleKey)
+
+  // Give initial focus to main container so it can be scrolled using keys.
+  const main = document.getElementById("bodycontainer")
+  if (main) {
+    main.focus()
+  }
 }
 </script>
 {{end}}

--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -176,17 +176,11 @@ View
 <div class="menu">
 <button title="{{.Help.top}}" id="topbtn">Top</button>
 <button title="{{.Help.graph}}" id="graphbtn">Graph</button>
+<button title="{{.Help.peek}}" id="peek">Peek</button>
 <button title="{{.Help.list}}" id="list">Source</button>
+<button title="{{.Help.disasm}}" id="disasm">Disassemble</button>
 <hr>
 <button title="{{.Help.details}}" id="details">Details</button>
-</div>
-</div>
-
-<div class="menu-header">
-Functions
-<div class="menu">
-<button title="{{.Help.peek}}" id="peek">Peek</button>
-<button title="{{.Help.disasm}}" id="disasm">Disassemble</button>
 </div>
 </div>
 
@@ -224,7 +218,7 @@ Refine
 {{template "header" .}}
 <div id="graphcontainer">
 <div id="graph">
-{{.Body}}
+{{.HTMLBody}}
 </div>
 
 </div>
@@ -481,8 +475,8 @@ function viewer(baseUrl, nodes) {
   function handleTop() { navigate("/top", "f", false) }
   function handleGraph() { navigate("/", "f", false) }
   function handleList() { navigate("/source", "f", false) }
-  function handleDisasm() { navigate("/disasm", "f", true) }
-  function handlePeek() { navigate("/peek", "f", true) }
+  function handleDisasm() { navigate("/disasm", "f", false) }
+  function handlePeek() { navigate("/peek", "f", false) }
   function handleFocus() { navigate(baseUrl, "f", false) }
   function handleShow() { navigate(baseUrl, "s", false) }
   function handleIgnore() { navigate(baseUrl, "i", false) }
@@ -680,7 +674,7 @@ function viewer(baseUrl, nodes) {
     const enable = (search.value != "" || selected.size != 0)
     if (buttonsEnabled == enable) return
     buttonsEnabled = enable
-    for (const id of ["peek", "disasm", "focus", "ignore", "hide", "show"]) {
+    for (const id of ["focus", "ignore", "hide", "show"]) {
       const btn = document.getElementById(id)
       if (btn != null) {
         btn.disabled = !enable
@@ -770,7 +764,31 @@ function viewer(baseUrl, nodes) {
 {{template "header" .}}
 
 <div id="bodycontainer">
-{{.Body}}
+{{.HTMLBody}}
+</div>
+
+{{template "script" .}}
+<script>viewer({{.BaseURL}}, null)</script>
+</body>
+</html>
+{{end}}
+
+{{define "plaintext" -}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{.Title}}</title>
+{{template "css" .}}
+</head>
+<body>
+
+{{template "header" .}}
+
+<div id="bodycontainer">
+<pre>
+{{.TextBody}}
+</pre>
 </div>
 
 {{template "script" .}}

--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -16,21 +16,18 @@ package driver
 
 import "html/template"
 
-// webTemplate defines a collection of related templates:
-//    css
-//    header
-//    script
-//    graph
-//    top
-var webTemplate = template.Must(template.New("web").Parse(`
+// addTemplates add a set of template defintions to templates.
+func addTemplates(templates *template.Template) {
+	template.Must(templates.Parse(`
 {{define "css"}}
 <style type="text/css">
-html, body {
+html {
   height: 100%;
   min-height: 100%;
   margin: 0px;
 }
 body {
+  margin: 0px;
   width: 100%;
   height: 100%;
   min-height: 100%;
@@ -129,11 +126,12 @@ button {
 #searchbox {
   margin-left: 10pt;
 }
-#topcontainer {
+#bodycontainer {
   width: 100%;
   height: 100%;
   max-height: 100%;
   overflow: scroll;
+  padding-top: 5px;
 }
 #toptable {
   border-spacing: 0px;
@@ -176,12 +174,9 @@ button {
 <div class="menu-header">
 View
 <div class="menu">
-{{if (ne .Type "top")}}
-  <button title="{{.Help.top}}" id="topbtn">Top</button>
-{{end}}
-{{if (ne .Type "dot")}}
-  <button title="{{.Help.graph}}" id="graphbtn">Graph</button>
-{{end}}
+<button title="{{.Help.top}}" id="topbtn">Top</button>
+<button title="{{.Help.graph}}" id="graphbtn">Graph</button>
+<button title="{{.Help.list}}" id="list">Source</button>
 <hr>
 <button title="{{.Help.details}}" id="details">Details</button>
 </div>
@@ -191,7 +186,6 @@ View
 Functions
 <div class="menu">
 <button title="{{.Help.peek}}" id="peek">Peek</button>
-<button title="{{.Help.list}}" id="list">List</button>
 <button title="{{.Help.disasm}}" id="disasm">Disassemble</button>
 </div>
 </div>
@@ -230,7 +224,7 @@ Refine
 {{template "header" .}}
 <div id="graphcontainer">
 <div id="graph">
-{{.Svg}}
+{{.Body}}
 </div>
 
 </div>
@@ -486,7 +480,7 @@ function viewer(baseUrl, nodes) {
   function handleReset() { window.location.href = baseUrl }
   function handleTop() { navigate("/top", "f", false) }
   function handleGraph() { navigate("/", "f", false) }
-  function handleList() { navigate("/weblist", "f", true) }
+  function handleList() { navigate("/source", "f", false) }
   function handleDisasm() { navigate("/disasm", "f", true) }
   function handlePeek() { navigate("/peek", "f", true) }
   function handleFocus() { navigate(baseUrl, "f", false) }
@@ -686,7 +680,7 @@ function viewer(baseUrl, nodes) {
     const enable = (search.value != "" || selected.size != 0)
     if (buttonsEnabled == enable) return
     buttonsEnabled = enable
-    for (const id of ["peek", "list", "disasm", "focus", "ignore", "hide", "show"]) {
+    for (const id of ["peek", "disasm", "focus", "ignore", "hide", "show"]) {
       const btn = document.getElementById(id)
       if (btn != null) {
         btn.disabled = !enable
@@ -746,7 +740,7 @@ function viewer(baseUrl, nodes) {
 
 {{template "header" .}}
 
-<div id="topcontainer">
+<div id="bodycontainer">
 <table id="toptable">
 <tr><th>Flat<th>Flat%<th>Sum%<th>Cum<th>Cum%<th>Name<th>Inlined?</tr>
 {{range $i,$e := .Top}}
@@ -760,4 +754,29 @@ function viewer(baseUrl, nodes) {
 </body>
 </html>
 {{end}}
+
+{{define "sourcelisting" -}}
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{.Title}}</title>
+{{template "css" .}}
+{{template "weblistcss" .}}
+{{template "weblistjs" .}}
+</head>
+<body>
+
+{{template "header" .}}
+
+<div id="bodycontainer">
+{{.Body}}
+</div>
+
+{{template "script" .}}
+<script>viewer({{.BaseURL}}, null)</script>
+</body>
+</html>
+{{end}}
 `))
+}

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -35,9 +35,22 @@ import (
 
 // webInterface holds the state needed for serving a browser based interface.
 type webInterface struct {
-	prof    *profile.Profile
-	options *plugin.Options
-	help    map[string]string
+	prof      *profile.Profile
+	options   *plugin.Options
+	help      map[string]string
+	templates *template.Template
+}
+
+func makeWebInterface(p *profile.Profile, opt *plugin.Options) *webInterface {
+	templates := template.New("templategroup")
+	addTemplates(templates)
+	report.AddSourceTemplates(templates)
+	return &webInterface{
+		prof:      p,
+		options:   opt,
+		help:      make(map[string]string),
+		templates: templates,
+	}
 }
 
 // errorCatcher is a UI that captures errors for reporting to the browser.
@@ -54,23 +67,18 @@ func (ec *errorCatcher) PrintErr(args ...interface{}) {
 // webArgs contains arguments passed to templates in webhtml.go.
 type webArgs struct {
 	BaseURL string
-	Type    string
 	Title   string
 	Errors  []string
 	Legend  []string
 	Help    map[string]string
 	Nodes   []string
-	Svg     template.HTML
+	Body    template.HTML
 	Top     []report.TextItem
 }
 
 func serveWebInterface(hostport string, p *profile.Profile, o *plugin.Options) error {
 	interactiveMode = true
-	ui := &webInterface{
-		prof:    p,
-		options: o,
-		help:    make(map[string]string),
-	}
+	ui := makeWebInterface(p, o)
 	for n, c := range pprofCommands {
 		ui.help[n] = c.description
 	}
@@ -101,7 +109,7 @@ func serveWebInterface(hostport string, p *profile.Profile, o *plugin.Options) e
 	mux.Handle("/", wrap(http.HandlerFunc(ui.dot)))
 	mux.Handle("/top", wrap(http.HandlerFunc(ui.top)))
 	mux.Handle("/disasm", wrap(http.HandlerFunc(ui.disasm)))
-	mux.Handle("/weblist", wrap(http.HandlerFunc(ui.weblist)))
+	mux.Handle("/source", wrap(http.HandlerFunc(ui.source)))
 	mux.Handle("/peek", wrap(http.HandlerFunc(ui.peek)))
 
 	s := &http.Server{Handler: mux}
@@ -187,27 +195,59 @@ func varsFromURL(u *gourl.URL) variables {
 	return vars
 }
 
+// makeReport generates a report for the specified command.
+func (ui *webInterface) makeReport(w http.ResponseWriter, req *http.Request,
+	cmd []string, vars ...string) (*report.Report, []string) {
+	v := varsFromURL(req.URL)
+	for i := 0; i+1 < len(vars); i += 2 {
+		v[vars[i]].value = vars[i+1]
+	}
+	catcher := &errorCatcher{UI: ui.options.UI}
+	options := *ui.options
+	options.UI = catcher
+	_, rpt, err := generateRawReport(ui.prof, cmd, v, &options)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		ui.options.UI.PrintErr(err)
+		return nil, nil
+	}
+	return rpt, catcher.errors
+}
+
+// render generates html using the named template based on the contents of data.
+func (ui *webInterface) render(w http.ResponseWriter, baseURL, tmpl string,
+	errList, legend []string, data webArgs) {
+	file := getFromLegend(legend, "File: ", "unknown")
+	profile := getFromLegend(legend, "Type: ", "unknown")
+	data.BaseURL = baseURL
+	data.Title = file + " " + profile
+	data.Errors = errList
+	data.Legend = legend
+	data.Help = ui.help
+	html := &bytes.Buffer{}
+	if err := ui.templates.ExecuteTemplate(html, tmpl, data); err != nil {
+		http.Error(w, "internal template error", http.StatusInternalServerError)
+		ui.options.UI.PrintErr(err)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html")
+	w.Write(html.Bytes())
+}
+
 // dot generates a web page containing an svg diagram.
 func (ui *webInterface) dot(w http.ResponseWriter, req *http.Request) {
+	// Disable prefix matching behavior of net/http.
 	if req.URL.Path != "/" {
 		http.NotFound(w, req)
 		return
 	}
 
-	// Capture any error messages generated while generating a report.
-	catcher := &errorCatcher{UI: ui.options.UI}
-	options := *ui.options
-	options.UI = catcher
+	rpt, errList := ui.makeReport(w, req, []string{"svg"})
+	if rpt == nil {
+		return // error already reported
+	}
 
 	// Generate dot graph.
-	args := []string{"svg"}
-	vars := varsFromURL(req.URL)
-	_, rpt, err := generateRawReport(ui.prof, args, vars, &options)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		ui.options.UI.PrintErr(err)
-		return
-	}
 	g, config := report.GetDOT(rpt)
 	legend := config.Labels
 	config.Labels = nil
@@ -229,27 +269,10 @@ func (ui *webInterface) dot(w http.ResponseWriter, req *http.Request) {
 		nodes = append(nodes, n.Info.Name)
 	}
 
-	// Embed in html.
-	file := getFromLegend(legend, "File: ", "unknown")
-	profile := getFromLegend(legend, "Type: ", "unknown")
-	data := webArgs{
-		BaseURL: "/",
-		Type:    "dot",
-		Title:   file + " " + profile,
-		Errors:  catcher.errors,
-		Svg:     template.HTML(string(svg)),
-		Legend:  legend,
-		Nodes:   nodes,
-		Help:    ui.help,
-	}
-	html := &bytes.Buffer{}
-	if err := webTemplate.ExecuteTemplate(html, "graph", data); err != nil {
-		http.Error(w, "internal template error", http.StatusInternalServerError)
-		ui.options.UI.PrintErr(err)
-		return
-	}
-	w.Header().Set("Content-Type", "text/html")
-	w.Write(html.Bytes())
+	ui.render(w, "/", "graph", errList, legend, webArgs{
+		Body:  template.HTML(string(svg)),
+		Nodes: nodes,
+	})
 }
 
 func dotToSvg(dot []byte) ([]byte, error) {
@@ -271,51 +294,20 @@ func dotToSvg(dot []byte) ([]byte, error) {
 }
 
 func (ui *webInterface) top(w http.ResponseWriter, req *http.Request) {
-	// Capture any error messages generated while generating a report.
-	catcher := &errorCatcher{UI: ui.options.UI}
-	options := *ui.options
-	options.UI = catcher
-
-	// Generate top report
-	args := []string{"top"}
-	vars := varsFromURL(req.URL)
-	vars["nodecount"].value = "500"
-	_, rpt, err := generateRawReport(ui.prof, args, vars, &options)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		ui.options.UI.PrintErr(err)
-		return
+	rpt, errList := ui.makeReport(w, req, []string{"top"}, "nodecount", "500")
+	if rpt == nil {
+		return // error already reported
 	}
-
 	top, legend := report.TextItems(rpt)
-
-	// Get all node names into an array.
 	var nodes []string
 	for _, item := range top {
 		nodes = append(nodes, item.Name)
 	}
 
-	// Embed in html.
-	file := getFromLegend(legend, "File: ", "unknown")
-	profile := getFromLegend(legend, "Type: ", "unknown")
-	data := webArgs{
-		BaseURL: "/top",
-		Type:    "top",
-		Title:   file + " " + profile,
-		Errors:  catcher.errors,
-		Legend:  legend,
-		Help:    ui.help,
-		Top:     top,
-		Nodes:   nodes,
-	}
-	html := &bytes.Buffer{}
-	if err := webTemplate.ExecuteTemplate(html, "top", data); err != nil {
-		http.Error(w, "internal template error", http.StatusInternalServerError)
-		ui.options.UI.PrintErr(err)
-		return
-	}
-	w.Header().Set("Content-Type", "text/html")
-	w.Write(html.Bytes())
+	ui.render(w, "/top", "top", errList, legend, webArgs{
+		Top:   top,
+		Nodes: nodes,
+	})
 }
 
 // disasm generates a web page containing disassembly.
@@ -323,9 +315,27 @@ func (ui *webInterface) disasm(w http.ResponseWriter, req *http.Request) {
 	ui.output(w, req, "disasm", "text/plain", pprofVariables.makeCopy())
 }
 
-// weblist generates a web page containing disassembly.
-func (ui *webInterface) weblist(w http.ResponseWriter, req *http.Request) {
-	ui.output(w, req, "weblist", "text/html", pprofVariables.makeCopy())
+// source generates a web page containing disassembly.
+func (ui *webInterface) source(w http.ResponseWriter, req *http.Request) {
+	args := []string{"weblist", req.URL.Query().Get("f")}
+	rpt, errList := ui.makeReport(w, req, args)
+	if rpt == nil {
+		return // error already reported
+	}
+
+	// Generate source listing.
+	var body bytes.Buffer
+	const maxFiles = 50
+	if err := report.PrintWebList(&body, rpt, ui.options.Obj, maxFiles); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		ui.options.UI.PrintErr(err)
+		return
+	}
+
+	legend := report.ProfileLabels(rpt)
+	ui.render(w, "/source", "sourcelisting", errList, legend, webArgs{
+		Body: template.HTML(body.String()),
+	})
 }
 
 // peek generates a web page listing callers/callers.

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -335,7 +335,8 @@ func (ui *webInterface) disasm(w http.ResponseWriter, req *http.Request) {
 
 }
 
-// source generates a web page containing disassembly.
+// source generates a web page containing source code annotated with profile
+// data.
 func (ui *webInterface) source(w http.ResponseWriter, req *http.Request) {
 	args := []string{"weblist", req.URL.Query().Get("f")}
 	rpt, errList := ui.makeReport(w, req, args)

--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -32,11 +32,7 @@ import (
 
 func TestWebInterface(t *testing.T) {
 	prof := makeFakeProfile()
-	ui := &webInterface{
-		prof:    prof,
-		options: &plugin.Options{Obj: fakeObjTool{}},
-		help:    make(map[string]string),
-	}
+	ui := makeWebInterface(prof, &plugin.Options{Obj: fakeObjTool{}})
 
 	// Start test server.
 	server := httptest.NewServer(http.HandlerFunc(
@@ -50,8 +46,8 @@ func TestWebInterface(t *testing.T) {
 				ui.disasm(w, r)
 			case "/peek":
 				ui.peek(w, r)
-			case "/weblist":
-				ui.weblist(w, r)
+			case "/source":
+				ui.source(w, r)
 			}
 		}))
 	defer server.Close()
@@ -69,7 +65,7 @@ func TestWebInterface(t *testing.T) {
 	testcases := []testCase{
 		{"/", []string{"F1", "F2", "F3", "testbin", "cpu"}, true},
 		{"/top", []string{"Flat", "200ms.*100%.*F2"}, false},
-		{"/weblist?f=" + url.QueryEscape("F[12]"),
+		{"/source?f=" + url.QueryEscape("F[12]"),
 			[]string{"F1", "F2", "300ms line1"}, false},
 		{"/peek?f=" + url.QueryEscape("F[12]"),
 			[]string{"300ms.*F1", "200ms.*300ms.*F2"}, false},

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -345,6 +345,7 @@ func printAssembly(w io.Writer, rpt *Report, obj plugin.ObjTool) error {
 	return PrintAssembly(w, rpt, obj, -1)
 }
 
+// PrintAssembly prints annotated disasssembly of rpt to w.
 func PrintAssembly(w io.Writer, rpt *Report, obj plugin.ObjTool, maxFuncs int) error {
 	o := rpt.options
 	prof := rpt.prof

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -297,7 +297,7 @@ func printHeader(w io.Writer, rpt *Report) {
 <title>Pprof listing</title>`)
 	fmt.Fprintln(w, weblistPageCSS)
 	fmt.Fprintln(w, weblistPageScript)
-	fmt.Fprintln(w, "</head>\n<body>\n")
+	fmt.Fprint(w, "</head>\n<body>\n\n")
 
 	var labels []string
 	for _, l := range ProfileLabels(rpt) {

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -188,12 +188,9 @@ func PrintWebList(w io.Writer, rpt *Report, obj plugin.ObjTool, maxFiles int) er
 
 	// Limit number of files printed?
 	if maxFiles < 0 {
-		// TODO(reviewers): Is it worth-while using FileOrder for
-		// backwards compatibility, or should we sort by decreasing
-		// cumulative samples always?
 		sourceFiles.Sort(graph.FileOrder)
 	} else {
-		sourceFiles.Sort(graph.CumNameOrder)
+		sourceFiles.Sort(graph.FlatNameOrder)
 		if maxFiles < len(sourceFiles) {
 			sourceFiles = sourceFiles[:maxFiles]
 		}

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -124,6 +124,7 @@ func printWebSource(w io.Writer, rpt *Report, obj plugin.ObjTool) error {
 	return nil
 }
 
+// PrintWebList prints annotated source listing of rpt to w.
 func PrintWebList(w io.Writer, rpt *Report, obj plugin.ObjTool, maxFiles int) error {
 	o := rpt.options
 	g := rpt.newGraph(nil)
@@ -294,7 +295,7 @@ func printHeader(w io.Writer, rpt *Report) {
 <head>
 <meta charset="UTF-8">
 <title>Pprof listing</title>`)
-	fmt.Fprintln(w, weblistPageCss)
+	fmt.Fprintln(w, weblistPageCSS)
 	fmt.Fprintln(w, weblistPageScript)
 	fmt.Fprintln(w, "</head>\n<body>\n")
 

--- a/internal/report/source_html.go
+++ b/internal/report/source_html.go
@@ -14,13 +14,16 @@
 
 package report
 
-const weblistPageHeader = `
-<!DOCTYPE html>
-<html>
-<head>
-<meta charset="UTF-8">
-<title>Pprof listing</title>
-<style type="text/css">
+import (
+	"html/template"
+)
+
+func AddSourceTemplates(t *template.Template) {
+	template.Must(t.Parse(`{{define "weblistcss"}}` + weblistPageCss + `{{end}}`))
+	template.Must(t.Parse(`{{define "weblistjs"}}` + weblistPageScript + `{{end}}`))
+}
+
+const weblistPageCss = `<style type="text/css">
 body {
 font-family: sans-serif;
 }
@@ -60,8 +63,9 @@ background-color: #eeeeee;
 color: #008800;
 display: none;
 }
-</style>
-<script type="text/javascript">
+</style>`
+
+const weblistPageScript = `<script type="text/javascript">
 function pprof_toggle_asm(e) {
   var target;
   if (!e) e = window.event;
@@ -77,10 +81,7 @@ function pprof_toggle_asm(e) {
     }
   }
 }
-</script>
-</head>
-<body>
-`
+</script>`
 
 const weblistPageClosing = `
 </body>

--- a/internal/report/source_html.go
+++ b/internal/report/source_html.go
@@ -18,12 +18,13 @@ import (
 	"html/template"
 )
 
+// AddSourceTemplates adds templates used by PrintWebList to t.
 func AddSourceTemplates(t *template.Template) {
-	template.Must(t.Parse(`{{define "weblistcss"}}` + weblistPageCss + `{{end}}`))
+	template.Must(t.Parse(`{{define "weblistcss"}}` + weblistPageCSS + `{{end}}`))
 	template.Must(t.Parse(`{{define "weblistjs"}}` + weblistPageScript + `{{end}}`))
 }
 
-const weblistPageCss = `<style type="text/css">
+const weblistPageCSS = `<style type="text/css">
 body {
 font-family: sans-serif;
 }


### PR DESCRIPTION
Details:

* Made it easier to reuse css, javascript, etc. across views.
* Added two new templates: sourcelisting, plaintext.
* Use new templates for showing source code, disassembly, peek.
* Merged Functions menu into View menu.
* View change menu entries are now always enabled.
* Removed now unused "newWindow" argument to navigate.
* Removed redundancy in web handlers.
* Renamed /weblist URL to /source.
* Assembly and source code listings are now limited to 500 functions
  sorted by decreasing flat value (to prevent huge delays when
  selecting asm/source view across the entire profile).
