### PR TITLE
Use o.Writer if not nil to write output

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -20,6 +20,7 @@ package driver
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -138,7 +139,15 @@ func generateReport(p *profile.Profile, cmd []string, vars variables, o *plugin.
 
 	// Output to specified file.
 	o.UI.PrintErr("Generating report in ", output)
-	out, err := os.Create(output)
+
+	openOutput := func(output string) (io.WriteCloser, error) {
+		if o.Writer != nil {
+			return o.Writer.Open(output)
+		}
+		return os.Create(output)
+	}
+
+	out, err := openOutput(output)
 	if err != nil {
 		return err
 	}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -20,7 +20,6 @@ package driver
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -139,15 +138,7 @@ func generateReport(p *profile.Profile, cmd []string, vars variables, o *plugin.
 
 	// Output to specified file.
 	o.UI.PrintErr("Generating report in ", output)
-
-	openOutput := func(output string) (io.WriteCloser, error) {
-		if o.Writer != nil {
-			return o.Writer.Open(output)
-		}
-		return os.Create(output)
-	}
-
-	out, err := openOutput(output)
+	out, err := o.Writer.Open(output)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#329 (The function internal/driver.generateReport does not use o.Writer to write output)