### PR TITLE
internal/driver: allow local symbolization with perf path format

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -407,6 +407,7 @@ mapping:
 				if matches, err := filepath.Glob(filepath.Join(path, m.BuildID, "*")); err == nil {
 					fileNames = append(fileNames, matches...)
 				}
+				fileNames = append(fileNames, filepath.Join(path, m.File, m.BuildID)) // perf path format
 			}
 			if m.File != "" {
 				// Try both the basename and the full path, to support the same directory


### PR DESCRIPTION
pprof can not find a dependency in the format created by perf.

pprof checks:
`path/m.BuildID/Base(m.File)`
`path/Base(m.File)`
`path/m.File`

But perf build path in format:
`path/m.File/m.BuildID`

For example:
`RELPATH/usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0/fd6376149047833953b0269e84de181ca45dbe90`
