### PR TITLE
Improve POST URL status error

### DIFF
--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -121,7 +121,7 @@ func postURL(source, post string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, statusCodeError(resp)
+		return nil, fmt.Errorf("%s: %v", source, statusCodeError(resp))
 	}
 	return ioutil.ReadAll(resp.Body)
 }

--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -121,7 +121,7 @@ func postURL(source, post string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s: %v", source, statusCodeError(resp))
+		return nil, fmt.Errorf("http post %s: %v", source, statusCodeError(resp))
 	}
 	return ioutil.ReadAll(resp.Body)
 }


### PR DESCRIPTION
Errors due to unwanted status codes in POST responses give no URL context. This adds it to match the style used for connection issues. This is useful for example when symbol look fails and generates a 404. Previously there was no mention of why a 404 error occurred, and the action that triggered it.