### PR TITLE
Support parsing of is_folded bit

### DIFF
--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -168,6 +168,7 @@ func doLocalSymbolize(prof *profile.Profile, fast, force bool, obj plugin.ObjToo
 		}
 
 		l.Line = make([]profile.Line, len(stack))
+		l.IsFolded = false
 		for i, frame := range stack {
 			if frame.Func != "" {
 				m.HasFunctions = true

--- a/profile/encode.go
+++ b/profile/encode.go
@@ -494,7 +494,7 @@ var locationDecoder = []decoder{
 		pp.Line = append(pp.Line, Line{})
 		return decodeMessage(b, &pp.Line[n])
 	},
-	func(b *buffer, m message) error { return decodeBool(b, &m.(*Location).IsFolded) },
+	func(b *buffer, m message) error { return decodeBool(b, &m.(*Location).IsFolded) }, // optional bool is_folded = 5;
 }
 
 func (p *Line) decoder() []decoder {

--- a/profile/encode.go
+++ b/profile/encode.go
@@ -480,6 +480,7 @@ func (p *Location) encode(b *buffer) {
 	for i := range p.Line {
 		encodeMessage(b, 4, &p.Line[i])
 	}
+	encodeBoolOpt(b, 5, p.IsFolded)
 }
 
 var locationDecoder = []decoder{
@@ -493,6 +494,7 @@ var locationDecoder = []decoder{
 		pp.Line = append(pp.Line, Line{})
 		return decodeMessage(b, &pp.Line[n])
 	},
+	func(b *buffer, m message) error { return decodeBool(b, &m.(*Location).IsFolded) },
 }
 
 func (p *Line) decoder() []decoder {

--- a/profile/merge.go
+++ b/profile/merge.go
@@ -234,10 +234,11 @@ func (pm *profileMerger) mapLocation(src *Location) *Location {
 
 	mi := pm.mapMapping(src.Mapping)
 	l := &Location{
-		ID:      uint64(len(pm.p.Location) + 1),
-		Mapping: mi.m,
-		Address: uint64(int64(src.Address) + mi.offset),
-		Line:    make([]Line, len(src.Line)),
+		ID:       uint64(len(pm.p.Location) + 1),
+		Mapping:  mi.m,
+		Address:  uint64(int64(src.Address) + mi.offset),
+		Line:     make([]Line, len(src.Line)),
+		IsFolded: src.IsFolded,
 	}
 	for i, ln := range src.Line {
 		l.Line[i] = pm.mapLine(ln)
@@ -258,7 +259,8 @@ func (pm *profileMerger) mapLocation(src *Location) *Location {
 // key generates locationKey to be used as a key for maps.
 func (l *Location) key() locationKey {
 	key := locationKey{
-		addr: l.Address,
+		addr:     l.Address,
+		isFolded: l.IsFolded,
 	}
 	if l.Mapping != nil {
 		// Normalizes address to handle address space randomization.
@@ -279,6 +281,7 @@ func (l *Location) key() locationKey {
 type locationKey struct {
 	addr, mappingID uint64
 	lines           string
+	isFolded        bool
 }
 
 func (pm *profileMerger) mapMapping(src *Mapping) mapInfo {

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -592,6 +592,9 @@ func (l *Location) string() string {
 	if m := l.Mapping; m != nil {
 		locStr = locStr + fmt.Sprintf("M=%d ", m.ID)
 	}
+	if l.IsFolded {
+		locStr = locStr + "(folded) "
+	}
 	if len(l.Line) == 0 {
 		ss = append(ss, locStr)
 	}

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -593,7 +593,7 @@ func (l *Location) string() string {
 		locStr = locStr + fmt.Sprintf("M=%d ", m.ID)
 	}
 	if l.IsFolded {
-		locStr = locStr + "(folded) "
+		locStr = locStr + "[F] "
 	}
 	if len(l.Line) == 0 {
 		ss = append(ss, locStr)

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -109,10 +109,11 @@ type Mapping struct {
 
 // Location corresponds to Profile.Location
 type Location struct {
-	ID      uint64
-	Mapping *Mapping
-	Address uint64
-	Line    []Line
+	ID       uint64
+	Mapping  *Mapping
+	Address  uint64
+	Line     []Line
+	IsFolded bool
 
 	mappingIDX uint64
 }

--- a/profile/profile_test.go
+++ b/profile/profile_test.go
@@ -275,53 +275,6 @@ var cpuL = []*Location{
 	},
 }
 
-var cpuLFolded = []*Location{
-	{
-		ID:      1000,
-		Mapping: cpuM[1],
-		Address: 0x1000,
-		Line: []Line{
-			{Function: cpuF[0], Line: 1},
-		},
-	},
-	{
-		ID:      2000,
-		Mapping: cpuM[0],
-		Address: 0x2000,
-		Line: []Line{
-			{Function: cpuF[1], Line: 2},
-			{Function: cpuF[2], Line: 1},
-		},
-		IsFolded: true,
-	},
-	{
-		ID:      3000,
-		Mapping: cpuM[0],
-		Address: 0x3000,
-		Line: []Line{
-			{Function: cpuF[1], Line: 2},
-			{Function: cpuF[2], Line: 1},
-		},
-		IsFolded: true,
-	},
-	{
-		ID:      3001,
-		Mapping: cpuM[0],
-		Address: 0x3001,
-		Line: []Line{
-			{Function: cpuF[2], Line: 2},
-		},
-	},
-	{
-		ID:      3002,
-		Mapping: cpuM[0],
-		Address: 0x3002,
-		Line: []Line{
-			{Function: cpuF[2], Line: 3},
-		},
-	},
-}
-
 var testProfile1 = &Profile{
 	PeriodType:    &ValueType{Type: "cpu", Unit: "milliseconds"},
 	Period:        1,
@@ -429,61 +382,6 @@ var testProfile1NoMapping = &Profile{
 	},
 	Location: cpuL,
 	Function: cpuF,
-}
-
-var testProfile1Folded = &Profile{
-	PeriodType:    &ValueType{Type: "cpu", Unit: "milliseconds"},
-	Period:        1,
-	DurationNanos: 10e9,
-	SampleType: []*ValueType{
-		{Type: "samples", Unit: "count"},
-		{Type: "cpu", Unit: "milliseconds"},
-	},
-	Sample: []*Sample{
-		{
-			Location: []*Location{cpuLFolded[0]},
-			Value:    []int64{1000, 1000},
-			Label: map[string][]string{
-				"key1": {"tag1"},
-				"key2": {"tag1"},
-			},
-		},
-		{
-			Location: []*Location{cpuLFolded[1], cpuLFolded[0]},
-			Value:    []int64{100, 100},
-			Label: map[string][]string{
-				"key1": {"tag2"},
-				"key3": {"tag2"},
-			},
-		},
-		{
-			Location: []*Location{cpuLFolded[2], cpuLFolded[0]},
-			Value:    []int64{10, 10},
-			Label: map[string][]string{
-				"key1": {"tag3"},
-				"key2": {"tag2"},
-			},
-		},
-		{
-			Location: []*Location{cpuLFolded[3], cpuLFolded[0]},
-			Value:    []int64{10000, 10000},
-			Label: map[string][]string{
-				"key1": {"tag4"},
-				"key2": {"tag1"},
-			},
-		},
-		{
-			Location: []*Location{cpuLFolded[4], cpuL[0]},
-			Value:    []int64{1, 1},
-			Label: map[string][]string{
-				"key1": {"tag4"},
-				"key2": {"tag1"},
-			},
-		},
-	},
-	Location: cpuLFolded,
-	Function: cpuF,
-	Mapping:  cpuM,
 }
 
 var testProfile2 = &Profile{
@@ -784,6 +682,10 @@ func TestMergeAll(t *testing.T) {
 }
 
 func TestIsFoldedMerge(t *testing.T) {
+	testProfile1Folded := testProfile1.Copy()
+	testProfile1Folded.Location[0].IsFolded = true
+	testProfile1Folded.Location[1].IsFolded = true
+
 	for _, tc := range []struct {
 		name            string
 		profs           []*Profile

--- a/profile/proto_test.go
+++ b/profile/proto_test.go
@@ -52,6 +52,8 @@ var testF = []*Function{
 	{ID: 1, Name: "func1", SystemName: "func1", Filename: "file1"},
 	{ID: 2, Name: "func2", SystemName: "func2", Filename: "file1"},
 	{ID: 3, Name: "func3", SystemName: "func3", Filename: "file2"},
+	{ID: 4, Name: "func4", SystemName: "func4", Filename: "file3"},
+	{ID: 5, Name: "func5", SystemName: "func5", Filename: "file4"},
 }
 
 var testL = []*Location{
@@ -85,6 +87,22 @@ var testL = []*Location{
 		ID:      3,
 		Mapping: testM[1],
 		Address: 12,
+	},
+	{
+		ID:      4,
+		Mapping: testM[1],
+		Address: 12,
+		Line: []Line{
+			{
+				Function: testF[4],
+				Line:     6,
+			},
+			{
+				Function: testF[4],
+				Line:     6,
+			},
+		},
+		IsFolded: true,
 	},
 }
 

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -118,7 +118,7 @@ message Label {
   // Should only be present when num is present.
   // Specifies the units of num.
   // Use arbitrary string (for example, "requests") as a custom count unit.
-  // If no unit is specificed, consumer may apply heuristic to deduce the unit.
+  // If no unit is specified, consumer may apply heuristic to deduce the unit.
   // Consumers may also  interpret units like "bytes" and "kilobytes" as memory
   // units and units like "seconds" and "nanoseconds" as time units,
   // and apply appropriate unit conversions to these.

--- a/proto/profile.proto
+++ b/proto/profile.proto
@@ -1,3 +1,8 @@
+// Copyright (c) 2016, Google Inc.
+// All rights reserved.
+//
+////////////////////////////////////////////////////////////////////////////////
+
 // Profile is a common stacktrace profile format.
 //
 // Measurements represented with this format should follow the
@@ -113,7 +118,7 @@ message Label {
   // Should only be present when num is present.
   // Specifies the units of num.
   // Use arbitrary string (for example, "requests") as a custom count unit.
-  // If no unit is specified, consumer may apply heuristic to deduce the unit.
+  // If no unit is specificed, consumer may apply heuristic to deduce the unit.
   // Consumers may also  interpret units like "bytes" and "kilobytes" as memory
   // units and units like "seconds" and "nanoseconds" as time units,
   // and apply appropriate unit conversions to these.
@@ -151,7 +156,7 @@ message Location {
   // instruction addresses or any integer sequence as ids.
   uint64 id = 1;
   // The id of the corresponding profile.Mapping for this location.
-  // If can be unset if the mapping is unknown or not applicable for
+  // It can be unset if the mapping is unknown or not applicable for
   // this profile type.
   uint64 mapping_id = 2;
   // The instruction address for this location, if available.  It
@@ -168,6 +173,12 @@ message Location {
   //    line[0].function_name == "memcpy"
   //    line[1].function_name == "printf"
   repeated Line line = 4;
+  // Provides an indication that multiple symbols map to this location's
+  // address, for example due to identical code folding by the linker. In that
+  // case the line information above represents one of the multiple
+  // symbols. This field must be recomputed when the symbolization state of the
+  // profile changes.
+  bool is_folded = 5;
 }
 
 message Line {


### PR DESCRIPTION
Modified pprof to keep is_folded bit during encoding and decoding, factor in is_folded bit during merges, and print is_folded bit when converting profile to string. 