### PR TITLE
Install graphviz on xcode7.3 and xcode8.3 travis builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: go
 
 go_import_path: github.com/google/pprof
 
-env: SKIP_GRAPHVIZ=0
-
 matrix:
   include:
     - os: linux
@@ -52,8 +50,8 @@ addons:
       
 before_install:
   - go get -u github.com/golang/lint/golint honnef.co/go/tools/cmd/...   
-  - if (("$TRAVIS_OS_NAME" == "osx") && (!"$SKIP_GRAPHVIZ")); then brew update          ; fi
-  - if (("$TRAVIS_OS_NAME" == "osx") && (!"$SKIP_GRAPHVIZ")); then brew install graphviz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && (-z $SKIP_GRAPHVIZ) ]]; then brew update          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && (-z $SKIP_GRAPHVIZ) ]]; then brew install graphviz; fi
 
 script:
   - gofmtdiff=$(gofmt -s -d .) && if [ -n "$gofmtdiff" ]; then printf 'gofmt -s found:\n%s\n' "$gofmtdiff" && exit 1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ addons:
       
 before_install:
   - go get -u github.com/golang/lint/golint honnef.co/go/tools/cmd/...   
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && (-z $SKIP_GRAPHVIZ) ]]; then brew update          ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && (-z $SKIP_GRAPHVIZ) ]]; then brew install graphviz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && -z $SKIP_GRAPHVIZ ]]; then brew update          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && -z $SKIP_GRAPHVIZ ]]; then brew install graphviz; fi
 
 script:
   - gofmtdiff=$(gofmt -s -d .) && if [ -n "$gofmtdiff" ]; then printf 'gofmt -s found:\n%s\n' "$gofmtdiff" && exit 1; fi


### PR DESCRIPTION
PR #270 want meant to stop installing graphviz on xcode6.4 to fix #255.

However, #270 also stopped graphviz from being installed on  xcode7.3 and xcode8.3 (issue #317).

This PR modifies .travis.yml so graphviz is installed on   xcode7.3 and xcode8.3.

Completed build: https://travis-ci.org/nolanmar511/pprof/builds/339568567
I confirmed that TestWebInterface ran on all linux builds, all xcode7.3 and xcode8.3 builds, but not on any xcode6.4 builds.

