### PR TITLE
Show menu on click, not hover.

### DIFF
--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -85,9 +85,7 @@ button {
   position: relative;
   display: inline-block;
   padding: 2px 2px;
-  cursor: default;
   font-size: 14pt;
-  user-select: none;
 }
 .menu {
   display: none;
@@ -99,8 +97,13 @@ button {
   margin-top: 2px;
   left: 0px;
   min-width: 5em;
+}
+.menu-header, .menu {
   cursor: default;
   user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
 }
 .menu hr {
   background-color: #fff;


### PR DESCRIPTION
Previously, users had to be careful to not move the mouse
outside the menu (otherwise it would disappear unintentionally).

Also fixed a minor bug where we were not overwriting URL
parameters correctly when no selection was made.