### PR TITLE
Cast javascript and css variables to string when using them

### DIFF
--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -21,10 +21,10 @@ import "github.com/google/pprof/third_party/d3flamegraph"
 
 // addTemplates adds a set of template definitions to templates.
 func addTemplates(templates *template.Template) {
-	template.Must(templates.Parse(`{{define "d3script"}}` + d3.JSSource + `{{end}}`))
-	template.Must(templates.Parse(`{{define "d3tipscript"}}` + d3tip.JSSource + `{{end}}`))
-	template.Must(templates.Parse(`{{define "d3flamegraphscript"}}` + d3flamegraph.JSSource + `{{end}}`))
-	template.Must(templates.Parse(`{{define "d3flamegraphcss"}}` + d3flamegraph.CSSSource + `{{end}}`))
+	template.Must(templates.Parse(`{{define "d3script"}}` + string(d3.JSSource) + `{{end}}`))
+	template.Must(templates.Parse(`{{define "d3tipscript"}}` + string(d3tip.JSSource) + `{{end}}`))
+	template.Must(templates.Parse(`{{define "d3flamegraphscript"}}` + string(d3flamegraph.JSSource) + `{{end}}`))
+	template.Must(templates.Parse(`{{define "d3flamegraphcss"}}` + string(d3flamegraph.CSSSource) + `{{end}}`))
 	template.Must(templates.Parse(`
 {{define "css"}}
 <style type="text/css">


### PR DESCRIPTION
When third_party files are overridden in other locations, the type of these variables will be []byte.  Casting to string allows these to be used.