### PR TITLE
Fix graphviz installation on appveyor tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 clone_folder: c:\go\src\github.com\google\pprof
 
 install:
- - cinst graphviz.portable
+ - cinst graphviz
 
 before_build:
  - go get github.com/ianlancetaylor/demangle


### PR DESCRIPTION
Graphviz has failed to install on appveyor tests, so appveyor does not pass.
This change makes it so graphviz can again be successfully installed on appveyor.