### PR TITLE
Add ShowFrom and HideFrom filters to profile filter lib

### DIFF
--- a/internal/driver/driver_focus.go
+++ b/internal/driver/driver_focus.go
@@ -40,7 +40,7 @@ func applyFocus(prof *profile.Profile, numLabelUnits map[string]string, v variab
 		return err
 	}
 
-	fm, im, hm, hnm := prof.FilterSamplesByName(focus, ignore, hide, show)
+	fm, im, _, _, hnm, hm := prof.FilterSamplesByName(focus, ignore, nil, nil, show, hide)
 	warnNoMatches(focus == nil || fm, "Focus", ui)
 	warnNoMatches(ignore == nil || im, "Ignore", ui)
 	warnNoMatches(hide == nil || hm, "Hide", ui)


### PR DESCRIPTION
- Added HideFrom and ShowFrom filters.
- They are not yet exposed as command line flags. This change is pretty big so I thought it would be helpful to keep it minimal but I could add that here if desired. I plan to add that in another change.
- Added lots of test cases for interactions between filters, as well as handling of locations with empty lines.