### PR TITLE
Skip tests requiring tcp unless environment variable set to indicate tcp available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: go
 
 go_import_path: github.com/google/pprof
 
-env: SKIP_GRAPHVIZ=0
+env: 
+ - SKIP_GRAPHVIZ=0
+ - TCP_AVAILABLE=true
 
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,4 +10,5 @@ build_script:
  - go build github.com/google/pprof
 
 test_script:
+  - cmd: set TCP_AVAILABLE="true"
   - go test -v ./...

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -31,6 +31,7 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -359,7 +360,7 @@ func closedError() string {
 }
 
 func TestHttpsInsecure(t *testing.T) {
-	if runtime.GOOS == "nacl" {
+	if tcpAvailable, err := strconv.ParseBool(os.Getenv("TCP_AVAILABLE")); err == nil && tcpAvailable {
 		t.Skip("test assumes tcp available")
 	}
 

--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -21,9 +21,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"os/exec"
 	"regexp"
-	"runtime"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -32,7 +33,7 @@ import (
 )
 
 func TestWebInterface(t *testing.T) {
-	if runtime.GOOS == "nacl" {
+	if tcpAvailable, err := strconv.ParseBool(os.Getenv("TCP_AVAILABLE")); err == nil && tcpAvailable {
 		t.Skip("test assumes tcp available")
 	}
 


### PR DESCRIPTION
A number of issues have been filed related to tests failing on environments (in the past, on nacl) where TCP is not available. (For example, #144, #200, #251)

With #300, tests are also failing on openbsd, windows, and freebsd.

This fixes #300 by only running tests requiring tcp (specifically TestHttpsInsecure and TestWebInterface) if a flag is set to indicate tcp is available. This also updates .travis.yml and appveyor.yml so TestHttpsInsecure and TestWebInterface are still run on travis and appveyor.
