### PR TITLE
Update perf_to_profile cli arguments to use flags. (#277)

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -534,7 +534,9 @@ func convertPerfData(perfPath string, ui plugin.UI) (*os.File, error) {
 		return nil, err
 	}
 	deferDeleteTempFile(profile.Name())
-	cmd := exec.Command("perf_to_profile", perfPath, profile.Name())
+	cmd := exec.Command("perf_to_profile", "-i", perfPath, "-o", profile.Name(), "-f")
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
 	if err := cmd.Run(); err != nil {
 		profile.Close()
 		return nil, fmt.Errorf("failed to convert perf.data file. Try github.com/google/perf_data_converter: %v", err)

--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -535,8 +535,7 @@ func convertPerfData(perfPath string, ui plugin.UI) (*os.File, error) {
 	}
 	deferDeleteTempFile(profile.Name())
 	cmd := exec.Command("perf_to_profile", "-i", perfPath, "-o", profile.Name(), "-f")
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	if err := cmd.Run(); err != nil {
 		profile.Close()
 		return nil, fmt.Errorf("failed to convert perf.data file. Try github.com/google/perf_data_converter: %v", err)


### PR DESCRIPTION
Fixes #277
As perf_to_profile uses flags to parse its arguments, modify the call to perf_to_profile to use flags. Also pass the '-f' flag to overwrite the existing output profile file.
Redirect perf_to_profile's stdout/stderr to pprof's stdout/stderr.

Tested by executing pprof with a perf.data:
Eg:
perf record -e cycles -o perf.data -- sleep 1
./pprof perf.data