### PR TITLE
internal/driver: suggest sample_index in case empty default samples

### DIFF
--- a/internal/driver/interactive.go
+++ b/internal/driver/interactive.go
@@ -149,9 +149,14 @@ func greetings(p *profile.Profile, ui plugin.UI) {
 	numLabelUnits := identifyNumLabelUnits(p, ui)
 	ropt, err := reportOptions(p, numLabelUnits, pprofVariables)
 	if err == nil {
-		ui.Print(strings.Join(report.ProfileLabels(report.New(p, ropt)), "\n"))
+		rpt := report.New(p, ropt)
+		ui.Print(strings.Join(report.ProfileLabels(rpt), "\n"))
+		if rpt.Total() == 0 && len(p.SampleType) > 1 {
+			ui.Print(`No samples were found with the default sample value type.`)
+			ui.Print(`Try "sample_index" command to analyze different sample values.`, "\n")
+		}
 	}
-	ui.Print("Entering interactive mode (type \"help\" for commands, \"o\" for options)")
+	ui.Print(`Entering interactive mode (type "help" for commands, "o" for options)`)
 }
 
 // shortcuts represents composite commands that expand into a sequence


### PR DESCRIPTION
In the interactive mode, inform users of different sample types
if the profile includes zero samples for selected sample type
by default (or through user-provided sample_index flag value).

The example output may look like

$ pprof mem.prof
Type: inuse_space
Time: Mar 20, 2018 at 11:36am (EDT)

No samples were found with the default sample value type.
Try "sample_index" command to analyze different sample values.

Entering interactive mode (type "help" for commands, "o" for options)
(pprof)

Update golang/go#24443

I believe ultimately the profile producer should annotate the profile 
with the appropriate default index. I hope this helps users to learn about the 
next step when encountering zero sample issues reported in the bug 
until then.