### PR TITLE
Skip TestWebInterface on nacl

### DIFF
--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -28,9 +28,14 @@ import (
 
 	"github.com/google/pprof/internal/plugin"
 	"github.com/google/pprof/profile"
+	"runtime"
 )
 
 func TestWebInterface(t *testing.T) {
+	if runtime.GOOS == "nacl" {
+		t.Skip("test assumes tcp available")
+	}
+
 	prof := makeFakeProfile()
 
 	// Custom http server creator


### PR DESCRIPTION
Should fix #251.

In #229, TestWebInterface was modified the server, so it now runs in a separate thread.
I think that this changes how tests interact with the server, so it runs into limitations similar to those which caused #196 (specifically that tcp isn't available on nacl).