### PR TITLE
Fix unit warnings

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -290,7 +290,7 @@ func identifyNumLabelUnits(p *profile.Profile, ui plugin.UI) map[string]string {
 	// Print errors for tags with multiple units associated with
 	// a single key.
 	for k, units := range ignoredUnits {
-		ui.PrintErr(fmt.Sprintf("For tag %s used unit %s, also encountered unit(s) %s", k, numLabelUnits[k], strings.Join(units, ",")))
+		ui.PrintErr(fmt.Sprintf("For tag %s used unit %s, also encountered unit(s) %s", k, numLabelUnits[k], strings.Join(units, ", ")))
 	}
 	return numLabelUnits
 }

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -450,20 +450,16 @@ func (p *Profile) Aggregate(inlineFrame, function, filename, linenumber, address
 func (p *Profile) NumLabelUnits() (map[string]string, map[string][]string) {
 	numLabelUnits := map[string]string{}
 	ignoredUnits := map[string]map[string]bool{}
+	encounteredKeys := map[string]bool{}
 
 	// Determine units based on numeric tags for each sample.
 	for _, s := range p.Sample {
-		for k, vs := range s.NumLabel {
-			units := s.NumUnit[k]
-			if len(units) != len(vs) {
-				if _, ok := numLabelUnits[k]; !ok {
-					numLabelUnits[k] = ""
-				} else {
-					ignoredUnits[k] = map[string]bool{"": true}
+		for k := range s.NumLabel {
+			encounteredKeys[k] = true
+			for _, unit := range s.NumUnit[k] {
+				if unit == "" {
+					continue
 				}
-				continue
-			}
-			for _, unit := range units {
 				if wantUnit, ok := numLabelUnits[k]; !ok {
 					numLabelUnits[k] = unit
 				} else if wantUnit != unit {
@@ -476,10 +472,10 @@ func (p *Profile) NumLabelUnits() (map[string]string, map[string][]string) {
 			}
 		}
 	}
-
 	// Infer units for keys without any units associated with
 	// numeric tag values.
-	for key, unit := range numLabelUnits {
+	for key := range encounteredKeys {
+		unit := numLabelUnits[key]
 		if unit == "" {
 			switch key {
 			case "alignment", "request":


### PR DESCRIPTION
Now, warnings will only be printed if multiple units are associated with one key, but not if units are inferred based on the keys, units are inferred, or some values are missing units.

Fixes #239