### PR TITLE
symbolz: skip un-symbolizable mappings

### DIFF
--- a/internal/symbolz/symbolz.go
+++ b/internal/symbolz/symbolz.go
@@ -38,11 +38,16 @@ var (
 // symbolz handler. syms receives the symbolz query (hex addresses
 // separated by '+') and returns the symbolz output in a string. If
 // force is false, it will only symbolize locations from mappings
-// not already marked as HasFunctions.
+// not already marked as HasFunctions. Never attempts symbolization of
+// any symbols found in unsymbolizable system mappings.
 func Symbolize(p *profile.Profile, force bool, sources plugin.MappingSources, syms func(string, string) ([]byte, error), ui plugin.UI) error {
 	for _, m := range p.Mapping {
 		if !force && m.HasFunctions {
 			// Only check for HasFunctions as symbolz only populates function names.
+			continue
+		}
+		// Skip well-known system mappings.
+		if m.Unsymbolizable() {
 			continue
 		}
 		mappingSources := sources[m.File]


### PR DESCRIPTION
This fixes https://github.com/google/pprof/issues/339 by skipping
attempts to symbolize anything from system mappings like [vdso],
[vsyscall], etc.