### PR TITLE
Pass text segment info to GetBase to handle Linux kernel ASLR case.

### DIFF
--- a/internal/binutils/binutils.go
+++ b/internal/binutils/binutils.go
@@ -215,7 +215,7 @@ func (b *binrep) openELF(name string, start, limit, offset uint64) (plugin.ObjFi
 		}
 	}
 
-	base, err := elfexec.GetBase(&ef.FileHeader, nil, stextOffset, start, limit, offset)
+	base, err := elfexec.GetBase(&ef.FileHeader, elfexec.FindTextProgHeader(ef), stextOffset, start, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("Could not identify base for %s: %v", name, err)
 	}

--- a/internal/elfexec/elfexec.go
+++ b/internal/elfexec/elfexec.go
@@ -259,3 +259,19 @@ func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint6
 	}
 	return 0, fmt.Errorf("Don't know how to handle FileHeader.Type %v", fh.Type)
 }
+
+// FindTextProgHeader finds the program segment header containing the .text
+// section or nil if the segment cannot be found.
+func FindTextProgHeader(f *elf.File) *elf.ProgHeader {
+	for _, s := range f.Sections {
+		if s.Name == ".text" {
+			// Find the LOAD segment containing the .text section.
+			for _, p := range f.Progs {
+				if p.Type == elf.PT_LOAD && p.Flags&elf.PF_X != 0 && s.Addr >= p.Vaddr && s.Addr < p.Vaddr+p.Memsz {
+					return &p.ProgHeader
+				}
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
When pprof symbolizes kernel addresses in vmlinux binary for a profile
converted using https://github.com/google/perf_data_converter, the
addresses need to be adjusted if kernel ASLR is in effect. So far the
call to GetBase did not pass text segment info to GetBase which
shortcircuited the code to merely return zero adjustment. This change
fixes the call to GetBase to address that.

The added test case is an approximation of what happens with vmlinux,
but it should be pretty close. Including a vmlinux file into the test data
does not appear practical due to the binary size. I verified that the test
failed before the fix and passes after.

Note that the fixed issue is specific to the kernel ASLR as user-mode
ASRL-enabled binaries (i.e. built with -pie / -fpie) have ET_DYN type
which takes a different code path in GetBase which did not have issues
before this fix in practice.