### PR TITLE
Introduce (UI).WantBrowser

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -218,6 +218,9 @@ type UI interface {
 	// interactive terminal (as opposed to being redirected to a file).
 	IsTerminal() bool
 
+	// WantBrowser indicates whether browser should be opened with the -http option.
+	WantBrowser() bool
+
 	// SetAutoComplete instructs the UI to call complete(cmd) to obtain
 	// the auto-completion of cmd, if the UI supports auto-completion at all.
 	SetAutoComplete(complete func(string) string)

--- a/internal/driver/options.go
+++ b/internal/driver/options.go
@@ -128,6 +128,10 @@ func (ui *stdUI) IsTerminal() bool {
 	return false
 }
 
+func (ui *stdUI) WantBrowser() bool {
+	return true
+}
+
 func (ui *stdUI) SetAutoComplete(func(string) string) {
 }
 

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -117,7 +117,7 @@ func serveWebInterface(hostport string, p *profile.Profile, o *plugin.Options) e
 		},
 	}
 
-	if o.UI.IsTerminal() {
+	if o.UI.WantBrowser() {
 		go openBrowser("http://"+args.Hostport, o)
 	}
 	return server(args)

--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -28,14 +28,9 @@ import (
 	"testing"
 
 	"github.com/google/pprof/internal/plugin"
+	"github.com/google/pprof/internal/proftest"
 	"github.com/google/pprof/profile"
 )
-
-type nonTerminalUI struct {
-	plugin.UI
-}
-
-func (*nonTerminalUI) IsTerminal() bool { return false }
 
 func TestWebInterface(t *testing.T) {
 	if runtime.GOOS == "nacl" {
@@ -61,7 +56,7 @@ func TestWebInterface(t *testing.T) {
 	// Start server and wait for it to be initialized
 	go serveWebInterface("unused:1234", prof, &plugin.Options{
 		Obj:        fakeObjTool{},
-		UI:         &nonTerminalUI{&stdUI{}}, // don't open browser
+		UI:         &proftest.TestUI{},
 		HTTPServer: creator,
 	})
 	<-serverCreated

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -192,6 +192,9 @@ type UI interface {
 	// interactive terminal (as opposed to being redirected to a file).
 	IsTerminal() bool
 
+	// WantBrowser indicates whether a browser should be opened with the -http option.
+	WantBrowser() bool
+
 	// SetAutoComplete instructs the UI to call complete(cmd) to obtain
 	// the auto-completion of cmd, if the UI supports auto-completion at all.
 	SetAutoComplete(complete func(string) string)

--- a/internal/proftest/proftest.go
+++ b/internal/proftest/proftest.go
@@ -130,6 +130,11 @@ func (ui *TestUI) IsTerminal() bool {
 	return false
 }
 
+// WantBrowser indicates whether a browser should be opened with the -http option.
+func (ui *TestUI) WantBrowser() bool {
+	return false
+}
+
 // SetAutoComplete is not supported by the test UI.
 func (ui *TestUI) SetAutoComplete(_ func(string) string) {
 }


### PR DESCRIPTION
This fixes a bug introduced in #341 which caused the browser
opening code to be disabled for the standard `pprof -http`
invocation.

Introduce a proper getter on the UI which determines whether
the browser ought to be opened.