### PR TITLE
update order of available browsers

### DIFF
--- a/internal/driver/commands.go
+++ b/internal/driver/commands.go
@@ -337,21 +337,23 @@ func listHelp(c string, redirect bool) string {
 
 // browsers returns a list of commands to attempt for web visualization.
 func browsers() []string {
-	cmds := []string{"chrome", "google-chrome", "firefox"}
+	var cmds []string
+	if userBrowser := os.Getenv("BROWSER"); userBrowser != "" {
+		cmds = append(cmds, userBrowser)
+	}
 	switch runtime.GOOS {
 	case "darwin":
-		return append(cmds, "/usr/bin/open")
+		cmds = append(cmds, "/usr/bin/open")
 	case "windows":
-		return append(cmds, "cmd /c start")
+		cmds = append(cmds, "cmd /c start")
 	default:
-		userBrowser := os.Getenv("BROWSER")
-		if userBrowser != "" {
-			cmds = append([]string{userBrowser, "sensible-browser"}, cmds...)
-		} else {
-			cmds = append([]string{"sensible-browser"}, cmds...)
+		if os.Getenv("DISPLAY") != "" {
+			// xdg-open is only for use in a desktop environment.
+			cmds = append(cmds, "xdg-open")
 		}
-		return append(cmds, "xdg-open")
+		cmds = append(cmds, "sensible-browser")
 	}
+	return append(cmds, []string{"chrome", "google-chrome", "chromium", "firefox"}...)
 }
 
 var kcachegrind = []string{"kcachegrind"}


### PR DESCRIPTION
Fixes first issue mentioned in #389
Order of commands matches go's [cmd/internal/browser Commands()](https://github.com/golang/go/blob/46076c37578fba9b49059584ef896099c9240fb2/src/cmd/internal/browser/browser.go#L18) function, except that "sensible-browser" is added when no on windows or darwin, and "xdg-open" is added even when "DISPLAY" env variable is not set.

