### PR TITLE
Read response from http.Get() in TestWebInterface, so http.Get() does not hang

### DIFF
--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -119,7 +119,10 @@ func TestWebInterface(t *testing.T) {
 		for count := 0; count < 2; count++ {
 			wg.Add(1)
 			go func() {
-				http.Get(path)
+				res, err := http.Get(path)
+				if err == nil {
+					ioutil.ReadAll(res.Body)
+				}
 				wg.Done()
 			}()
 		}

--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -120,8 +120,13 @@ func TestWebInterface(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				res, err := http.Get(path)
-				if err == nil {
-					ioutil.ReadAll(res.Body)
+				if err != nil {
+					t.Error("could not fetch", c.path, err)
+					wg.Done()
+					return
+				}
+				if _, err = ioutil.ReadAll(res.Body); err != nil {
+					t.Error("could not read response", c.path, err)
 				}
 				wg.Done()
 			}()

--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -119,16 +119,15 @@ func TestWebInterface(t *testing.T) {
 		for count := 0; count < 2; count++ {
 			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				res, err := http.Get(path)
 				if err != nil {
 					t.Error("could not fetch", c.path, err)
-					wg.Done()
 					return
 				}
 				if _, err = ioutil.ReadAll(res.Body); err != nil {
 					t.Error("could not read response", c.path, err)
 				}
-				wg.Done()
 			}()
 		}
 	}


### PR DESCRIPTION
This fixes test failure described in #300.

The response from http.Get() was not previously read, which caused http.Get() to hang forever.