### PR TITLE
Set base address on OSX

### DIFF
--- a/internal/binutils/binutils.go
+++ b/internal/binutils/binutils.go
@@ -172,6 +172,21 @@ func (bu *Binutils) Open(name string, start, limit, offset uint64) (plugin.ObjFi
 	return nil, fmt.Errorf("unrecognized binary: %s", name)
 }
 
+// Base address of the __TEXT section. Usually 0 for shared libraries
+// of 0x100000000 for executables. You can check this value by
+// running `objdump -private-headers <file>`.
+func getTextAddress(of *macho.File) uint64 {
+	for _, ld := range of.Loads {
+		switch s := ld.(type) {
+		case *macho.Segment:
+			if s.Name == "__TEXT" {
+				return s.Addr
+			}
+		}
+	}
+	return 0
+}
+
 func (b *binrep) openMachO(name string, start, limit, offset uint64) (plugin.ObjFile, error) {
 	of, err := macho.Open(name)
 	if err != nil {
@@ -179,10 +194,12 @@ func (b *binrep) openMachO(name string, start, limit, offset uint64) (plugin.Obj
 	}
 	defer of.Close()
 
+	base := start - getTextAddress(of)
+
 	if b.fast || (!b.addr2lineFound && !b.llvmSymbolizerFound) {
-		return &fileNM{file: file{b: b, name: name}}, nil
+		return &fileNM{file: file{b: b, name: name, base: base}}, nil
 	}
-	return &fileAddr2Line{file: file{b: b, name: name}}, nil
+	return &fileAddr2Line{file: file{b: b, name: name, base: base}}, nil
 }
 
 func (b *binrep) openELF(name string, start, limit, offset uint64) (plugin.ObjFile, error) {


### PR DESCRIPTION
This fixes issue #311. The mapped address of libraries was never considered, nor was the load address of the segments.