### PR TITLE
internal/driver: ignore temp dir error on Android

### DIFF
--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -412,8 +412,10 @@ func TestHttpsInsecure(t *testing.T) {
 		Symbolize: "remote",
 	}
 	rx := "Saved profile in"
-	if runtime.GOOS == "darwin" && (runtime.GOARCH == "arm" || runtime.GOARCH == "arm64") {
+	if runtime.GOOS == "darwin" && (runtime.GOARCH == "arm" || runtime.GOARCH == "arm64") ||
+		runtime.GOOS == "android" {
 		// On iOS, $HOME points to the app root directory and is not writable.
+		// On Android, $HOME points to / which is not writable.
 		rx += "|Could not use temp dir"
 	}
 	o := &plugin.Options{


### PR DESCRIPTION
On an instance of the Android emulator running x86_64, $HOME points
to / which is not writable. Add Android to the list of GOOS where
the temp dir error is skipped.

Fixes the android/amd64 and android/386 builders on build.golang.org.