### PR TITLE
add -diff flag for better profile comparision

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -216,6 +216,36 @@ search for them in a directory pointed to by the environment variable
 * **-weblist= _regex_:** Generates a source/assembly combined annotated listing for
   functions matching *regex*, and starts a web browser to display it.
 
+## Comparing profiles
+
+pprof can subtract one profile's samples from another in order to compare them.
+For that, use the **-diff_base= _profile_** option, where *profile* is the filename
+or URL for the profile to be subtracted (referred to as the base profile). When
+using this mode, percentages reported in the output will be relative to the
+total of the base profile. To separate samples that are part of the diff base
+profile from those in the source profile, a string tag, "base"="1" is added to
+all samples in the base profile. This means that if one saves the merged profile
+and looks at it again with pprof, it will still be treated as a profile with a 
+diff base. It also means that any other samples which also have this tag will
+be treated as part of the diff base profile.
+
+If one is interested in the relative differences between the source and base
+profiles (for example, which profile has a larger percentage of CPU time used
+in a particular function), it can be useful to use the **-normalize** option.
+With this option, the source profile is scaled so that the total of samples in
+the source profile is equal to the total of samples in the base profile prior
+to merging the profiles.
+
+When comparing two cumulative profiles, for example two contention profiles
+collected from the same program at different times, use the **-base** flag
+in place of the **-diff_base** flag. When this flag is used and no negative
+values appear in the merged profile when aggregated at the address-level, 
+which would be the case when comparing cummulative profiles collected from the
+same program, percentages reported will be relative to the the difference
+between the total for the source profile and the total for the base profile.
+In the general case, percentages will be relative to the total of the absolute
+value of all samples when aggregated at the address level.
+
 # Fetching profiles
 
 pprof can read profiles from a file or directly from a URL over http. Its native
@@ -236,11 +266,6 @@ If multiple profiles are specified, pprof will fetch them all and merge
 them. This is useful to combine profiles from multiple processes of a
 distributed job. The profiles may be from different programs but must be
 compatible (for example, CPU profiles cannot be combined with heap profiles).
-
-pprof can subtract a profile from another in order to compare them. For that,
-use the **-base= _profile_** option, where *profile* is the filename or URL for the
-profile to be subtracted. This may result on some report entries having negative
-values.
 
 ## Symbolization
 
@@ -286,4 +311,3 @@ the symbolization handler.
 
 * **-symbolize=demangle=templates:** Demangle, and trim function parameters, but
   not template parameters.
-

--- a/doc/README.md
+++ b/doc/README.md
@@ -240,38 +240,42 @@ compatible (for example, CPU profiles cannot be combined with heap profiles).
 
 ## Comparing profiles
 
-pprof can subtract a profile from another, provided the profiles are of 
-compatible types, in order to compare them. For that, use the 
-**-diff_base= _profile_** option, where *profile* is the filename or URL for the
-profile to be subtracted. This may result in some report entries having negative
-values. Percentages in the report are relative to the total of 
-the diff base. 
+pprof can subtract one profile from another, provided the profiles are of
+compatible types. pprof has two options which can be used to specify the
+filename or URL for a profile to be subtracted from the source profile:
 
-If the merged profile is output as a protocol buffer, all samples in
-the diff base profile will have a label with the key "pprof::base" and a value
-of "true". If pprof is then used to look at the merged profile, it will behave
-as if separate source and base profiles were passed in.
+* **-diff_base= _profile_:** useful for comparing any two profiles of compatible
+types (i.e. any two heap profiles). Percentages in the output are relative to
+the total of samples in the diff base profile.
 
-The **-base** option can be used in the place of the **-diff_base** option, and
-may be preferrable when comparing two cumulative profiles, for example two
-contention profiles collected from the same program at different times. When 
-this flag is used and no negative values appear in the merged profile when
-aggregated at the address-level, percentages reported will be relative to the 
-the difference between the total for the source profile and the total for the
-base profile. In the general case, percentages will be relative to the total of
-the absolute value of all samples when aggregated at the address level.
+* **-base= _profile_:** useful for subtracting a cumulative profile, like a
+[golang block profile](https://golang.org/doc/diagnostics.html#profiling),
+from another cumulative profile collected from the same program at a later time.
+When comparing cumulative profiles collected on the same profile, percentages in
+the output are relative to the the difference between the total for the source
+profile and the total for the base profile.
 
-The **-normalize** option can be useful for determining the relative differences 
-between profiles, for example, which profile has a larger percentage of CPU time
-used in a particular function. With this option, the source profile is scaled so
-that the total of samples in the source profile is equal to the total of samples
-in the base profile prior to merging the profiles. 
+The following flag can be used when a base profile is specified with either the
+`-diff_base` or the `-base` option:
 
-This flag can be only be used when a diff base or a base profile is specified, 
-so for example:
+* **-normalize**: Scales the source profile so that that the total of samples 
+in the source profile is equal to the total of samples in the base profile prior
+to subtracting the base profile from the source profile. Useful for determining
+the relative differences between profiles, for example, which profile has a
+larger percentage of CPU time used in a particular function.
 
-    pprof <format> -normalize -diff_base=base source
-    
+When using the **-diff_base** option, some report entries may have negative
+values. If the merged profile is output as a protocol buffer, all samples in the
+diff base profile will have a label with the key "pprof::base" and a value of
+"true". If pprof is then used to look at the merged profile, it will behave as
+if separate source and base profiles were passed in.
+
+When using the **-base** option to subtract one cumulative profile from another
+collected on the same program at a later time, percentages will be relative to
+the difference between the total for the source profile and the total for
+the base profile, and all values will be positive. In the general case, some 
+report entries may have negative values and percentages will be relative to the
+total of the absolute value of all samples when aggregated at the address level.
 
 ## Symbolization
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -216,35 +216,9 @@ search for them in a directory pointed to by the environment variable
 * **-weblist= _regex_:** Generates a source/assembly combined annotated listing for
   functions matching *regex*, and starts a web browser to display it.
 
-## Comparing profiles
-
-pprof can subtract one profile's samples from another in order to compare them.
-For that, use the **-diff_base= _profile_** option, where *profile* is the filename
-or URL for the profile to be subtracted (referred to as the base profile). When
-using this mode, percentages reported in the output will be relative to the
-total of the base profile. To separate samples that are part of the diff base
-profile from those in the source profile, a string tag, "base"="1" is added to
-all samples in the base profile. This means that if one saves the merged profile
-and looks at it again with pprof, it will still be treated as a profile with a 
-diff base. It also means that any other samples which also have this tag will
-be treated as part of the diff base profile.
-
-If one is interested in the relative differences between the source and base
-profiles (for example, which profile has a larger percentage of CPU time used
-in a particular function), it can be useful to use the **-normalize** option.
-With this option, the source profile is scaled so that the total of samples in
-the source profile is equal to the total of samples in the base profile prior
-to merging the profiles.
-
-When comparing two cumulative profiles, for example two contention profiles
-collected from the same program at different times, use the **-base** flag
-in place of the **-diff_base** flag. When this flag is used and no negative
-values appear in the merged profile when aggregated at the address-level, 
-which would be the case when comparing cummulative profiles collected from the
-same program, percentages reported will be relative to the the difference
-between the total for the source profile and the total for the base profile.
-In the general case, percentages will be relative to the total of the absolute
-value of all samples when aggregated at the address level.
+Samples in a profile may have tags. These tags have a name and a value; this
+value can be either numeric or a string. pprof can select samples from a
+profile based on these tags using the `-tagfocus` and `-tagignore` options.
 
 # Fetching profiles
 
@@ -266,6 +240,42 @@ If multiple profiles are specified, pprof will fetch them all and merge
 them. This is useful to combine profiles from multiple processes of a
 distributed job. The profiles may be from different programs but must be
 compatible (for example, CPU profiles cannot be combined with heap profiles).
+
+
+## Comparing profiles
+
+pprof can subtract a profile from another, provided the profiles are of 
+compatible types, in order to compare them. For that, use the 
+**-diff_base= _profile_** option, where *profile* is the filename or URL for the
+profile to be subtracted. This may result in some report entries having negative
+values.  Percentages in the report are relative to the total of 
+the diff base. 
+
+If the merged profile is output as a protocol buffer, all samples in 
+the diff base profile will have a label with the key "base" and a value of "1".
+If pprof is then used to look at the merged profile, it will behave as if 
+separate source and base profiles were passed in. 
+
+The **-base** option can be used in the place of the **-diff_base** option, and
+may be preferrable when comparing two cumulative profiles, for example two
+contention profiles collected from the same program at different times. When 
+this flag is used and no negative values appear in the merged profile when
+aggregated at the address-level, percentages reported will be relative to the 
+the difference between the total for the source profile and the total for the
+base profile. In the general case, percentages will be relative to the total of
+the absolute value of all samples when aggregated at the address level.
+
+The **-normalize** option can be useful for determining the relative differences 
+between profiles, for example, which profile has a larger percentage of CPU time
+used in a particular function. With this option, the source profile is scaled so
+that the total of samples in the source profile is equal to the total of samples
+in the base profile prior to merging the profiles. 
+
+This flag can be only be used when a diff base or a base profile is specified, 
+so for example:
+
+    pprof <format> -normalize -diff_base=base source
+    
 
 ## Symbolization
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -216,6 +216,44 @@ search for them in a directory pointed to by the environment variable
 * **-weblist= _regex_:** Generates a source/assembly combined annotated listing for
   functions matching *regex*, and starts a web browser to display it.
 
+## Comparing profiles
+
+pprof can subtract one profile from another, provided the profiles are of
+compatible types (i.e. two heap profiles). pprof has two options which can be
+used to specify the filename or URL for a profile to be subtracted from the
+source profile:
+
+* **-diff_base= _profile_:** useful for comparing two profiles. Percentages in
+the output are relative to the total of samples in the diff base profile.
+
+* **-base= _profile_:** useful for subtracting a cumulative profile, like a
+[golang block profile](https://golang.org/doc/diagnostics.html#profiling),
+from another cumulative profile collected from the same program at a later time.
+When comparing cumulative profiles collected on the same profile, percentages in
+the output are relative to the difference between the total for the source
+profile and the total for the base profile.
+
+The **-normalize** flag can be used when a base profile is specified with either 
+the `-diff_base` or the `-base` option. This flag scales the source profile so
+that the total of samples in the source profile is equal to the total of samples
+in the base profile prior to subtracting the base profile from the source
+profile. Useful for determining the relative differences between profiles, for
+example, which profile has a larger percentage of CPU time used in a particular
+function.
+
+When using the **-diff_base** option, some report entries may have negative
+values. If the merged profile is output as a protocol buffer, all samples in the
+diff base profile will have a label with the key "pprof::base" and a value of
+"true". If pprof is then used to look at the merged profile, it will behave as
+if separate source and base profiles were passed in.
+
+When using the **-base** option to subtract one cumulative profile from another
+collected on the same program at a later time, percentages will be relative to
+the difference between the total for the source profile and the total for
+the base profile, and all values will be positive. In the general case, some 
+report entries may have negative values and percentages will be relative to the
+total of the absolute value of all samples when aggregated at the address level.
+
 # Fetching profiles
 
 pprof can read profiles from a file or directly from a URL over http. Its native
@@ -236,46 +274,6 @@ If multiple profiles are specified, pprof will fetch them all and merge
 them. This is useful to combine profiles from multiple processes of a
 distributed job. The profiles may be from different programs but must be
 compatible (for example, CPU profiles cannot be combined with heap profiles).
-
-
-## Comparing profiles
-
-pprof can subtract one profile from another, provided the profiles are of
-compatible types. pprof has two options which can be used to specify the
-filename or URL for a profile to be subtracted from the source profile:
-
-* **-diff_base= _profile_:** useful for comparing any two profiles of compatible
-types (i.e. any two heap profiles). Percentages in the output are relative to
-the total of samples in the diff base profile.
-
-* **-base= _profile_:** useful for subtracting a cumulative profile, like a
-[golang block profile](https://golang.org/doc/diagnostics.html#profiling),
-from another cumulative profile collected from the same program at a later time.
-When comparing cumulative profiles collected on the same profile, percentages in
-the output are relative to the the difference between the total for the source
-profile and the total for the base profile.
-
-The following flag can be used when a base profile is specified with either the
-`-diff_base` or the `-base` option:
-
-* **-normalize**: Scales the source profile so that that the total of samples 
-in the source profile is equal to the total of samples in the base profile prior
-to subtracting the base profile from the source profile. Useful for determining
-the relative differences between profiles, for example, which profile has a
-larger percentage of CPU time used in a particular function.
-
-When using the **-diff_base** option, some report entries may have negative
-values. If the merged profile is output as a protocol buffer, all samples in the
-diff base profile will have a label with the key "pprof::base" and a value of
-"true". If pprof is then used to look at the merged profile, it will behave as
-if separate source and base profiles were passed in.
-
-When using the **-base** option to subtract one cumulative profile from another
-collected on the same program at a later time, percentages will be relative to
-the difference between the total for the source profile and the total for
-the base profile, and all values will be positive. In the general case, some 
-report entries may have negative values and percentages will be relative to the
-total of the absolute value of all samples when aggregated at the address level.
 
 ## Symbolization
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -229,7 +229,7 @@ the output are relative to the total of samples in the diff base profile.
 * **-base= _profile_:** useful for subtracting a cumulative profile, like a
 [golang block profile](https://golang.org/doc/diagnostics.html#profiling),
 from another cumulative profile collected from the same program at a later time.
-When comparing cumulative profiles collected on the same profile, percentages in
+When comparing cumulative profiles collected on the same program, percentages in
 the output are relative to the difference between the total for the source
 profile and the total for the base profile.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -216,10 +216,6 @@ search for them in a directory pointed to by the environment variable
 * **-weblist= _regex_:** Generates a source/assembly combined annotated listing for
   functions matching *regex*, and starts a web browser to display it.
 
-Samples in a profile may have tags. These tags have a name and a value; this
-value can be either numeric or a string. pprof can select samples from a
-profile based on these tags using the `-tagfocus` and `-tagignore` options.
-
 # Fetching profiles
 
 pprof can read profiles from a file or directly from a URL over http. Its native
@@ -248,13 +244,13 @@ pprof can subtract a profile from another, provided the profiles are of
 compatible types, in order to compare them. For that, use the 
 **-diff_base= _profile_** option, where *profile* is the filename or URL for the
 profile to be subtracted. This may result in some report entries having negative
-values.  Percentages in the report are relative to the total of 
+values. Percentages in the report are relative to the total of 
 the diff base. 
 
-If the merged profile is output as a protocol buffer, all samples in 
-the diff base profile will have a label with the key "base" and a value of "1".
-If pprof is then used to look at the merged profile, it will behave as if 
-separate source and base profiles were passed in. 
+If the merged profile is output as a protocol buffer, all samples in
+the diff base profile will have a label with the key "pprof::base" and a value
+of "true". If pprof is then used to look at the merged profile, it will behave
+as if separate source and base profiles were passed in.
 
 The **-base** option can be used in the place of the **-diff_base** option, and
 may be preferrable when comparing two cumulative profiles, for example two

--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -142,7 +142,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 		Comment:      *flagAddComment,
 	}
 
-	if err := source.addBaseProfiles(flagBase, flagDiffBase); err != nil {
+	if err := source.addBaseProfiles(*flagBase, *flagDiffBase); err != nil {
 		return nil, nil, err
 	}
 
@@ -161,9 +161,9 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 // addBaseProfiles adds the list of base profiles or diff base profiles to
 // the source. This function will return an error if both base and diff base
 // profiles are specified.
-func (source *source) addBaseProfiles(flagBase, flagDiffBase *[]*string) error {
-	base := parseStringListFlag(flagBase)
-	diffBase := parseStringListFlag(flagDiffBase)
+func (source *source) addBaseProfiles(flagBase, flagDiffBase []*string) error {
+	base := dropEmpty(flagBase)
+	diffBase := dropEmpty(flagDiffBase)
 
 	if len(base) > 0 && len(diffBase) > 0 {
 		return fmt.Errorf("-base and -diff_base flags cannot both be specified")
@@ -177,11 +177,11 @@ func (source *source) addBaseProfiles(flagBase, flagDiffBase *[]*string) error {
 	return nil
 }
 
-// parseStringListFlag list takes a StringList flag, and outputs an array of non-empty
+// dropEmpty list takes a StringList flag, and outputs an array of non-empty
 // strings associated with the flag.
-func parseStringListFlag(list *[]*string) []string {
+func dropEmpty(list []*string) []string {
 	var l []string
-	for _, s := range *list {
+	for _, s := range list {
 		if *s != "" {
 			l = append(l, *s)
 		}

--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -142,18 +142,28 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 		Comment:      *flagAddComment,
 	}
 
-	if len(*flagBase) > 0 && len(*flagDiff) > 0 {
-		return nil, nil, fmt.Errorf("only -base or -diff flag can be specified")
-	}
-	base := *flagBase
-	if len(*flagDiff) > 0 {
-		base = *flagDiff
-		source.DiffBase = true
-	}
-	for _, s := range base {
+	var base []string
+	for _, s := range *flagBase {
 		if *s != "" {
-			source.Base = append(source.Base, *s)
+			base = append(base, *s)
 		}
+	}
+
+	var diff []string
+	for _, s := range *flagDiff {
+		if *s != "" {
+			diff = append(diff, *s)
+		}
+	}
+
+	if len(base) > 0 && len(diff) > 0 {
+		return nil, nil, fmt.Errorf("-base and -diff flags cannot both be specified")
+	}
+
+	source.Base = base
+	if len(diff) > 0 {
+		source.Base = diff
+		source.DiffBase = true
 	}
 
 	normalize := pprofVariables["normalize"].boolValue()

--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -15,6 +15,7 @@
 package driver
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -87,7 +88,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 			usageMsgVars)
 	})
 	if len(args) == 0 {
-		return nil, nil, fmt.Errorf("no profile source specified")
+		return nil, nil, errors.New("no profile source specified")
 	}
 
 	var execName string
@@ -114,7 +115,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 		return nil, nil, err
 	}
 	if cmd != nil && *flagHTTP != "" {
-		return nil, nil, fmt.Errorf("-http is not compatible with an output format on the command line")
+		return nil, nil, errors.New("-http is not compatible with an output format on the command line")
 	}
 
 	si := pprofVariables["sample_index"].value
@@ -148,7 +149,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 
 	normalize := pprofVariables["normalize"].boolValue()
 	if normalize && len(source.Base) == 0 {
-		return nil, nil, fmt.Errorf("Must have base profile to normalize by")
+		return nil, nil, errors.New("Must have base profile to normalize by")
 	}
 	source.Normalize = normalize
 
@@ -162,17 +163,15 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 // the source. This function will return an error if both base and diff base
 // profiles are specified.
 func (source *source) addBaseProfiles(flagBase, flagDiffBase []*string) error {
-	base := dropEmpty(flagBase)
-	diffBase := dropEmpty(flagDiffBase)
+	base, diffBase := dropEmpty(flagBase), dropEmpty(flagDiffBase)
 
 	if len(base) > 0 && len(diffBase) > 0 {
-		return fmt.Errorf("-base and -diff_base flags cannot both be specified")
+		return errors.New("-base and -diff_base flags cannot both be specified")
 	}
 
 	source.Base = base
 	if len(diffBase) > 0 {
-		source.Base = diffBase
-		source.DiffBase = true
+		source.Base, source.DiffBase = diffBase, true
 	}
 	return nil
 }
@@ -271,7 +270,7 @@ func outputFormat(bcmd map[string]*bool, acmd map[string]*string) (cmd []string,
 	for n, b := range bcmd {
 		if *b {
 			if cmd != nil {
-				return nil, fmt.Errorf("must set at most one output format")
+				return nil, errors.New("must set at most one output format")
 			}
 			cmd = []string{n}
 		}
@@ -279,7 +278,7 @@ func outputFormat(bcmd map[string]*bool, acmd map[string]*string) (cmd []string,
 	for n, s := range acmd {
 		if *s != "" {
 			if cmd != nil {
-				return nil, fmt.Errorf("must set at most one output format")
+				return nil, errors.New("must set at most one output format")
 			}
 			cmd = []string{n, *s}
 		}

--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -45,7 +45,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 	flag := o.Flagset
 	// Comparisons.
 	flagBase := flag.StringList("base", "", "Source for base profile for profile subtraction")
-	flagDiff := flag.StringList("diff", "", "Source for base profile for comparison")
+	flagDiffBase := flag.StringList("diff_base", "", "Source for diff base profile for comparison")
 	// Source options.
 	flagSymbolize := flag.String("symbolize", "", "Options for profile symbolization")
 	flagBuildID := flag.String("buildid", "", "Override build id for first mapping")
@@ -149,20 +149,20 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 		}
 	}
 
-	var diff []string
-	for _, s := range *flagDiff {
+	var diffBase []string
+	for _, s := range *flagDiffBase {
 		if *s != "" {
-			diff = append(diff, *s)
+			diffBase = append(diffBase, *s)
 		}
 	}
 
-	if len(base) > 0 && len(diff) > 0 {
-		return nil, nil, fmt.Errorf("-base and -diff flags cannot both be specified")
+	if len(base) > 0 && len(diffBase) > 0 {
+		return nil, nil, fmt.Errorf("-base and -diff_base flags cannot both be specified")
 	}
 
 	source.Base = base
-	if len(diff) > 0 {
-		source.Base = diff
+	if len(diffBase) > 0 {
+		source.Base = diffBase
 		source.DiffBase = true
 	}
 

--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -149,7 +149,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 
 	normalize := pprofVariables["normalize"].boolValue()
 	if normalize && len(source.Base) == 0 {
-		return nil, nil, errors.New("Must have base profile to normalize by")
+		return nil, nil, errors.New("must have base profile to normalize by")
 	}
 	source.Normalize = normalize
 
@@ -164,7 +164,6 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 // profiles are specified.
 func (source *source) addBaseProfiles(flagBase, flagDiffBase []*string) error {
 	base, diffBase := dropEmpty(flagBase), dropEmpty(flagDiffBase)
-
 	if len(base) > 0 && len(diffBase) > 0 {
 		return errors.New("-base and -diff_base flags cannot both be specified")
 	}
@@ -176,8 +175,8 @@ func (source *source) addBaseProfiles(flagBase, flagDiffBase []*string) error {
 	return nil
 }
 
-// dropEmpty list takes a StringList flag, and outputs an array of non-empty
-// strings associated with the flag.
+// dropEmpty list takes a slice of string pointers, and outputs a slice of
+// non-empty strings associated with the flag.
 func dropEmpty(list []*string) []string {
 	var l []string
 	for _, s := range list {

--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -28,6 +28,7 @@ type source struct {
 	ExecName  string
 	BuildID   string
 	Base      []string
+	DiffBase  bool
 	Normalize bool
 
 	Seconds      int
@@ -43,7 +44,8 @@ type source struct {
 func parseFlags(o *plugin.Options) (*source, []string, error) {
 	flag := o.Flagset
 	// Comparisons.
-	flagBase := flag.StringList("base", "", "Source for base profile for comparison")
+	flagBase := flag.StringList("base", "", "Source for base profile for profile subtraction")
+	flagDiff := flag.StringList("diff", "", "Source for base profile for comparison")
 	// Source options.
 	flagSymbolize := flag.String("symbolize", "", "Options for profile symbolization")
 	flagBuildID := flag.String("buildid", "", "Override build id for first mapping")
@@ -140,7 +142,15 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 		Comment:      *flagAddComment,
 	}
 
-	for _, s := range *flagBase {
+	if len(*flagBase) > 0 && len(*flagDiff) > 0 {
+		return nil, nil, fmt.Errorf("only -base or -diff flag can be specified")
+	}
+	base := *flagBase
+	if len(*flagDiff) > 0 {
+		base = *flagDiff
+		source.DiffBase = true
+	}
+	for _, s := range base {
 		if *s != "" {
 			source.Base = append(source.Base, *s)
 		}

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -355,6 +355,7 @@ func (f testFlags) StringVar(p *string, s, d, c string) {
 
 func (f testFlags) StringList(s, d, c string) *[]*string {
 	if t, ok := f.stringLists[s]; ok {
+		// convert slice of strings to slice of string pointers before returning.
 		tp := make([]*string, len(t))
 		for i, v := range t {
 			tp[i] = &v

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -288,7 +288,7 @@ type testFlags struct {
 	floats      map[string]float64
 	strings     map[string]string
 	args        []string
-	stringLists map[string][]*string
+	stringLists map[string][]string
 }
 
 func (testFlags) ExtraUsage() string { return "" }
@@ -355,7 +355,11 @@ func (f testFlags) StringVar(p *string, s, d, c string) {
 
 func (f testFlags) StringList(s, d, c string) *[]*string {
 	if t, ok := f.stringLists[s]; ok {
-		return &t
+		tp := make([]*string, len(t))
+		for i, v := range t {
+			tp[i] = &v
+		}
+		return &tp
 	}
 	return &[]*string{}
 }

--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -136,7 +136,7 @@ func grabSourcesAndBases(sources, bases []profileSource, isDiffBase bool, fetch 
 		defer wg.Done()
 		pbase, mbase, savebase, countbase, errbase = chunkedGrab(bases, fetch, obj, ui)
 		if pbase != nil && isDiffBase {
-			pbase.AddTag("pprof::diff", "true")
+			pbase.SetTag("pprof::diff", []string{"true"})
 		}
 	}()
 	wg.Wait()

--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -136,7 +136,7 @@ func grabSourcesAndBases(sources, bases []profileSource, isDiffBase bool, fetch 
 		defer wg.Done()
 		pbase, mbase, savebase, countbase, errbase = chunkedGrab(bases, fetch, obj, ui)
 		if pbase != nil && isDiffBase {
-			pbase.SetTag("base", []string{"1"})
+			pbase.SetTag("pprof::base", []string{"true"})
 		}
 	}()
 	wg.Wait()

--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -57,7 +57,7 @@ func fetchProfiles(s *source, o *plugin.Options) (*profile.Profile, error) {
 		})
 	}
 
-	p, pbase, m, mbase, save, err := grabSourcesAndBases(sources, bases, o.Fetch, o.Obj, o.UI)
+	p, pbase, m, mbase, save, err := grabSourcesAndBases(sources, bases, s.DiffBase, o.Fetch, o.Obj, o.UI)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func fetchProfiles(s *source, o *plugin.Options) (*profile.Profile, error) {
 	return p, nil
 }
 
-func grabSourcesAndBases(sources, bases []profileSource, fetch plugin.Fetcher, obj plugin.ObjTool, ui plugin.UI) (*profile.Profile, *profile.Profile, plugin.MappingSources, plugin.MappingSources, bool, error) {
+func grabSourcesAndBases(sources, bases []profileSource, isDiffBase bool, fetch plugin.Fetcher, obj plugin.ObjTool, ui plugin.UI) (*profile.Profile, *profile.Profile, plugin.MappingSources, plugin.MappingSources, bool, error) {
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 	var psrc, pbase *profile.Profile
@@ -135,6 +135,9 @@ func grabSourcesAndBases(sources, bases []profileSource, fetch plugin.Fetcher, o
 	go func() {
 		defer wg.Done()
 		pbase, mbase, savebase, countbase, errbase = chunkedGrab(bases, fetch, obj, ui)
+		if pbase != nil && isDiffBase {
+			pbase.AddTag("pprof::diff", "true")
+		}
 	}()
 	wg.Wait()
 	save := savesrc || savebase

--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -136,7 +136,7 @@ func grabSourcesAndBases(sources, bases []profileSource, isDiffBase bool, fetch 
 		defer wg.Done()
 		pbase, mbase, savebase, countbase, errbase = chunkedGrab(bases, fetch, obj, ui)
 		if pbase != nil && isDiffBase {
-			pbase.SetTag("pprof::diff", []string{"true"})
+			pbase.SetTag("base", []string{"1"})
 		}
 	}()
 	wg.Wait()

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -398,39 +398,39 @@ func TestFetchWithBase(t *testing.T) {
 				},
 				{
 					values: []int64{-2700, -608881724},
-					labels: map[string][]string{"pprof::diff": {"true"}},
+					labels: map[string][]string{"base": {"1"}},
 				},
 				{
 					values: []int64{-100, -23992},
-					labels: map[string][]string{"pprof::diff": {"true"}},
+					labels: map[string][]string{"base": {"1"}},
 				},
 				{
 					values: []int64{-200, -179943},
-					labels: map[string][]string{"pprof::diff": {"true"}},
+					labels: map[string][]string{"base": {"1"}},
 				},
 				{
 					values: []int64{-100, -17778444},
-					labels: map[string][]string{"pprof::diff": {"true"}},
+					labels: map[string][]string{"base": {"1"}},
 				},
 				{
 					values: []int64{-100, -75976},
-					labels: map[string][]string{"pprof::diff": {"true"}},
+					labels: map[string][]string{"base": {"1"}},
 				},
 				{
 					values: []int64{-300, -63568134},
-					labels: map[string][]string{"pprof::diff": {"true"}},
+					labels: map[string][]string{"base": {"1"}},
 				},
 			},
 			"",
 		},
 		{
-			"diff and base both specified",
+			"diff_base and base both specified",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.contention"},
 			false,
 			[]WantSample{},
-			"-base and -diff flags cannot both be specified",
+			"-base and -diff_base flags cannot both be specified",
 		},
 	}
 
@@ -450,8 +450,8 @@ func TestFetchWithBase(t *testing.T) {
 
 			f := testFlags{
 				stringLists: map[string][]*string{
-					"base": base,
-					"diff": diffBase,
+					"base":      base,
+					"diff_base": diffBase,
 				},
 				bools: map[string]bool{
 					"normalize": tc.normalize,

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -398,27 +398,27 @@ func TestFetchWithBase(t *testing.T) {
 				},
 				{
 					values: []int64{-2700, -608881724},
-					labels: map[string][]string{"base": {"1"}},
+					labels: map[string][]string{"pprof::base": {"true"}},
 				},
 				{
 					values: []int64{-100, -23992},
-					labels: map[string][]string{"base": {"1"}},
+					labels: map[string][]string{"pprof::base": {"true"}},
 				},
 				{
 					values: []int64{-200, -179943},
-					labels: map[string][]string{"base": {"1"}},
+					labels: map[string][]string{"pprof::base": {"true"}},
 				},
 				{
 					values: []int64{-100, -17778444},
-					labels: map[string][]string{"base": {"1"}},
+					labels: map[string][]string{"pprof::base": {"true"}},
 				},
 				{
 					values: []int64{-100, -75976},
-					labels: map[string][]string{"base": {"1"}},
+					labels: map[string][]string{"pprof::base": {"true"}},
 				},
 				{
 					values: []int64{-300, -63568134},
-					labels: map[string][]string{"base": {"1"}},
+					labels: map[string][]string{"pprof::base": {"true"}},
 				},
 			},
 			"",

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -437,20 +437,10 @@ func TestFetchWithBase(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
 			pprofVariables = baseVars.makeCopy()
-			base := make([]*string, len(tc.bases))
-			for i, s := range tc.bases {
-				base[i] = &s
-			}
-
-			diffBase := make([]*string, len(tc.diffBases))
-			for i, s := range tc.diffBases {
-				diffBase[i] = &s
-			}
-
 			f := testFlags{
-				stringLists: map[string][]*string{
-					"base":      base,
-					"diff_base": diffBase,
+				stringLists: map[string][]string{
+					"base":      tc.bases,
+					"diff_base": tc.diffBases,
 				},
 				bools: map[string]bool{
 					"normalize": tc.normalize,
@@ -468,8 +458,8 @@ func TestFetchWithBase(t *testing.T) {
 				if err == nil {
 					t.Fatalf("got nil, want error %q", tc.wantErrorMsg)
 				}
-				gotErrMsg := err.Error()
-				if gotErrMsg != tc.wantErrorMsg {
+
+				if gotErrMsg := err.Error(); gotErrMsg != tc.wantErrorMsg {
 					t.Fatalf("got error %q, want error %q", gotErrMsg, tc.wantErrorMsg)
 				}
 				return
@@ -485,7 +475,7 @@ func TestFetchWithBase(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if want, got := len(tc.wantSamples), len(p.Sample); want != got {
+			if got, want := len(p.Sample), len(tc.wantSamples); got != want {
 				t.Fatalf("got %d samples want %d", got, want)
 			}
 

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -210,13 +210,20 @@ func TestFetchWithBase(t *testing.T) {
 	baseVars := pprofVariables
 	defer func() { pprofVariables = baseVars }()
 
+	type WantSample struct {
+		values []int64
+		labels map[string][]string
+	}
+
 	const path = "testdata/"
 	type testcase struct {
-		desc            string
-		sources         []string
-		bases           []string
-		normalize       bool
-		expectedSamples [][]int64
+		desc         string
+		sources      []string
+		bases        []string
+		diffBases    []string
+		normalize    bool
+		wantSamples  []WantSample
+		wantErrorMsg string
 	}
 
 	testcases := []testcase{
@@ -224,43 +231,206 @@ func TestFetchWithBase(t *testing.T) {
 			"not normalized base is same as source",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.contention"},
+			[]string{},
 			false,
-			[][]int64{},
+			[]WantSample{},
+			"",
+		},
+		{
+			"not normalized base is same as source",
+			[]string{path + "cppbench.contention"},
+			[]string{path + "cppbench.contention"},
+			[]string{},
+			false,
+			[]WantSample{},
+			"",
 		},
 		{
 			"not normalized single source, multiple base (all profiles same)",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.contention", path + "cppbench.contention"},
+			[]string{},
 			false,
-			[][]int64{{-2700, -608881724}, {-100, -23992}, {-200, -179943}, {-100, -17778444}, {-100, -75976}, {-300, -63568134}},
+			[]WantSample{
+				{
+					values: []int64{-2700, -608881724},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{-100, -23992},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{-200, -179943},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{-100, -17778444},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{-100, -75976},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{-300, -63568134},
+					labels: map[string][]string{},
+				},
+			},
+			"",
 		},
 		{
 			"not normalized, different base and source",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.small.contention"},
+			[]string{},
 			false,
-			[][]int64{{1700, 608878600}, {100, 23992}, {200, 179943}, {100, 17778444}, {100, 75976}, {300, 63568134}},
+			[]WantSample{
+				{
+					values: []int64{1700, 608878600},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{100, 23992},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{200, 179943},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{100, 17778444},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{100, 75976},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{300, 63568134},
+					labels: map[string][]string{},
+				},
+			},
+			"",
 		},
 		{
 			"normalized base is same as source",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.contention"},
+			[]string{},
 			true,
-			[][]int64{},
+			[]WantSample{},
+			"",
 		},
 		{
 			"normalized single source, multiple base (all profiles same)",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.contention", path + "cppbench.contention"},
+			[]string{},
 			true,
-			[][]int64{},
+			[]WantSample{},
+			"",
 		},
 		{
 			"normalized different base and source",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.small.contention"},
+			[]string{},
 			true,
-			[][]int64{{-229, -370}, {28, 0}, {57, 0}, {28, 80}, {28, 0}, {85, 287}},
+			[]WantSample{
+				{
+					values: []int64{-229, -370},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{28, 0},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{57, 0},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{28, 80},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{28, 0},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{85, 287},
+					labels: map[string][]string{},
+				},
+			},
+			"",
+		},
+		{
+			"not normalized diff base is same as source",
+			[]string{path + "cppbench.contention"},
+			[]string{},
+			[]string{path + "cppbench.contention"},
+			false,
+			[]WantSample{
+				{
+					values: []int64{2700, 608881724},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{100, 23992},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{200, 179943},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{100, 17778444},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{100, 75976},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{300, 63568134},
+					labels: map[string][]string{},
+				},
+				{
+					values: []int64{-2700, -608881724},
+					labels: map[string][]string{"pprof::diff": {"true"}},
+				},
+				{
+					values: []int64{-100, -23992},
+					labels: map[string][]string{"pprof::diff": {"true"}},
+				},
+				{
+					values: []int64{-200, -179943},
+					labels: map[string][]string{"pprof::diff": {"true"}},
+				},
+				{
+					values: []int64{-100, -17778444},
+					labels: map[string][]string{"pprof::diff": {"true"}},
+				},
+				{
+					values: []int64{-100, -75976},
+					labels: map[string][]string{"pprof::diff": {"true"}},
+				},
+				{
+					values: []int64{-300, -63568134},
+					labels: map[string][]string{"pprof::diff": {"true"}},
+				},
+			},
+			"",
+		},
+		{
+			"diff and base both specified",
+			[]string{path + "cppbench.contention"},
+			[]string{path + "cppbench.contention"},
+			[]string{path + "cppbench.contention"},
+			false,
+			[]WantSample{},
+			"only -base or -diff flag can be specified",
 		},
 	}
 
@@ -273,9 +443,15 @@ func TestFetchWithBase(t *testing.T) {
 				base[i] = &s
 			}
 
+			diffBase := make([]*string, len(tc.diffBases))
+			for i, s := range tc.diffBases {
+				diffBase[i] = &s
+			}
+
 			f := testFlags{
 				stringLists: map[string][]*string{
 					"base": base,
+					"diff": diffBase,
 				},
 				bools: map[string]bool{
 					"normalize": tc.normalize,
@@ -289,29 +465,38 @@ func TestFetchWithBase(t *testing.T) {
 			})
 			src, _, err := parseFlags(o)
 
+			if tc.wantErrorMsg != "" {
+				if err == nil {
+					t.Errorf("want error %q, got nil", tc.wantErrorMsg)
+				}
+				gotErrMsg := err.Error()
+				if gotErrMsg != tc.wantErrorMsg {
+					t.Errorf("want error %q, got error %q", tc.wantErrorMsg, gotErrMsg)
+				}
+				return
+			}
+
 			if err != nil {
 				t.Fatalf("%s: %v", tc.desc, err)
 			}
 
 			p, err := fetchProfiles(src, o)
-			pprofVariables = baseVars
+
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if want, got := len(tc.expectedSamples), len(p.Sample); want != got {
+			if want, got := len(tc.wantSamples), len(p.Sample); want != got {
 				t.Fatalf("want %d samples got %d", want, got)
 			}
 
 			if len(p.Sample) > 0 {
 				for i, sample := range p.Sample {
-					if want, got := len(tc.expectedSamples[i]), len(sample.Value); want != got {
-						t.Errorf("want %d values for sample %d, got %d", want, i, got)
+					if !reflect.DeepEqual(tc.wantSamples[i].values, sample.Value) {
+						t.Errorf("for sample %d want values %v, got %v", i, tc.wantSamples[i], sample.Value)
 					}
-					for j, value := range sample.Value {
-						if want, got := tc.expectedSamples[i][j], value; want != got {
-							t.Errorf("want value of %d for value %d of sample %d, got %d", want, j, i, got)
-						}
+					if !reflect.DeepEqual(tc.wantSamples[i].labels, sample.Label) {
+						t.Errorf("for sample %d want labels %v, got %v", i, tc.wantSamples[i].labels, sample.Label)
 					}
 				}
 			}

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -231,25 +231,25 @@ func TestFetchWithBase(t *testing.T) {
 			"not normalized base is same as source",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.contention"},
-			[]string{},
+			nil,
 			false,
-			[]WantSample{},
+			nil,
 			"",
 		},
 		{
 			"not normalized base is same as source",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.contention"},
-			[]string{},
+			nil,
 			false,
-			[]WantSample{},
+			nil,
 			"",
 		},
 		{
 			"not normalized single source, multiple base (all profiles same)",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.contention", path + "cppbench.contention"},
-			[]string{},
+			nil,
 			false,
 			[]WantSample{
 				{
@@ -283,7 +283,7 @@ func TestFetchWithBase(t *testing.T) {
 			"not normalized, different base and source",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.small.contention"},
-			[]string{},
+			nil,
 			false,
 			[]WantSample{
 				{
@@ -317,7 +317,7 @@ func TestFetchWithBase(t *testing.T) {
 			"normalized base is same as source",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.contention"},
-			[]string{},
+			nil,
 			true,
 			[]WantSample{},
 			"",
@@ -326,7 +326,7 @@ func TestFetchWithBase(t *testing.T) {
 			"normalized single source, multiple base (all profiles same)",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.contention", path + "cppbench.contention"},
-			[]string{},
+			nil,
 			true,
 			[]WantSample{},
 			"",
@@ -335,7 +335,7 @@ func TestFetchWithBase(t *testing.T) {
 			"normalized different base and source",
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.small.contention"},
-			[]string{},
+			nil,
 			true,
 			[]WantSample{
 				{
@@ -368,7 +368,7 @@ func TestFetchWithBase(t *testing.T) {
 		{
 			"not normalized diff base is same as source",
 			[]string{path + "cppbench.contention"},
-			[]string{},
+			nil,
 			[]string{path + "cppbench.contention"},
 			false,
 			[]WantSample{
@@ -466,12 +466,12 @@ func TestFetchWithBase(t *testing.T) {
 
 		if tc.wantErrorMsg != "" {
 			if err == nil {
-				t.Errorf("%s: want error %q, got nil", tc.desc, tc.wantErrorMsg)
+				t.Errorf("%s: got nil, want error %q", tc.desc, tc.wantErrorMsg)
 				continue
 			}
 			gotErrMsg := err.Error()
 			if gotErrMsg != tc.wantErrorMsg {
-				t.Errorf("%s: want error %q, got error %q", tc.desc, tc.wantErrorMsg, gotErrMsg)
+				t.Errorf("%s: got error %q, want error %q", tc.desc, gotErrMsg, tc.wantErrorMsg)
 			}
 			continue
 		}
@@ -489,18 +489,16 @@ func TestFetchWithBase(t *testing.T) {
 		}
 
 		if want, got := len(tc.wantSamples), len(p.Sample); want != got {
-			t.Errorf("%s: want %d samples got %d", tc.desc, want, got)
+			t.Errorf("%s: got %d samples want %d", tc.desc, got, want)
 			continue
 		}
 
-		if len(p.Sample) > 0 {
-			for i, sample := range p.Sample {
-				if !reflect.DeepEqual(tc.wantSamples[i].values, sample.Value) {
-					t.Errorf("%s: for sample %d want values %v, got %v", tc.desc, i, tc.wantSamples[i], sample.Value)
-				}
-				if !reflect.DeepEqual(tc.wantSamples[i].labels, sample.Label) {
-					t.Errorf("%s: for sample %d want labels %v, got %v", tc.desc, i, tc.wantSamples[i].labels, sample.Label)
-				}
+		for i, sample := range p.Sample {
+			if !reflect.DeepEqual(tc.wantSamples[i].values, sample.Value) {
+				t.Errorf("%s: for sample %d got values %v, want %v", tc.desc, i, sample.Value, tc.wantSamples[i])
+			}
+			if !reflect.DeepEqual(tc.wantSamples[i].labels, sample.Label) {
+				t.Errorf("%s: for sample %d got labels %v, want %v", tc.desc, i, sample.Label, tc.wantSamples[i].labels)
 			}
 		}
 	}

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -430,7 +430,7 @@ func TestFetchWithBase(t *testing.T) {
 			[]string{path + "cppbench.contention"},
 			false,
 			[]WantSample{},
-			"only -base or -diff flag can be specified",
+			"-base and -diff flags cannot both be specified",
 		},
 	}
 

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -319,7 +319,7 @@ func TestFetchWithBase(t *testing.T) {
 			[]string{path + "cppbench.contention"},
 			nil,
 			true,
-			[]WantSample{},
+			nil,
 			"",
 		},
 		{
@@ -328,7 +328,7 @@ func TestFetchWithBase(t *testing.T) {
 			[]string{path + "cppbench.contention", path + "cppbench.contention"},
 			nil,
 			true,
-			[]WantSample{},
+			nil,
 			"",
 		},
 		{
@@ -429,7 +429,7 @@ func TestFetchWithBase(t *testing.T) {
 			[]string{path + "cppbench.contention"},
 			[]string{path + "cppbench.contention"},
 			false,
-			[]WantSample{},
+			nil,
 			"-base and -diff_base flags cannot both be specified",
 		},
 	}
@@ -466,13 +466,13 @@ func TestFetchWithBase(t *testing.T) {
 			}
 
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("got error %q, want no error", err)
 			}
 
 			p, err := fetchProfiles(src, o)
 
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("got error %q, want no error", err)
 			}
 
 			if got, want := len(p.Sample), len(tc.wantSamples); got != want {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -266,7 +266,7 @@ func (rpt *Report) newGraph(nodes graph.NodeSet) *graph.Graph {
 
 	// Remove tag marking samples from the base profiles, so it does not appear
 	// as a nodelet in the graph view.
-	prof.SetTag("base", []string{})
+	prof.SetTag("pprof::base", []string{})
 
 	formatTag := func(v int64, key string) string {
 		return measurement.ScaledLabel(v, key, o.OutputUnit)
@@ -1217,7 +1217,7 @@ func NewDefault(prof *profile.Profile, options Options) *Report {
 }
 
 // computeTotal computes the sum of the absolute value of all sample values.
-// If any samples have the tag "base" with value "1", then the total
+// If any samples have the tag "pprof::base" with value "true", then the total
 // will only include samples with that tag.
 func computeTotal(prof *profile.Profile, value, meanDiv func(v []int64) int64) int64 {
 	var div, total, diffDiv, diffTotal int64
@@ -1231,11 +1231,11 @@ func computeTotal(prof *profile.Profile, value, meanDiv func(v []int64) int64) i
 			v = -v
 		}
 		total += v
-		if sample.HasTag("base", "1") {
+		div += d
+		if sample.HasTag("pprof::base", "true") {
 			diffTotal += v
 			diffDiv += d
 		}
-		div += d
 	}
 	if diffTotal > 0 {
 		total = diffTotal

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -264,7 +264,7 @@ func (rpt *Report) newGraph(nodes graph.NodeSet) *graph.Graph {
 		s.NumUnit = numUnits
 	}
 
-	// Remove tag marking samples from the base profiles, so it does not appear
+	// Remove label marking samples from the base profiles, so it does not appear
 	// as a nodelet in the graph view.
 	prof.RemoveLabel("pprof::base")
 
@@ -1217,8 +1217,8 @@ func NewDefault(prof *profile.Profile, options Options) *Report {
 }
 
 // computeTotal computes the sum of the absolute value of all sample values.
-// If any samples have the tag "pprof::base" with value "true", then the total
-// will only include samples with that tag.
+// If any samples have the label "pprof::base" with value "true", then the total
+// will only include samples with that label.
 func computeTotal(prof *profile.Profile, value, meanDiv func(v []int64) int64) int64 {
 	var div, total, diffDiv, diffTotal int64
 	for _, sample := range prof.Sample {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -266,7 +266,7 @@ func (rpt *Report) newGraph(nodes graph.NodeSet) *graph.Graph {
 
 	// Remove tag marking samples from the base profiles, so it does not appear
 	// as a nodelet in the graph view.
-	prof.SetTag("pprof::base", []string{})
+	prof.RemoveLabel("pprof::base")
 
 	formatTag := func(v int64, key string) string {
 		return measurement.ScaledLabel(v, key, o.OutputUnit)
@@ -1232,7 +1232,7 @@ func computeTotal(prof *profile.Profile, value, meanDiv func(v []int64) int64) i
 		}
 		total += v
 		div += d
-		if sample.HasTag("pprof::base", "true") {
+		if sample.HasLabel("pprof::base", "true") {
 			diffTotal += v
 			diffDiv += d
 		}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -266,7 +266,7 @@ func (rpt *Report) newGraph(nodes graph.NodeSet) *graph.Graph {
 
 	// Remove tag marking samples from the base profiles, so it does not appear
 	// as a nodelet in the graph view.
-	prof.SetTag("pprof::diff", []string{})
+	prof.SetTag("base", []string{})
 
 	formatTag := func(v int64, key string) string {
 		return measurement.ScaledLabel(v, key, o.OutputUnit)
@@ -1217,7 +1217,7 @@ func NewDefault(prof *profile.Profile, options Options) *Report {
 }
 
 // computeTotal computes the sum of the absolute value of all sample values.
-// If any samples have the tag "pprof::diff" with value "true", then the total
+// If any samples have the tag "base" with value "1", then the total
 // will only include samples with that tag.
 func computeTotal(prof *profile.Profile, value, meanDiv func(v []int64) int64) int64 {
 	var div, total, diffDiv, diffTotal int64
@@ -1231,7 +1231,7 @@ func computeTotal(prof *profile.Profile, value, meanDiv func(v []int64) int64) i
 			v = -v
 		}
 		total += v
-		if sample.HasTag("pprof::diff", "true") {
+		if sample.HasTag("base", "1") {
 			diffTotal += v
 			diffDiv += d
 		}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1217,9 +1217,10 @@ func NewDefault(prof *profile.Profile, options Options) *Report {
 }
 
 // computeTotal computes the sum of the absolute value of all sample values.
-// This will be used to compute percentages.
+// If any samples have the tag "pprof::diff" with value "true", then the total
+// will only include samples with that tag.
 func computeTotal(prof *profile.Profile, value, meanDiv func(v []int64) int64) int64 {
-	var div, total, diffTotal int64
+	var div, total, diffDiv, diffTotal int64
 	for _, sample := range prof.Sample {
 		var d, v int64
 		v = value(sample.Value)
@@ -1232,11 +1233,13 @@ func computeTotal(prof *profile.Profile, value, meanDiv func(v []int64) int64) i
 		total += v
 		if sample.HasTag("pprof::diff", "true") {
 			diffTotal += v
+			diffDiv += d
 		}
 		div += d
 	}
 	if diffTotal > 0 {
 		total = diffTotal
+		div = diffDiv
 	}
 	if div != 0 {
 		return total / div

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -401,7 +401,7 @@ func TestComputeTotal(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			gotTotal := computeTotal(tc.prof, tc.value, tc.meanDiv)
 			if gotTotal != tc.wantTotal {
-				t.Errorf("want total %d, got %v", tc.wantTotal, gotTotal)
+				t.Errorf("got total %d, want %v", gotTotal, tc.wantTotal)
 			}
 		})
 	}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -330,7 +330,7 @@ func TestComputeTotal(t *testing.T) {
 		{
 			Location: []*profile.Location{testL[2], testL[1], testL[0]},
 			Value:    []int64{-10, 3},
-			Label:    map[string][]string{"base": {"1"}},
+			Label:    map[string][]string{"pprof::base": {"true"}},
 		},
 		{
 			Location: []*profile.Location{testL[2], testL[1], testL[0]},
@@ -339,12 +339,12 @@ func TestComputeTotal(t *testing.T) {
 		{
 			Location: []*profile.Location{testL[2], testL[1], testL[0]},
 			Value:    []int64{-9000, 3},
-			Label:    map[string][]string{"base": {"1"}},
+			Label:    map[string][]string{"pprof::base": {"true"}},
 		},
 		{
 			Location: []*profile.Location{testL[2], testL[1], testL[0]},
 			Value:    []int64{-1, 3},
-			Label:    map[string][]string{"base": {"1"}},
+			Label:    map[string][]string{"pprof::base": {"true"}},
 		},
 		{
 			Location: []*profile.Location{testL[4], testL[2], testL[0]},
@@ -353,7 +353,7 @@ func TestComputeTotal(t *testing.T) {
 		{
 			Location: []*profile.Location{testL[2], testL[1], testL[0]},
 			Value:    []int64{100, 3},
-			Label:    map[string][]string{"base": {"1"}},
+			Label:    map[string][]string{"pprof::base": {"true"}},
 		},
 	}
 

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -288,7 +288,7 @@ func TestLegendActiveFilters(t *testing.T) {
 	}
 }
 
-func TestComputTotal(t *testing.T) {
+func TestComputeTotal(t *testing.T) {
 	p1 := testProfile.Copy()
 	p1.Sample = []*profile.Sample{
 		{

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -330,7 +330,7 @@ func TestComputeTotal(t *testing.T) {
 		{
 			Location: []*profile.Location{testL[2], testL[1], testL[0]},
 			Value:    []int64{-10, 3},
-			Label:    map[string][]string{"pprof::diff": {"true"}},
+			Label:    map[string][]string{"base": {"1"}},
 		},
 		{
 			Location: []*profile.Location{testL[2], testL[1], testL[0]},
@@ -339,12 +339,12 @@ func TestComputeTotal(t *testing.T) {
 		{
 			Location: []*profile.Location{testL[2], testL[1], testL[0]},
 			Value:    []int64{-9000, 3},
-			Label:    map[string][]string{"pprof::diff": {"true"}},
+			Label:    map[string][]string{"base": {"1"}},
 		},
 		{
 			Location: []*profile.Location{testL[2], testL[1], testL[0]},
 			Value:    []int64{-1, 3},
-			Label:    map[string][]string{"pprof::diff": {"true"}},
+			Label:    map[string][]string{"base": {"1"}},
 		},
 		{
 			Location: []*profile.Location{testL[4], testL[2], testL[0]},
@@ -353,7 +353,7 @@ func TestComputeTotal(t *testing.T) {
 		{
 			Location: []*profile.Location{testL[2], testL[1], testL[0]},
 			Value:    []int64{100, 3},
-			Label:    map[string][]string{"pprof::diff": {"true"}},
+			Label:    map[string][]string{"base": {"1"}},
 		},
 	}
 
@@ -364,7 +364,7 @@ func TestComputeTotal(t *testing.T) {
 		wantTotal      int64
 	}{
 		{
-			desc: "non-diff profile, all positive values, index 1",
+			desc: "no diff base, all positive values, index 1",
 			prof: p1,
 			value: func(v []int64) int64 {
 				return v[0]
@@ -372,7 +372,7 @@ func TestComputeTotal(t *testing.T) {
 			wantTotal: 3,
 		},
 		{
-			desc: "non-diff profile, all positive values, index 2",
+			desc: "no diff base, all positive values, index 2",
 			prof: p1,
 			value: func(v []int64) int64 {
 				return v[1]
@@ -380,7 +380,7 @@ func TestComputeTotal(t *testing.T) {
 			wantTotal: 111,
 		},
 		{
-			desc: "non-diff profile, some negative values",
+			desc: "no diff base, some negative values",
 			prof: p2,
 			value: func(v []int64) int64 {
 				return v[1]
@@ -388,7 +388,7 @@ func TestComputeTotal(t *testing.T) {
 			wantTotal: 111,
 		},
 		{
-			desc: "diff profile, some negative values",
+			desc: "diff base, some negative values",
 			prof: p3,
 			value: func(v []int64) int64 {
 				return v[0]

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -399,8 +399,7 @@ func TestComputeTotal(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
-			gotTotal := computeTotal(tc.prof, tc.value, tc.meanDiv)
-			if gotTotal != tc.wantTotal {
+			if gotTotal := computeTotal(tc.prof, tc.value, tc.meanDiv); gotTotal != tc.wantTotal {
 				t.Errorf("got total %d, want %v", gotTotal, tc.wantTotal)
 			}
 		})

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -674,21 +674,14 @@ func numLabelsToString(numLabels map[string][]int64, numUnits map[string][]strin
 	return strings.Join(ls, " ")
 }
 
-// AddTag adds a tag with the specified key and value to all samples in the
+// SetTag sets the specified key to the specified value for all samples in the
 // profile.
-func (p *Profile) AddTag(key, value string) {
+func (p *Profile) SetTag(key string, value []string) {
 	for _, sample := range p.Sample {
-		if sample.HasTag(key, value) {
-			continue
+		if sample.Label == nil {
+			sample.Label = make(map[string][]string)
 		}
-		if values := sample.Label[key]; values != nil {
-			sample.Label[key] = append(values, value)
-		} else {
-			if sample.Label == nil {
-				sample.Label = make(map[string][]string)
-			}
-			sample.Label[key] = []string{value}
-		}
+		sample.Label[key] = value
 	}
 }
 

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -674,9 +674,9 @@ func numLabelsToString(numLabels map[string][]int64, numUnits map[string][]strin
 	return strings.Join(ls, " ")
 }
 
-// SetTag sets the specified key to the specified value for all samples in the
+// SetLabel sets the specified key to the specified value for all samples in the
 // profile.
-func (p *Profile) SetTag(key string, value []string) {
+func (p *Profile) SetLabel(key string, value []string) {
 	for _, sample := range p.Sample {
 		if sample.Label == nil {
 			sample.Label = map[string][]string{}
@@ -685,8 +685,18 @@ func (p *Profile) SetTag(key string, value []string) {
 	}
 }
 
-// HasTag returns true if a sample has a tag with indicated key and value.
-func (s *Sample) HasTag(key, value string) bool {
+// RemoveLabel removes all labels associated with the specified key for all
+// samples in the profile.
+func (p *Profile) RemoveLabel(key string) {
+	for _, sample := range p.Sample {
+		if _, ok := sample.Label[key]; ok {
+			delete(sample.Label, key)
+		}
+	}
+}
+
+// HasLabel returns true if a sample has a label with indicated key and value.
+func (s *Sample) HasLabel(key, value string) bool {
 	if values, ok := s.Label[key]; ok {
 		for _, v := range values {
 			if v == value {

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -679,9 +679,10 @@ func numLabelsToString(numLabels map[string][]int64, numUnits map[string][]strin
 func (p *Profile) SetLabel(key string, value []string) {
 	for _, sample := range p.Sample {
 		if sample.Label == nil {
-			sample.Label = map[string][]string{}
+			sample.Label = map[string][]string{key: value}
+		} else {
+			sample.Label[key] = value
 		}
-		sample.Label[key] = value
 	}
 }
 
@@ -689,19 +690,15 @@ func (p *Profile) SetLabel(key string, value []string) {
 // samples in the profile.
 func (p *Profile) RemoveLabel(key string) {
 	for _, sample := range p.Sample {
-		if _, ok := sample.Label[key]; ok {
-			delete(sample.Label, key)
-		}
+		delete(sample.Label, key)
 	}
 }
 
 // HasLabel returns true if a sample has a label with indicated key and value.
 func (s *Sample) HasLabel(key, value string) bool {
-	if values, ok := s.Label[key]; ok {
-		for _, v := range values {
-			if v == value {
-				return true
-			}
+	for _, v := range s.Label[key] {
+		if v == value {
+			return true
 		}
 	}
 	return false

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -674,6 +674,36 @@ func numLabelsToString(numLabels map[string][]int64, numUnits map[string][]strin
 	return strings.Join(ls, " ")
 }
 
+// AddTag adds a tag with the specified key and value to all samples in the
+// profile.
+func (p *Profile) AddTag(key, value string) {
+	for _, sample := range p.Sample {
+		if sample.HasTag(key, value) {
+			continue
+		}
+		if values := sample.Label[key]; values != nil {
+			sample.Label[key] = append(values, value)
+		} else {
+			if sample.Label == nil {
+				sample.Label = make(map[string][]string)
+			}
+			sample.Label[key] = []string{value}
+		}
+	}
+}
+
+// HasTag returns true if a sample has a tag with indicated key and value.
+func (s *Sample) HasTag(key, value string) bool {
+	if values, ok := s.Label[key]; ok {
+		for _, v := range values {
+			if v == value {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // Scale multiplies all sample values in a profile by a constant.
 func (p *Profile) Scale(ratio float64) {
 	if ratio == 1 {

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -679,7 +679,7 @@ func numLabelsToString(numLabels map[string][]int64, numUnits map[string][]strin
 func (p *Profile) SetTag(key string, value []string) {
 	for _, sample := range p.Sample {
 		if sample.Label == nil {
-			sample.Label = make(map[string][]string)
+			sample.Label = map[string][]string{}
 		}
 		sample.Label[key] = value
 	}

--- a/profile/profile_test.go
+++ b/profile/profile_test.go
@@ -1033,7 +1033,7 @@ func TestRemove(t *testing.T) {
 				for wantKey, wantValues := range wantLabels {
 					if gotValues, ok := sample.Label[wantKey]; ok {
 						if !reflect.DeepEqual(gotValues, wantValues) {
-							t.Fatalf("for key %s, got values %v, want values %v", wantKey, gotValues, wantValues)
+							t.Errorf("for key %s, got values %v, want values %v", wantKey, gotValues, wantValues)
 						}
 					} else {
 						t.Errorf("for key %s got no values, want %v", wantKey, wantValues)
@@ -1166,7 +1166,7 @@ func TestSetLabel(t *testing.T) {
 				for wantKey, wantValues := range wantLabels {
 					if gotValues, ok := sample.Label[wantKey]; ok {
 						if !reflect.DeepEqual(gotValues, wantValues) {
-							t.Fatalf("for key %s, got values %v, want values %v", wantKey, gotValues, wantValues)
+							t.Errorf("for key %s, got values %v, want values %v", wantKey, gotValues, wantValues)
 						}
 					} else {
 						t.Errorf("for key %s got no values, want %v", wantKey, wantValues)

--- a/profile/profile_test.go
+++ b/profile/profile_test.go
@@ -1026,30 +1026,30 @@ func TestHasTag(t *testing.T) {
 	}
 }
 
-func TestAddTag(t *testing.T) {
+func TestSetTag(t *testing.T) {
 	var testcases = []struct {
 		desc     string
 		profile  *Profile
-		addKey   string
-		addVal   string
+		setKey   string
+		setVal   []string
 		wantTags []map[string][]string
 	}{
 		{
 			desc:    "some samples have tag already",
 			profile: testProfile6.Copy(),
-			addKey:  "key1",
-			addVal:  "value1",
+			setKey:  "key1",
+			setVal:  []string{"value1"},
 			wantTags: []map[string][]string{
 				{"key1": {"value1"}},
-				{"key1": {"value1", "value2", "value3"}, "key2": {"value1"}},
-				{"key1": {"value2", "value1"}},
+				{"key1": {"value1"}, "key2": {"value1"}},
+				{"key1": {"value1"}},
 			},
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
-			tc.profile.AddTag(tc.addKey, tc.addVal)
+			tc.profile.SetTag(tc.setKey, tc.setVal)
 			if got, want := len(tc.profile.Sample), len(tc.wantTags); got != want {
 				t.Fatalf("got %v samples, want %v samples", got, want)
 			}

--- a/profile/profile_test.go
+++ b/profile/profile_test.go
@@ -741,7 +741,7 @@ func TestNumLabelMerge(t *testing.T) {
 		wantNumUnits  []map[string][]string
 	}{
 		{
-			name:  "different tag units not merged",
+			name:  "different label units not merged",
 			profs: []*Profile{testProfile4.Copy(), testProfile5.Copy()},
 			wantNumLabels: []map[string][]int64{
 				{
@@ -912,56 +912,56 @@ func locationHash(s *Sample) string {
 	return tb
 }
 
-func TestHasTag(t *testing.T) {
+func TestHasLabel(t *testing.T) {
 	var testcases = []struct {
-		desc       string
-		labels     map[string][]string
-		key        string
-		value      string
-		wantHasTag bool
+		desc         string
+		labels       map[string][]string
+		key          string
+		value        string
+		wantHasLabel bool
 	}{
 		{
-			desc:       "empty label does not have tag",
-			labels:     map[string][]string{},
-			key:        "key",
-			value:      "value",
-			wantHasTag: false,
+			desc:         "empty label does not have label",
+			labels:       map[string][]string{},
+			key:          "key",
+			value:        "value",
+			wantHasLabel: false,
 		},
 		{
-			desc:       "label with one key and value has tag",
-			labels:     map[string][]string{"key": {"value"}},
-			key:        "key",
-			value:      "value",
-			wantHasTag: true,
+			desc:         "label with one key and value has label",
+			labels:       map[string][]string{"key": {"value"}},
+			key:          "key",
+			value:        "value",
+			wantHasLabel: true,
 		},
 		{
-			desc:       "label with one key and value does not have tag",
-			labels:     map[string][]string{"key": {"value"}},
-			key:        "key1",
-			value:      "value1",
-			wantHasTag: false,
+			desc:         "label with one key and value does not have label",
+			labels:       map[string][]string{"key": {"value"}},
+			key:          "key1",
+			value:        "value1",
+			wantHasLabel: false,
 		},
 		{
-			desc: "label with many keys and values has tag",
+			desc: "label with many keys and values has label",
 			labels: map[string][]string{
 				"key1": {"value2", "value1"},
 				"key2": {"value1", "value2", "value2"},
 				"key3": {"value1", "value2", "value2"},
 			},
-			key:        "key1",
-			value:      "value1",
-			wantHasTag: true,
+			key:          "key1",
+			value:        "value1",
+			wantHasLabel: true,
 		},
 		{
-			desc: "label with many keys and values does not have tag",
+			desc: "label with many keys and values does not have label",
 			labels: map[string][]string{
 				"key1": {"value2", "value1"},
 				"key2": {"value1", "value2", "value2"},
 				"key3": {"value1", "value2", "value2"},
 			},
-			key:        "key5",
-			value:      "value5",
-			wantHasTag: false,
+			key:          "key5",
+			value:        "value5",
+			wantHasLabel: false,
 		},
 	}
 
@@ -970,23 +970,90 @@ func TestHasTag(t *testing.T) {
 			sample := &Sample{
 				Label: tc.labels,
 			}
-			if gotHasTag := sample.HasTag(tc.key, tc.value); gotHasTag != tc.wantHasTag {
-				t.Errorf("sample.HasTag(%q, %q) got %v, want %v", tc.key, tc.value, gotHasTag, tc.wantHasTag)
+			if gotHasLabel := sample.HasLabel(tc.key, tc.value); gotHasLabel != tc.wantHasLabel {
+				t.Errorf("sample.HasLabel(%q, %q) got %v, want %v", tc.key, tc.value, gotHasLabel, tc.wantHasLabel)
 			}
 		})
 	}
 }
 
-func TestSetTag(t *testing.T) {
+func TestRemove(t *testing.T) {
 	var testcases = []struct {
-		desc     string
-		samples  []*Sample
-		setKey   string
-		setVal   []string
-		wantTags []map[string][]string
+		desc       string
+		samples    []*Sample
+		removeKey  string
+		wantLabels []map[string][]string
 	}{
 		{
-			desc: "some samples have tag already",
+			desc: "some samples have label already",
+			samples: []*Sample{
+				{
+					Location: []*Location{cpuL[0]},
+					Value:    []int64{1000},
+				},
+				{
+					Location: []*Location{cpuL[0]},
+					Value:    []int64{1000},
+					Label: map[string][]string{
+						"key1": {"value1", "value2", "value3"},
+						"key2": {"value1"},
+					},
+				},
+				{
+					Location: []*Location{cpuL[0]},
+					Value:    []int64{1000},
+					Label: map[string][]string{
+						"key1": {"value2"},
+					},
+				},
+			},
+			removeKey: "key1",
+			wantLabels: []map[string][]string{
+				{},
+				{"key2": {"value1"}},
+				{},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.desc, func(t *testing.T) {
+			profile := testProfile1.Copy()
+			profile.Sample = tc.samples
+			profile.RemoveLabel(tc.removeKey)
+			if got, want := len(profile.Sample), len(tc.wantLabels); got != want {
+				t.Fatalf("got %v samples, want %v samples", got, want)
+			}
+			for i, sample := range profile.Sample {
+				wantLabels := tc.wantLabels[i]
+				if got, want := len(sample.Label), len(wantLabels); got != want {
+					t.Errorf("got %v label keys for sample %v, want %v", got, i, want)
+					continue
+				}
+				for wantKey, wantValues := range wantLabels {
+					if gotValues, ok := sample.Label[wantKey]; ok {
+						if !reflect.DeepEqual(gotValues, wantValues) {
+							t.Fatalf("for key %s, got values %v, want values %v", wantKey, gotValues, wantValues)
+						}
+					} else {
+						t.Errorf("for key %s got no values, want %v", wantKey, wantValues)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSetLabel(t *testing.T) {
+	var testcases = []struct {
+		desc       string
+		samples    []*Sample
+		setKey     string
+		setVal     []string
+		wantLabels []map[string][]string
+	}{
+		{
+			desc: "some samples have label already",
 			samples: []*Sample{
 				{
 					Location: []*Location{cpuL[0]},
@@ -1010,14 +1077,14 @@ func TestSetTag(t *testing.T) {
 			},
 			setKey: "key1",
 			setVal: []string{"value1"},
-			wantTags: []map[string][]string{
+			wantLabels: []map[string][]string{
 				{"key1": {"value1"}},
 				{"key1": {"value1"}, "key2": {"value1"}},
 				{"key1": {"value1"}},
 			},
 		},
 		{
-			desc: "no samples have tags",
+			desc: "no samples have labels",
 			samples: []*Sample{
 				{
 					Location: []*Location{cpuL[0]},
@@ -1026,12 +1093,12 @@ func TestSetTag(t *testing.T) {
 			},
 			setKey: "key1",
 			setVal: []string{"value1"},
-			wantTags: []map[string][]string{
+			wantLabels: []map[string][]string{
 				{"key1": {"value1"}},
 			},
 		},
 		{
-			desc: "all samples have some tags, but not key being added",
+			desc: "all samples have some labels, but not key being added",
 			samples: []*Sample{
 				{
 					Location: []*Location{cpuL[0]},
@@ -1050,7 +1117,7 @@ func TestSetTag(t *testing.T) {
 			},
 			setKey: "key1",
 			setVal: []string{"value1"},
-			wantTags: []map[string][]string{
+			wantLabels: []map[string][]string{
 				{"key1": {"value1"}, "key2": {"value2"}},
 				{"key1": {"value1"}, "key3": {"value3"}},
 			},
@@ -1075,7 +1142,7 @@ func TestSetTag(t *testing.T) {
 			},
 			setKey: "key1",
 			setVal: []string{"value1"},
-			wantTags: []map[string][]string{
+			wantLabels: []map[string][]string{
 				{"key1": {"value1"}},
 				{"key1": {"value1"}},
 			},
@@ -1086,17 +1153,17 @@ func TestSetTag(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			profile := testProfile1.Copy()
 			profile.Sample = tc.samples
-			profile.SetTag(tc.setKey, tc.setVal)
-			if got, want := len(profile.Sample), len(tc.wantTags); got != want {
+			profile.SetLabel(tc.setKey, tc.setVal)
+			if got, want := len(profile.Sample), len(tc.wantLabels); got != want {
 				t.Fatalf("got %v samples, want %v samples", got, want)
 			}
 			for i, sample := range profile.Sample {
-				wantTags := tc.wantTags[i]
-				if got, want := len(sample.Label), len(wantTags); got != want {
+				wantLabels := tc.wantLabels[i]
+				if got, want := len(sample.Label), len(wantLabels); got != want {
 					t.Errorf("got %v label keys for sample %v, want %v", got, i, want)
 					continue
 				}
-				for wantKey, wantValues := range wantTags {
+				for wantKey, wantValues := range wantLabels {
 					if gotValues, ok := sample.Label[wantKey]; ok {
 						if !reflect.DeepEqual(gotValues, wantValues) {
 							t.Fatalf("for key %s, got values %v, want values %v", wantKey, gotValues, wantValues)


### PR DESCRIPTION
Part of fixing #323.

Changes made to design:
* Using key "base" and value "1" to mark profiles in the base profile, rather than key "pprof::base" (or "pprof::diff") and value "true", because we don't want to use long values (the are lots of samples, so adding lots of tags might increase memory usage too much).
* Using `-diff_base`, rather than `-diff` as the flag name. It should be clearer. 
