### PR TITLE
Hack the code so that both existing Go versions and current Go master format it the same

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -599,9 +599,9 @@ var httpGet = func(source string, timeout time.Duration) (*http.Response, error)
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			ResponseHeaderTimeout: timeout + 5*time.Second,
 			Proxy:                 http.ProxyFromEnvironment,
 			TLSClientConfig:       tlsConfig,
+			ResponseHeaderTimeout: timeout + 5*time.Second,
 		},
 	}
 	return client.Get(source)

--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -600,8 +600,8 @@ var httpGet = func(source string, timeout time.Duration) (*http.Response, error)
 	client := &http.Client{
 		Transport: &http.Transport{
 			ResponseHeaderTimeout: timeout + 5*time.Second,
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: tlsConfig,
+			Proxy:                 http.ProxyFromEnvironment,
+			TLSClientConfig:       tlsConfig,
 		},
 	}
 	return client.Get(source)


### PR DESCRIPTION
Starting around yesterday, CI fails with Go master version - https://travis-ci.org/google/pprof/jobs/363261750. Apparently there was a fix in Go that change how this specific place in code is formatted. The new version does make sense, but failing CI is bad, so hack the code fragment to make it formatted the same with all Go versions. Yep, it's a hack.