### PR TITLE
Add a separate function to binutils to check if a file is an executable

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -123,6 +123,12 @@ type MappingSources map[string][]struct {
 
 // An ObjTool inspects shared libraries and executable files.
 type ObjTool interface {
+	// ExecutableBuildID returns the build id associated to an executable.
+	// It returns err != nil if the file can't be recognized as an executable.
+	// It returns err == nil and an empty string if the file is an executable but
+	// the build id could not be determined.
+	ExecutableBuildID(file string) (string, error)
+
 	// Open opens the named object file. If the object is a shared
 	// library, start/limit/offset are the addresses where it is mapped
 	// into memory in the address space being inspected.

--- a/internal/binutils/binutils_test.go
+++ b/internal/binutils/binutils_test.go
@@ -293,8 +293,12 @@ func TestMachoFiles(t *testing.T) {
 			}},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
+			filename := filepath.Join("testdata", tc.file)
 			bu := &Binutils{}
-			f, err := bu.Open(filepath.Join("testdata", tc.file), tc.start, tc.limit, tc.offset)
+			if _, err := bu.ExecutableBuildID(filename); err != nil {
+				t.Fatalf("ExecutableBuildID: couldn't recognize %s: %v", filename, err)
+			}
+			f, err := bu.Open(filename, tc.start, tc.limit, tc.offset)
 			if err != nil {
 				t.Fatalf("Open: unexpected error %v", err)
 			}

--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -92,8 +92,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 	// Recognize first argument as an executable or buildid override.
 	if len(args) > 1 {
 		arg0 := args[0]
-		if file, err := o.Obj.Open(arg0, 0, ^uint64(0), 0); err == nil {
-			file.Close()
+		if _, err := o.Obj.ExecutableBuildID(arg0); err == nil {
 			execName = arg0
 			args = args[1:]
 		} else if *flagBuildID == "" && isBuildID(arg0) {

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -1425,6 +1425,10 @@ func TestSymbolzAfterMerge(t *testing.T) {
 
 type mockObjTool struct{}
 
+func (mockObjTool) ExecutableBuildID(file string) (string, error) {
+	return "", nil
+}
+
 func (*mockObjTool) Open(file string, start, limit, offset uint64) (plugin.ObjFile, error) {
 	return &mockFile{file, "abcdef", 0}, nil
 }

--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -417,9 +417,7 @@ mapping:
 				fileNames = append(fileNames, filepath.Join(path, m.File))
 			}
 			for _, name := range fileNames {
-				if f, err := obj.Open(name, m.Start, m.Limit, m.Offset); err == nil {
-					defer f.Close()
-					fileBuildID := f.BuildID()
+				if fileBuildID, err := obj.ExecutableBuildID(name); err == nil {
 					if m.BuildID != "" && m.BuildID != fileBuildID {
 						ui.PrintErr("Ignoring local file " + name + ": build-id mismatch (" + m.BuildID + " != " + fileBuildID + ")")
 					} else {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -109,6 +109,12 @@ type MappingSources map[string][]struct {
 
 // An ObjTool inspects shared libraries and executable files.
 type ObjTool interface {
+	// ExecutableBuildID returns the build id associated to an executable.
+	// It returns err != nil if the file can't be recognized as an executable.
+	// It returns err == nil and an empty string if the file is an executable but
+	// the build id could not be determined.
+	ExecutableBuildID(file string) (string, error)
+
 	// Open opens the named object file. If the object is a shared
 	// library, start/limit/offset are the addresses where it is mapped
 	// into memory in the address space being inspected.
@@ -130,7 +136,7 @@ type Inst struct {
 
 // An ObjFile is a single object file: a shared library or executable.
 type ObjFile interface {
-	// Name returns the underlyinf file name, if available
+	// Name returns the underlying file name, if available
 	Name() string
 
 	// Base returns the base address to use when looking up symbols in the file.

--- a/internal/symbolizer/symbolizer_test.go
+++ b/internal/symbolizer/symbolizer_test.go
@@ -263,6 +263,10 @@ func frame(fname, file string, line int) plugin.Frame {
 
 type mockObjTool struct{}
 
+func (mockObjTool) ExecutableBuildID(file string) (string, error) {
+	return "", nil
+}
+
 func (mockObjTool) Open(file string, start, limit, offset uint64) (plugin.ObjFile, error) {
 	return mockObjFile{frames: mockAddresses}, nil
 }


### PR DESCRIPTION
Currently bu.Open() is used to detect if a file is an executable,
but it depends on the mapping, which is not available before opening
the input profiles.

Create a separate ExecutableBuildID function on the ObjTool interface that only
does a basic check to see if a binary is an executable, and extracts the build
id if available.

This produces better diagnostics if there are issues with the mappings, as we
will still recognize the file as a binary.