### PR TITLE
Support HTTPS certs, keys and CAs

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -111,7 +111,7 @@ type Fetcher interface {
 
 // A Symbolizer introduces symbol information into a profile.
 type Symbolizer interface {
-	Symbolize(mode string, srcs MappingSources, prof *profile.Profile) error
+	Symbolize(mode string, tlsParam *plugin.TLSParams, srcs MappingSources, prof *profile.Profile) error
 }
 
 // MappingSources map each profile.Mapping to the source of the profile.
@@ -272,10 +272,10 @@ type internalSymbolizer struct {
 	Symbolizer
 }
 
-func (s *internalSymbolizer) Symbolize(mode string, srcs plugin.MappingSources, prof *profile.Profile) error {
+func (s *internalSymbolizer) Symbolize(mode string, tlsParam *plugin.TLSParams, srcs plugin.MappingSources, prof *profile.Profile) error {
 	isrcs := MappingSources{}
 	for m, s := range srcs {
 		isrcs[m] = s
 	}
-	return s.Symbolizer.Symbolize(mode, isrcs, prof)
+	return s.Symbolizer.Symbolize(mode, tlsParam, isrcs, prof)
 }

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -39,12 +39,12 @@ func PProf(eo *plugin.Options) error {
 
 	o := setDefaults(eo)
 
-	src, cmd, err := parseFlags(o)
+	src, tlsParam, cmd, err := parseFlags(o)
 	if err != nil {
 		return err
 	}
 
-	p, err := fetchProfiles(src, o)
+	p, err := fetchProfiles(src, tlsParam, o)
 	if err != nil {
 		return err
 	}

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -188,7 +188,7 @@ func TestFetch(t *testing.T) {
 		{path + "go.nomappings.crash", "/bin/gotest.exe"},
 		{"http://localhost/profile?file=cppbench.cpu", ""},
 	} {
-		p, _, _, err := grabProfile(&source{ExecName: tc.execName}, tc.source, nil, testObj{}, &proftest.TestUI{T: t})
+		p, _, _, err := grabProfile(&source{ExecName: tc.execName}, tc.source, nil, nil, testObj{}, &proftest.TestUI{T: t})
 		if err != nil {
 			t.Fatalf("%s: %s", tc.source, err)
 		}
@@ -285,13 +285,13 @@ func TestFetchWithBase(t *testing.T) {
 
 			o := setDefaults(nil)
 			o.Flagset = f
-			src, _, err := parseFlags(o)
+			src, tlsParam, _, err := parseFlags(o)
 
 			if err != nil {
 				t.Fatalf("%s: %v", tc.desc, err)
 			}
 
-			p, err := fetchProfiles(src, o)
+			p, err := fetchProfiles(src, tlsParam, o)
 			pprofVariables = baseVars
 			if err != nil {
 				t.Fatal(err)
@@ -331,7 +331,7 @@ func mappingSources(key, source string, start uint64) plugin.MappingSources {
 
 // stubHTTPGet intercepts a call to http.Get and rewrites it to use
 // "file://" to get the profile directly from a file.
-func stubHTTPGet(source string, _ time.Duration) (*http.Response, error) {
+func stubHTTPGet(source string, tlsParam *plugin.TLSParams, _ time.Duration) (*http.Response, error) {
 	url, err := url.Parse(source)
 	if err != nil {
 		return nil, err
@@ -421,7 +421,7 @@ func TestHttpsInsecure(t *testing.T) {
 		UI:  &proftest.TestUI{T: t, AllowRx: rx},
 	}
 	o.Sym = &symbolizer.Symbolizer{Obj: o.Obj, UI: o.UI}
-	p, err := fetchProfiles(s, o)
+	p, err := fetchProfiles(s, &plugin.TLSParams{}, o)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -44,6 +44,11 @@ type Options struct {
 	HTTPServer func(args *HTTPServerArgs) error
 }
 
+// TLS Parameters for HTTPS profile and symbol fetch
+type TLSParams struct {
+	HTTPSCert, HTTPSKey, HTTPSCA string
+}
+
 // Writer provides a mechanism to write data under a certain name,
 // typically a filename.
 type Writer interface {
@@ -97,7 +102,7 @@ type Fetcher interface {
 
 // A Symbolizer introduces symbol information into a profile.
 type Symbolizer interface {
-	Symbolize(mode string, srcs MappingSources, prof *profile.Profile) error
+	Symbolize(mode string, tlsParam *TLSParams, srcs MappingSources, prof *profile.Profile) error
 }
 
 // MappingSources map each profile.Mapping to the source of the profile.

--- a/internal/symbolizer/symbolizer_test.go
+++ b/internal/symbolizer/symbolizer_test.go
@@ -152,7 +152,7 @@ func TestSymbolization(t *testing.T) {
 		},
 	} {
 		prof := testProfile.Copy()
-		if err := s.Symbolize(tc.mode, nil, prof); err != nil {
+		if err := s.Symbolize(tc.mode, nil, nil, prof); err != nil {
 			t.Errorf("symbolize #%d: %v", i, err)
 			continue
 		}
@@ -164,7 +164,7 @@ func TestSymbolization(t *testing.T) {
 	}
 }
 
-func symbolzMock(p *profile.Profile, force bool, sources plugin.MappingSources, syms func(string, string) ([]byte, error), ui plugin.UI) error {
+func symbolzMock(p *profile.Profile, tlsParam *plugin.TLSParams, force bool, sources plugin.MappingSources, syms func(string, *plugin.TLSParams, string) ([]byte, error), ui plugin.UI) error {
 	var args []string
 	if force {
 		args = append(args, "force")

--- a/internal/symbolz/symbolz_test.go
+++ b/internal/symbolz/symbolz_test.go
@@ -55,7 +55,7 @@ func TestSymbolize(t *testing.T) {
 		for _, force := range []bool{false, true} {
 			p := testProfile(hasFunctions)
 
-			if err := Symbolize(p, force, s, fetchSymbols, &proftest.TestUI{T: t}); err != nil {
+			if err := Symbolize(p, &plugin.TLSParams{}, force, s, fetchSymbols, &proftest.TestUI{T: t}); err != nil {
 				t.Errorf("symbolz: %v", err)
 				continue
 			}
@@ -118,7 +118,7 @@ func checkSymbolized(locs []*profile.Location, wantSymbolized bool) error {
 	return nil
 }
 
-func fetchSymbols(source, post string) ([]byte, error) {
+func fetchSymbols(source string, tlsParam *plugin.TLSParams, post string) ([]byte, error) {
 	var symbolz string
 
 	addresses := strings.Split(post, "+")


### PR DESCRIPTION
As subject says, allows users to pass `-cert` `-key` and `-CA` so that pprof can be used against authenticated TLS endpoints.

Closes https://github.com/golang/go/issues/20939 and https://github.com/google/pprof/issues/244