### PR TITLE
Make readlineUI the default UI

### DIFF
--- a/internal/driver/options.go
+++ b/internal/driver/options.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/chzyer/readline"
 	"github.com/google/pprof/internal/binutils"
 	"github.com/google/pprof/internal/plugin"
 	"github.com/google/pprof/internal/symbolizer"
@@ -44,7 +45,7 @@ func setDefaults(o *plugin.Options) *plugin.Options {
 		d.Obj = &binutils.Binutils{}
 	}
 	if d.UI == nil {
-		d.UI = &stdUI{r: bufio.NewReader(os.Stdin)}
+		d.UI = defaultUI()
 	}
 	if d.Sym == nil {
 		d.Sym = &symbolizer.Symbolizer{Obj: d.Obj, UI: d.UI}
@@ -107,6 +108,15 @@ func (goFlags) Parse(usage func()) []string {
 	return args
 }
 
+func defaultUI() plugin.UI {
+	rl, err := readline.New("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fall back to the default UI due to a failure in initializing readline: %v", err)
+		return &stdUI{r: bufio.NewReader(os.Stdin)}
+	}
+	return &readlineUI{rl: rl}
+}
+
 type stdUI struct {
 	r *bufio.Reader
 }
@@ -141,6 +151,68 @@ func (ui *stdUI) fprint(f *os.File, args []interface{}) {
 		text += "\n"
 	}
 	f.WriteString(text)
+}
+
+// readlineUI implements the driver.UI interface using the
+// github.com/chzyer/readline library.
+// This is contained in pprof.go to avoid adding the readline
+// dependency in the vendored copy of pprof in the Go distribution,
+// which does not use this file.
+type readlineUI struct {
+	rl *readline.Instance
+}
+
+// Read returns a line of text (a command) read from the user.
+// prompt is printed before reading the command.
+func (r *readlineUI) ReadLine(prompt string) (string, error) {
+	r.rl.SetPrompt(prompt)
+	return r.rl.Readline()
+}
+
+// Print shows a message to the user.
+// It is printed over stderr as stdout is reserved for regular output.
+func (r *readlineUI) Print(args ...interface{}) {
+	text := fmt.Sprint(args...)
+	if !strings.HasSuffix(text, "\n") {
+		text += "\n"
+	}
+	fmt.Fprint(r.rl.Stderr(), text)
+}
+
+// Print shows a message to the user, colored in red for emphasis.
+// It is printed over stderr as stdout is reserved for regular output.
+func (r *readlineUI) PrintErr(args ...interface{}) {
+	text := fmt.Sprint(args...)
+	if !strings.HasSuffix(text, "\n") {
+		text += "\n"
+	}
+	fmt.Fprint(r.rl.Stderr(), colorize(text))
+}
+
+// colorize the msg using ANSI color escapes.
+func colorize(msg string) string {
+	var red = 31
+	var colorEscape = fmt.Sprintf("\033[0;%dm", red)
+	var colorResetEscape = "\033[0m"
+	return colorEscape + msg + colorResetEscape
+}
+
+// IsTerminal returns whether the UI is known to be tied to an
+// interactive terminal (as opposed to being redirected to a file).
+func (r *readlineUI) IsTerminal() bool {
+	const stdout = 1
+	return readline.IsTerminal(stdout)
+}
+
+// Start a browser on interactive mode.
+func (r *readlineUI) WantBrowser() bool {
+	return r.IsTerminal()
+}
+
+// SetAutoComplete instructs the UI to call complete(cmd) to obtain
+// the auto-completion of cmd, if the UI supports auto-completion at all.
+func (r *readlineUI) SetAutoComplete(complete func(string) string) {
+	// TODO: Implement auto-completion support.
 }
 
 // oswriter implements the Writer interface using a regular file.

--- a/pprof.go
+++ b/pprof.go
@@ -19,88 +19,13 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
-	"github.com/chzyer/readline"
 	"github.com/google/pprof/driver"
 )
 
 func main() {
-	if err := driver.PProf(&driver.Options{UI: newUI()}); err != nil {
+	if err := driver.PProf(&driver.Options{}); err != nil {
 		fmt.Fprintf(os.Stderr, "pprof: %v\n", err)
 		os.Exit(2)
 	}
-}
-
-// readlineUI implements the driver.UI interface using the
-// github.com/chzyer/readline library.
-// This is contained in pprof.go to avoid adding the readline
-// dependency in the vendored copy of pprof in the Go distribution,
-// which does not use this file.
-type readlineUI struct {
-	rl *readline.Instance
-}
-
-func newUI() driver.UI {
-	rl, err := readline.New("")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "readline: %v", err)
-		return nil
-	}
-	return &readlineUI{
-		rl: rl,
-	}
-}
-
-// Read returns a line of text (a command) read from the user.
-// prompt is printed before reading the command.
-func (r *readlineUI) ReadLine(prompt string) (string, error) {
-	r.rl.SetPrompt(prompt)
-	return r.rl.Readline()
-}
-
-// Print shows a message to the user.
-// It is printed over stderr as stdout is reserved for regular output.
-func (r *readlineUI) Print(args ...interface{}) {
-	text := fmt.Sprint(args...)
-	if !strings.HasSuffix(text, "\n") {
-		text += "\n"
-	}
-	fmt.Fprint(r.rl.Stderr(), text)
-}
-
-// Print shows a message to the user, colored in red for emphasis.
-// It is printed over stderr as stdout is reserved for regular output.
-func (r *readlineUI) PrintErr(args ...interface{}) {
-	text := fmt.Sprint(args...)
-	if !strings.HasSuffix(text, "\n") {
-		text += "\n"
-	}
-	fmt.Fprint(r.rl.Stderr(), colorize(text))
-}
-
-// colorize the msg using ANSI color escapes.
-func colorize(msg string) string {
-	var red = 31
-	var colorEscape = fmt.Sprintf("\033[0;%dm", red)
-	var colorResetEscape = "\033[0m"
-	return colorEscape + msg + colorResetEscape
-}
-
-// IsTerminal returns whether the UI is known to be tied to an
-// interactive terminal (as opposed to being redirected to a file).
-func (r *readlineUI) IsTerminal() bool {
-	const stdout = 1
-	return readline.IsTerminal(stdout)
-}
-
-// Start a browser on interactive mode.
-func (r *readlineUI) WantBrowser() bool {
-	return r.IsTerminal()
-}
-
-// SetAutoComplete instructs the UI to call complete(cmd) to obtain
-// the auto-completion of cmd, if the UI supports auto-completion at all.
-func (r *readlineUI) SetAutoComplete(complete func(string) string) {
-	// TODO: Implement auto-completion support.
 }


### PR DESCRIPTION
The current implementation placed the dependency on
github.com/chzyer/readline in pprof.go instead of placing
it in the default ui just because the go repository that
vendors pprof may not want the dependency.

I evaluated another option (golang.org/x/crypto/ssh/terminal)
for the Go repository and there exist subtle differences
in the behavior. Inconsistency in UI is undesirable so golang
decided to vendor the chzyer readline as well for now.

Update golang/go#14041