### PR TITLE
Update -help to list correct paths searched within PPROF_BINARY_PATH.

### DIFF
--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -316,5 +316,5 @@ var usageMsgVars = "\n\n" +
 	"   PPROF_TOOLS        Search path for object-level tools\n" +
 	"   PPROF_BINARY_PATH  Search path for local binary files\n" +
 	"                      default: $HOME/pprof/binaries\n" +
-	"                      finds binaries by $name and $buildid/$name\n" +
+	"                      searches $name, $path, $buildid/$name, $path/$buildid\n" +
 	"   * On Windows, %USERPROFILE% is used instead of $HOME"


### PR DESCRIPTION
The code was updated in #335 but the doc wasn't updated. Also the doc
didn't include $path which is searched as well, see locateBinaries in
internal/driver/fetch.go.