### PR TITLE
profile: fix legacy format Go heap profile parsing

### DIFF
--- a/profile/legacy_profile.go
+++ b/profile/legacy_profile.go
@@ -1103,6 +1103,7 @@ var heapzSampleTypes = [][]string{
 	{"objects", "space"},
 	{"inuse_objects", "inuse_space"},
 	{"alloc_objects", "alloc_space"},
+	{"alloc_objects", "alloc_space", "inuse_objects", "inuse_space"}, // Go pprof legacy profiles
 }
 var contentionzSampleTypes = [][]string{
 	{"contentions", "delay"},

--- a/profile/legacy_profile_test.go
+++ b/profile/legacy_profile_test.go
@@ -39,10 +39,12 @@ func TestLegacyProfileType(t *testing.T) {
 		{[]string{"objects", "space"}, heap, true, "heapzSampleTypes"},
 		{[]string{"inuse_objects", "inuse_space"}, heap, true, "heapzSampleTypes"},
 		{[]string{"alloc_objects", "alloc_space"}, heap, true, "heapzSampleTypes"},
+		{[]string{"alloc_objects", "alloc_space", "inuse_objects", "inuse_space"}, heap, true, "heapzSampleTypes"},
 		{[]string{"contentions", "delay"}, cont, true, "contentionzSampleTypes"},
 		// False cases
 		{[]string{"objects"}, heap, false, "heapzSampleTypes"},
 		{[]string{"objects", "unknown"}, heap, false, "heapzSampleTypes"},
+		{[]string{"inuse_objects", "inuse_space", "alloc_objects", "alloc_space"}, heap, false, "heapzSampleTypes"},
 		{[]string{"contentions", "delay"}, heap, false, "heapzSampleTypes"},
 		{[]string{"samples", "cpu"}, heap, false, "heapzSampleTypes"},
 		{[]string{"samples", "cpu"}, cont, false, "contentionzSampleTypes"},


### PR DESCRIPTION
This CL fixes a long-lasting bug that prevented pprof from recognizing
Legacy heap profile produced by Go. Go reports four types of samples
at once so the profile includes alloc_objects, alloc_space,
inuse_objects, and inuse_space. The bug caused pprof to misclassify Go
heap profile data and prevent selection of correct filtering/pruning
patterns in analysis.

Update golang/go#25096

Tested with the profile samples included in golang.org/issues/25096
(pprof hides the runtime functions with this change)