### PR TITLE
Replaced http wrapper field in plugin Options with HTTPServer.

### DIFF
--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -23,7 +23,6 @@ import (
 	"net/url"
 	"os/exec"
 	"regexp"
-	"runtime"
 	"testing"
 
 	"github.com/google/pprof/internal/plugin"
@@ -192,55 +191,6 @@ func makeFakeProfile() *profile.Profile {
 		Location: locs,
 		Function: funcs,
 		Mapping:  mapping,
-	}
-}
-
-func TestNewListenerAndURL(t *testing.T) {
-	if runtime.GOOS == "nacl" {
-		t.Skip("test assumes tcp available")
-	}
-
-	tests := []struct {
-		hostport  string
-		wantErr   bool
-		wantURLRe *regexp.Regexp
-		wantLocal bool
-	}{
-		{
-			hostport:  ":",
-			wantURLRe: regexp.MustCompile(`http://localhost:\d+`),
-			wantLocal: true,
-		},
-		{
-			hostport:  "localhost:",
-			wantURLRe: regexp.MustCompile(`http://localhost:\d+`),
-			wantLocal: true,
-		},
-		{
-			hostport: "http://localhost:12345",
-			wantErr:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.hostport, func(t *testing.T) {
-			_, url, isLocal, err := newListenerAndURL(tt.hostport)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("newListenerAndURL(%v) want error; got none", tt.hostport)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("newListenerAndURL(%v) = %v", tt.hostport, err)
-			}
-			if !tt.wantURLRe.MatchString(url) {
-				t.Errorf("newListenerAndURL(%v) URL = %v; want URL matching %v", tt.hostport, url, tt.wantURLRe)
-			}
-			if got, want := isLocal, tt.wantLocal; got != want {
-				t.Errorf("newListenerAndURL(%v) isLocal = %v; want %v", tt.hostport, got, want)
-			}
-		})
 	}
 }
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -33,14 +33,15 @@ type Options struct {
 	Obj     ObjTool
 	UI      UI
 
-	// HTTPWrapper takes a pprof http handler as an argument and
-	// returns the actual handler that should be invoked by http.
-	// A typical use is to add authentication before calling the
-	// pprof handler.
+	// HTTPServer is a function that should block serving http requests,
+	// including the handlers specfied in args.  If non-nil, pprof will
+	// invoke this function if necessary to provide a web interface.
 	//
-	// If HTTPWrapper is nil, a default wrapper will be used that
-	// disallows all requests except from the localhost.
-	HTTPWrapper func(http.Handler) http.Handler
+	// If HTTPServer is nil, pprof will use its own internal HTTP server.
+	//
+	// A common use for a custom HTTPServer is to provide custom
+	// authentication checks.
+	HTTPServer func(args *HTTPServerArgs) error
 }
 
 // Writer provides a mechanism to write data under a certain name,
@@ -194,4 +195,18 @@ type UI interface {
 	// SetAutoComplete instructs the UI to call complete(cmd) to obtain
 	// the auto-completion of cmd, if the UI supports auto-completion at all.
 	SetAutoComplete(complete func(string) string)
+}
+
+// HTTPServerArgs contains arguments needed by an HTTP server that
+// is exporting a pprof web interface.
+type HTTPServerArgs struct {
+	// Hostport contains the http server address (derived from flags).
+	Hostport string
+
+	Host string // Host portion of Hostport
+	Port int    // Port portion of Hostport
+
+	// Handlers maps from URL paths to the handler to invoke to
+	// serve that path.
+	Handlers map[string]http.Handler
 }


### PR DESCRIPTION
HTTPServer allows somebody embedding pprof to control how the
hosting HTTP server is constructed which makes pprof work in
more environments.
