### PR TITLE
Detect concatenated profile and give clearer error message

### DIFF
--- a/profile/encode.go
+++ b/profile/encode.go
@@ -214,7 +214,12 @@ var profileDecoder = []decoder{
 	// int64 keep_frames = 8
 	func(b *buffer, m message) error { return decodeInt64(b, &m.(*Profile).keepFramesX) },
 	// int64 time_nanos = 9
-	func(b *buffer, m message) error { return decodeInt64(b, &m.(*Profile).TimeNanos) },
+	func(b *buffer, m message) error {
+		if m.(*Profile).TimeNanos != 0 {
+			return ErrConcatProfile
+		}
+		return decodeInt64(b, &m.(*Profile).TimeNanos)
+	},
 	// int64 duration_nanos = 10
 	func(b *buffer, m message) error { return decodeInt64(b, &m.(*Profile).DurationNanos) },
 	// ValueType period_type = 11

--- a/profile/encode.go
+++ b/profile/encode.go
@@ -216,7 +216,7 @@ var profileDecoder = []decoder{
 	// int64 time_nanos = 9
 	func(b *buffer, m message) error {
 		if m.(*Profile).TimeNanos != 0 {
-			return ErrConcatProfile
+			return errConcatProfile
 		}
 		return decodeInt64(b, &m.(*Profile).TimeNanos)
 	},

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -164,7 +164,7 @@ func ParseData(data []byte) (*Profile, error) {
 			return nil, fmt.Errorf("decompressing profile: %v", err)
 		}
 	}
-	if p, err = ParseUncompressed(data); err != nil && err != errNoData && err != ErrConcatProfile {
+	if p, err = ParseUncompressed(data); err != nil && err != errNoData && err != errConcatProfile {
 		p, err = parseLegacy(data)
 	}
 
@@ -181,9 +181,7 @@ func ParseData(data []byte) (*Profile, error) {
 var errUnrecognized = fmt.Errorf("unrecognized profile format")
 var errMalformed = fmt.Errorf("malformed profile format")
 var errNoData = fmt.Errorf("empty input file")
-
-// ErrConcatProfile is the error returned when a concatenated profile is detected.
-var ErrConcatProfile = fmt.Errorf("concatenated profiles detected")
+var errConcatProfile = fmt.Errorf("concatenated profiles detected")
 
 func parseLegacy(data []byte) (*Profile, error) {
 	parsers := []func([]byte) (*Profile, error){

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -164,7 +164,7 @@ func ParseData(data []byte) (*Profile, error) {
 			return nil, fmt.Errorf("decompressing profile: %v", err)
 		}
 	}
-	if p, err = ParseUncompressed(data); err != nil && err != errNoData {
+	if p, err = ParseUncompressed(data); err != nil && err != errNoData && err != ErrConcatProfile {
 		p, err = parseLegacy(data)
 	}
 
@@ -181,6 +181,9 @@ func ParseData(data []byte) (*Profile, error) {
 var errUnrecognized = fmt.Errorf("unrecognized profile format")
 var errMalformed = fmt.Errorf("malformed profile format")
 var errNoData = fmt.Errorf("empty input file")
+
+// ErrConcatProfile is the error returned when a concatenated profile is detected.
+var ErrConcatProfile = fmt.Errorf("concatenated profiles detected")
 
 func parseLegacy(data []byte) (*Profile, error) {
 	parsers := []func([]byte) (*Profile, error){

--- a/profile/profile_test.go
+++ b/profile/profile_test.go
@@ -110,7 +110,6 @@ func TestParseError(t *testing.T) {
 
 func TestParseConcatentated(t *testing.T) {
 	prof := testProfile1.Copy()
-	prof.TimeNanos = 10000
 	// Write the profile twice to buffer to create concatented profile.
 	buf := bytes.NewBuffer(nil)
 	prof.Write(buf)
@@ -292,6 +291,7 @@ var cpuL = []*Location{
 }
 
 var testProfile1 = &Profile{
+	TimeNanos:     10000,
 	PeriodType:    &ValueType{Type: "cpu", Unit: "milliseconds"},
 	Period:        1,
 	DurationNanos: 10e9,

--- a/profile/profile_test.go
+++ b/profile/profile_test.go
@@ -108,6 +108,22 @@ func TestParseError(t *testing.T) {
 	}
 }
 
+func TestParseConcatentated(t *testing.T) {
+	prof := testProfile1.Copy()
+	prof.TimeNanos = 10000
+	// Write the profile twice to buffer to create concatented profile.
+	buf := bytes.NewBuffer(nil)
+	prof.Write(buf)
+	prof.Write(buf)
+	_, err := Parse(buf)
+	if err == nil {
+		t.Fatalf("got nil, want error")
+	}
+	if got, want := err.Error(), "parsing profile: concatenated profiles detected"; want != got {
+		t.Fatalf("got error %q, want error %q", got, want)
+	}
+}
+
 func TestCheckValid(t *testing.T) {
 	const path = "testdata/java.cpu"
 


### PR DESCRIPTION
This change detects concatenated profiles by checking if time_nanos appears more than once in the profile being parsed. 

Fixes #273 