### PR TITLE
Detect when binutils are not installed on OSX and skip the test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ matrix:
     - os: osx
       osx_image: xcode8.3
       go: master
+    - os: osx
+      env: SKIP_BINUTILS=1
+      go: master
 
 addons:
   apt:
@@ -51,7 +54,7 @@ addons:
 before_install:
   - go get -u github.com/golang/lint/golint honnef.co/go/tools/cmd/...
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install binutils ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && -z $SKIP_BINUTILS ]]; then brew install binutils ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && -z $SKIP_GRAPHVIZ ]]; then brew install graphviz; fi
 
 script:

--- a/internal/binutils/binutils.go
+++ b/internal/binutils/binutils.go
@@ -81,6 +81,26 @@ func (bu *Binutils) update(fn func(r *binrep)) {
 	bu.rep = r
 }
 
+// String returns string representation of the binutils state for debug logging.
+func (bu *Binutils) String() string {
+	r := bu.get()
+	var llvmSymbolizer, addr2line, nm, objdump string
+	if r.llvmSymbolizerFound {
+		llvmSymbolizer = r.llvmSymbolizer
+	}
+	if r.addr2lineFound {
+		addr2line = r.addr2line
+	}
+	if r.nmFound {
+		nm = r.nm
+	}
+	if r.objdumpFound {
+		objdump = r.objdump
+	}
+	return fmt.Sprintf("llvm-symbolizer=%q addr2line=%q nm=%q objdump=%q fast=%t",
+		llvmSymbolizer, addr2line, nm, objdump, r.fast)
+}
+
 // SetFastSymbolization sets a toggle that makes binutils use fast
 // symbolization (using nm), which is much faster than addr2line but
 // provides only symbol name information (no file/line).

--- a/internal/binutils/binutils_test.go
+++ b/internal/binutils/binutils_test.go
@@ -298,6 +298,13 @@ func TestMachoFiles(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Open: unexpected error %v", err)
 			}
+			t.Logf("binutils: %v", bu)
+			if runtime.GOOS == "darwin" && !bu.rep.addr2lineFound && !bu.rep.llvmSymbolizerFound {
+				// On OSX user needs to install gaddr2line or llvm-symbolizer with
+				// Homebrew, skip the test when the environment doesn't have it
+				// installed.
+				t.Skip("couldn't find addr2line or gaddr2line")
+			}
 			defer f.Close()
 			syms, err := f.Symbols(nil, 0)
 			if err != nil {


### PR DESCRIPTION
Fixes #342.