### PR TITLE
Change URL matching code to restore compatibility with old pprof (#276)

### DIFF
--- a/internal/symbolz/symbolz.go
+++ b/internal/symbolz/symbolz.go
@@ -65,7 +65,7 @@ func Symbolize(p *profile.Profile, force bool, sources plugin.MappingSources, sy
 
 // Check whether path ends with one of the suffixes listed in
 // pprof_remote_servers.html from the gperftools distribution
-func hasLegacySuffix(path string) bool {
+func hasGperftoolsSuffix(path string) bool {
 	var suffixes = [...]string{
 		"/pprof/heap",
 		"/pprof/growth",
@@ -84,8 +84,8 @@ func hasLegacySuffix(path string) bool {
 // symbolz returns the corresponding symbolz source for a profile URL.
 func symbolz(source string) string {
 	if url, err := url.Parse(source); err == nil && url.Host != "" {
-		// All paths in the net/http/pprof Go package start with /debug/pprof/
-		if strings.Contains(url.Path, "/debug/pprof/") || hasLegacySuffix(url.Path) {
+		// All paths in the net/http/pprof Go package contain /debug/pprof/
+		if strings.Contains(url.Path, "/debug/pprof/") || hasGperftoolsSuffix(url.Path) {
 			url.Path = path.Clean(url.Path + "/../symbol")
 		} else {
 			url.Path = "/symbolz"

--- a/internal/symbolz/symbolz.go
+++ b/internal/symbolz/symbolz.go
@@ -63,10 +63,29 @@ func Symbolize(p *profile.Profile, force bool, sources plugin.MappingSources, sy
 	return nil
 }
 
+// Check whether path ends with one of the suffixes listed in
+// pprof_remote_servers.html from the gperftools distribution
+func hasLegacySuffix(path string) bool {
+	var suffixes = [...]string {
+		"/pprof/heap",
+		"/pprof/growth",
+		"/pprof/profile",
+		"/pprof/pmuprofile",
+		"/pprof/contention",
+	}
+	for _, s := range suffixes {
+		if strings.HasSuffix(path, s) {
+			return true
+		}
+	}
+	return false
+}
+
 // symbolz returns the corresponding symbolz source for a profile URL.
 func symbolz(source string) string {
 	if url, err := url.Parse(source); err == nil && url.Host != "" {
-		if strings.Contains(url.Path, "/debug/pprof/") || strings.HasSuffix(url.Path, "/pprof/profile") || strings.HasSuffix(url.Path, "/pprof/heap") {
+		// All paths in the net/http/pprof Go package start with /debug/pprof/
+		if strings.Contains(url.Path, "/debug/pprof/") || hasLegacySuffix(url.Path) {
 			url.Path = path.Clean(url.Path + "/../symbol")
 		} else {
 			url.Path = "/symbolz"

--- a/internal/symbolz/symbolz.go
+++ b/internal/symbolz/symbolz.go
@@ -66,7 +66,7 @@ func Symbolize(p *profile.Profile, force bool, sources plugin.MappingSources, sy
 // Check whether path ends with one of the suffixes listed in
 // pprof_remote_servers.html from the gperftools distribution
 func hasGperftoolsSuffix(path string) bool {
-	var suffixes = [...]string{
+	suffixes := []string{
 		"/pprof/heap",
 		"/pprof/growth",
 		"/pprof/profile",

--- a/internal/symbolz/symbolz.go
+++ b/internal/symbolz/symbolz.go
@@ -66,7 +66,7 @@ func Symbolize(p *profile.Profile, force bool, sources plugin.MappingSources, sy
 // symbolz returns the corresponding symbolz source for a profile URL.
 func symbolz(source string) string {
 	if url, err := url.Parse(source); err == nil && url.Host != "" {
-		if strings.Contains(url.Path, "/debug/pprof/") {
+		if strings.Contains(url.Path, "/debug/pprof/") || strings.HasSuffix(url.Path, "/pprof/profile") || strings.HasSuffix(url.Path, "/pprof/heap") {
 			url.Path = path.Clean(url.Path + "/../symbol")
 		} else {
 			url.Path = "/symbolz"

--- a/internal/symbolz/symbolz.go
+++ b/internal/symbolz/symbolz.go
@@ -66,7 +66,7 @@ func Symbolize(p *profile.Profile, force bool, sources plugin.MappingSources, sy
 // Check whether path ends with one of the suffixes listed in
 // pprof_remote_servers.html from the gperftools distribution
 func hasLegacySuffix(path string) bool {
-	var suffixes = [...]string {
+	var suffixes = [...]string{
 		"/pprof/heap",
 		"/pprof/growth",
 		"/pprof/profile",

--- a/internal/symbolz/symbolz_test.go
+++ b/internal/symbolz/symbolz_test.go
@@ -34,6 +34,9 @@ func TestSymbolzURL(t *testing.T) {
 		"http://host:8000/debug/pprof/profile?seconds=10":                         "http://host:8000/debug/pprof/symbol",
 		"http://host:8000/debug/pprof/heap":                                       "http://host:8000/debug/pprof/symbol",
 		"http://some.host:8080/some/deeper/path/debug/pprof/endpoint?param=value": "http://some.host:8080/some/deeper/path/debug/pprof/symbol",
+		"http://host:8000/pprof/profile":                                          "http://host:8000/pprof/symbol",
+		"http://host:8000/pprof/profile?seconds=15":                               "http://host:8000/pprof/symbol",
+		"http://host:8000/pprof/heap":                                             "http://host:8000/pprof/symbol",
 	} {
 		if got := symbolz(try); got != want {
 			t.Errorf(`symbolz(%s)=%s, want "%s"`, try, got, want)

--- a/internal/symbolz/symbolz_test.go
+++ b/internal/symbolz/symbolz_test.go
@@ -37,6 +37,14 @@ func TestSymbolzURL(t *testing.T) {
 		"http://host:8000/pprof/profile":                                          "http://host:8000/pprof/symbol",
 		"http://host:8000/pprof/profile?seconds=15":                               "http://host:8000/pprof/symbol",
 		"http://host:8000/pprof/heap":                                             "http://host:8000/pprof/symbol",
+		"http://host:8000/debug/pprof/block":                                      "http://host:8000/debug/pprof/symbol",
+		"http://host:8000/debug/pprof/trace?seconds=5":                            "http://host:8000/debug/pprof/symbol",
+		"http://host:8000/debug/pprof/mutex":                                      "http://host:8000/debug/pprof/symbol",
+		"http://host/whatever/pprof/heap":                                         "http://host/whatever/pprof/symbol",
+		"http://host/whatever/pprof/growth":                                       "http://host/whatever/pprof/symbol",
+		"http://host/whatever/pprof/profile":                                      "http://host/whatever/pprof/symbol",
+		"http://host/whatever/pprof/pmuprofile":                                   "http://host/whatever/pprof/symbol",
+		"http://host/whatever/pprof/contention":                                   "http://host/whatever/pprof/symbol",
 	} {
 		if got := symbolz(try); got != want {
 			t.Errorf(`symbolz(%s)=%s, want "%s"`, try, got, want)


### PR DESCRIPTION
Here are the changes I have made to restore compatibility with the old pprof. I have left `strings.Contains(url.Path, "/debug/pprof/")` in the condition, together with the two `HasSuffix()` tests I have added. Leaving it seemed like the safe thing to do.