### PR TITLE
Update svgpan, add license, separate pprof-specific code.

### DIFF
--- a/internal/driver/commands.go
+++ b/internal/driver/commands.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/google/pprof/internal/plugin"
 	"github.com/google/pprof/internal/report"
-	"github.com/google/pprof/third_party/svg"
 )
 
 // commands describes the commands accepted by pprof.
@@ -398,7 +397,7 @@ func massageDotSVG() PostProcessor {
 		if err := generateSVG(input, baseSVG, ui); err != nil {
 			return err
 		}
-		_, err := output.Write([]byte(svg.Massage(baseSVG.String())))
+		_, err := output.Write([]byte(massageSVG(baseSVG.String())))
 		return err
 	}
 }

--- a/internal/driver/svg.go
+++ b/internal/driver/svg.go
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package svg provides tools related to handling of SVG files
-package svg
+package driver
 
 import (
 	"regexp"
 	"strings"
+
+	"github.com/google/pprof/third_party/svgpan"
 )
 
 var (
@@ -26,15 +27,15 @@ var (
 	svgClose = regexp.MustCompile(`</svg>`)
 )
 
-// Massage enhances the SVG output from DOT to provide better
-// panning inside a web browser. It uses the SVGPan library, which is
-// embedded into the svgPanJS variable.
-func Massage(svg string) string {
+// massageSVG enhances the SVG output from DOT to provide better
+// panning inside a web browser. It uses the svgpan library, which is
+// embedded into the svgpan.JSSource variable.
+func massageSVG(svg string) string {
 	// Work around for dot bug which misses quoting some ampersands,
 	// resulting on unparsable SVG.
 	svg = strings.Replace(svg, "&;", "&amp;;", -1)
 
-	//Dot's SVG output is
+	// Dot's SVG output is
 	//
 	//    <svg width="___" height="___"
 	//     viewBox="___" xmlns=...>
@@ -48,7 +49,7 @@ func Massage(svg string) string {
 	//    <svg width="100%" height="100%"
 	//     xmlns=...>
 
-	//    <script type="text/ecmascript"><![CDATA[` ..$(svgPanJS)... `]]></script>`
+	//    <script type="text/ecmascript"><![CDATA[` ..$(svgpan.JSSource)... `]]></script>`
 	//    <g id="viewport" transform="translate(0,0)">
 	//    <g id="graph0" transform="...">
 	//    ...
@@ -64,7 +65,7 @@ func Massage(svg string) string {
 
 	if loc := graphID.FindStringIndex(svg); loc != nil {
 		svg = svg[:loc[0]] +
-			`<script type="text/ecmascript"><![CDATA[` + string(svgPanJS) + `]]></script>` +
+			`<script type="text/ecmascript"><![CDATA[` + string(svgpan.JSSource) + `]]></script>` +
 			`<g id="viewport" transform="scale(0.5,0.5) translate(0,0)">` +
 			svg[loc[0]:]
 	}

--- a/third_party/svgpan/LICENSE
+++ b/third_party/svgpan/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2009-2017 Andrea Leofreddi <a.leofreddi@vleo.net>. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+   3. Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those of the
+authors and should not be interpreted as representing official policies, either expressed
+or implied, of Andrea Leofreddi.


### PR DESCRIPTION
The third_party svg directory has been a mix of pprof-specific code and
svgpan itself. This change moves the pprof-specific code out and adds a
license file. It also updates svgpan to 1.2.2 from
https://github.com/aleofreddi/svgpan while we are here. It also renames
the directory to svgpan to have all directories under third_party be
named precisely over the third party package they hold.