### PR TITLE
internal/driver: fix new unkeyed composite lit vet warnings

### DIFF
--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -1487,8 +1487,14 @@ func (m *mockFile) Symbols(r *regexp.Regexp, addr uint64) ([]*plugin.Sym, error)
 	switch r.String() {
 	case "line[13]":
 		return []*plugin.Sym{
-			{[]string{"line1000"}, m.name, 0x1000, 0x1003},
-			{[]string{"line3000"}, m.name, 0x3000, 0x3004},
+			{
+				Name: []string{"line1000"}, File: m.name,
+				Start: 0x1000, End: 0x1003,
+			},
+			{
+				Name: []string{"line3000"}, File: m.name,
+				Start: 0x3000, End: 0x3004,
+			},
 		}, nil
 	}
 	return nil, fmt.Errorf("unimplemented")

--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -143,9 +143,18 @@ func (f fakeObj) SourceLine(addr uint64) ([]plugin.Frame, error) {
 }
 func (f fakeObj) Symbols(r *regexp.Regexp, addr uint64) ([]*plugin.Sym, error) {
 	return []*plugin.Sym{
-		{[]string{"F1"}, fakeSource, addrBase, addrBase + 10},
-		{[]string{"F2"}, fakeSource, addrBase + 10, addrBase + 20},
-		{[]string{"F3"}, fakeSource, addrBase + 20, addrBase + 30},
+		{
+			Name: []string{"F1"}, File: fakeSource,
+			Start: addrBase, End: addrBase + 10,
+		},
+		{
+			Name: []string{"F2"}, File: fakeSource,
+			Start: addrBase + 10, End: addrBase + 20,
+		},
+		{
+			Name: []string{"F3"}, File: fakeSource,
+			Start: addrBase + 20, End: addrBase + 30,
+		},
 	}, nil
 }
 


### PR DESCRIPTION
The current version of go vet does not flag these as noted in
golang/go#23539. A fix is in the works, and will likely be included in
Go 1.11. Make the updated vet tool happy, so that the vendored copy of
pprof in the Go tree can be updated and make the vet trybot happy.

Fixes #297.