### PR TITLE
fix: viewer function receiving null node list

### DIFF
--- a/internal/driver/flamegraph.go
+++ b/internal/driver/flamegraph.go
@@ -47,6 +47,7 @@ func (ui *webInterface) flamegraph(w http.ResponseWriter, req *http.Request) {
 	var nodes []*treeNode
 	nroots := 0
 	rootValue := int64(0)
+	nodeArr := []string{}
 	nodeMap := map[*graph.Node]*treeNode{}
 	// Make all nodes and the map, collect the roots.
 	for _, n := range g.Nodes {
@@ -64,6 +65,8 @@ func (ui *webInterface) flamegraph(w http.ResponseWriter, req *http.Request) {
 			rootValue += v
 		}
 		nodeMap[n] = node
+		// Get all node names into an array.
+		nodeArr = append(nodeArr, n.Info.Name)
 	}
 	// Populate the child links.
 	for _, n := range g.Nodes {
@@ -91,5 +94,6 @@ func (ui *webInterface) flamegraph(w http.ResponseWriter, req *http.Request) {
 
 	ui.render(w, "/flamegraph", "flamegraph", rpt, errList, config.Labels, webArgs{
 		FlameGraph: template.JS(b),
+		Nodes:      nodeArr,
 	})
 }


### PR DESCRIPTION
Further testing revealed an issue with the flame graph search function. Since a node list was not being exported anymore after the `call_tree` change, the `selectMatching` function was throwing an exception because the the list was `null`. This is a simple fix, following the same approach as the _dot_ view and exporting the node name list again. The other option would be to move a few functions out of the `{{define "script"}}` template, load them separately in the _dot_ view, and not call the `viewer` function in the flame graph view.

