### PR TITLE
apply filters to -proto output format

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -152,7 +152,7 @@ func generateReport(p *profile.Profile, cmd []string, vars variables, o *plugin.
 }
 
 func applyCommandOverrides(cmd string, outputFormat int, v variables) variables {
-	trim, tagfilter, filter := v["trim"].boolValue(), true, true
+	trim := v["trim"].boolValue()
 
 	switch cmd {
 	case "callgrind", "kcachegrind":
@@ -162,7 +162,7 @@ func applyCommandOverrides(cmd string, outputFormat int, v variables) variables 
 		trim = false
 		v.set("addressnoinlines", "t")
 	case "peek":
-		trim, tagfilter, filter = false, false, false
+		trim = false
 	case "list":
 		v.set("nodecount", "0")
 		v.set("lines", "t")
@@ -185,17 +185,6 @@ func applyCommandOverrides(cmd string, outputFormat int, v variables) variables 
 		v.set("nodecount", "0")
 		v.set("nodefraction", "0")
 		v.set("edgefraction", "0")
-	}
-	if !tagfilter {
-		v.set("tagfocus", "")
-		v.set("tagignore", "")
-	}
-	if !filter {
-		v.set("focus", "")
-		v.set("ignore", "")
-		v.set("hide", "")
-		v.set("show", "")
-		v.set("show_from", "")
 	}
 	return v
 }

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -177,7 +177,7 @@ func applyCommandOverrides(cmd string, outputFormat int, v variables) variables 
 	}
 
 	if outputFormat == report.Proto || outputFormat == report.Raw {
-		trim, tagfilter, filter = false, false, false
+		trim = false
 		v.set("addresses", "t")
 	}
 

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -116,21 +116,21 @@ func TestParse(t *testing.T) {
 			}
 			defer os.Remove(protoTempFile.Name())
 			defer protoTempFile.Close()
-			f.bools["lines"] = true
 			f.strings["output"] = protoTempFile.Name()
 
 			if flags[0] == "topproto" {
 				f.bools["proto"] = false
 				f.bools["topproto"] = true
+				f.bools["addresses"] = true
 			}
 
 			// First pprof invocation to save the profile into a profile.proto.
-			o1 := setDefaults(nil)
-			o1.Flagset = f
-			o1.Fetch = testFetcher{}
-			o1.Sym = testSymbolizer{}
-			o1.UI = testUI
-			if err := PProf(o1); err != nil {
+			o := setDefaults(nil)
+			o.Flagset = f
+			o.Fetch = testFetcher{}
+			o.Sym = testSymbolizer{}
+			o.UI = testUI
+			if err := PProf(o); err != nil {
 				t.Fatalf("%s %q:  %v", tc.source, tc.flags, err)
 			}
 			// Reset the pprof variables after the proto invocation
@@ -162,13 +162,13 @@ func TestParse(t *testing.T) {
 
 			// Second pprof invocation to read the profile from profile.proto
 			// and generate a report.
-			o2 := setDefaults(nil)
-			o2.Flagset = f
-			o2.Sym = testSymbolizeDemangler{}
-			o2.Obj = new(mockObjTool)
-			o2.UI = testUI
+			o = setDefaults(nil)
+			o.Flagset = f
+			o.Sym = testSymbolizeDemangler{}
+			o.Obj = new(mockObjTool)
+			o.UI = testUI
 
-			if err := PProf(o2); err != nil {
+			if err := PProf(o); err != nil {
 				t.Errorf("%s: %v", tc.source, err)
 			}
 			b, err := ioutil.ReadFile(outputTempFile.Name())

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -104,8 +104,8 @@ func TestParse(t *testing.T) {
 
 			testUI := &proftest.TestUI{T: t, AllowRx: "Generating report in|Ignoring local file|expression matched no samples|Interpreted .* as range, not regexp"}
 
-			f1 := baseFlags()
-			f1.args = []string{tc.source}
+			f := baseFlags()
+			f.args = []string{tc.source}
 
 			flags := strings.Split(tc.flags, ",")
 
@@ -116,17 +116,17 @@ func TestParse(t *testing.T) {
 			}
 			defer os.Remove(protoTempFile.Name())
 			defer protoTempFile.Close()
-			f1.bools["lines"] = true
-			f1.strings["output"] = protoTempFile.Name()
+			f.bools["lines"] = true
+			f.strings["output"] = protoTempFile.Name()
 
 			if flags[0] == "topproto" {
-				f1.bools["proto"] = false
-				f1.bools["topproto"] = true
+				f.bools["proto"] = false
+				f.bools["topproto"] = true
 			}
 
 			// First pprof invocation to save the profile into a profile.proto.
 			o1 := setDefaults(nil)
-			o1.Flagset = f1
+			o1.Flagset = f
 			o1.Fetch = testFetcher{}
 			o1.Sym = testSymbolizer{}
 			o1.UI = testUI
@@ -144,26 +144,26 @@ func TestParse(t *testing.T) {
 			defer os.Remove(outputTempFile.Name())
 			defer outputTempFile.Close()
 
-			f2 := baseFlags()
-			f2.strings["output"] = outputTempFile.Name()
-			f2.args = []string{protoTempFile.Name()}
+			f = baseFlags()
+			f.strings["output"] = outputTempFile.Name()
+			f.args = []string{protoTempFile.Name()}
 
-			delete(f2.bools, "proto")
-			addFlags(&f2, flags)
-			solution := solutionFilename(tc.source, &f2)
+			delete(f.bools, "proto")
+			addFlags(&f, flags)
+			solution := solutionFilename(tc.source, &f)
 			// Apply the flags for the second pprof run, and identify name of
 			// the file containing expected results
 			if flags[0] == "topproto" {
-				addFlags(&f2, flags)
-				solution = solutionFilename(tc.source, &f2)
-				delete(f2.bools, "topproto")
-				f2.bools["text"] = true
+				addFlags(&f, flags)
+				solution = solutionFilename(tc.source, &f)
+				delete(f.bools, "topproto")
+				f.bools["text"] = true
 			}
 
 			// Second pprof invocation to read the profile from profile.proto
 			// and generate a report.
 			o2 := setDefaults(nil)
-			o2.Flagset = f2
+			o2.Flagset = f
 			o2.Sym = testSymbolizeDemangler{}
 			o2.Obj = new(mockObjTool)
 			o2.UI = testUI

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -125,12 +125,12 @@ func TestParse(t *testing.T) {
 			}
 
 			// First pprof invocation to save the profile into a profile.proto.
-			o := setDefaults(nil)
-			o.Flagset = f
-			o.Fetch = testFetcher{}
-			o.Sym = testSymbolizer{}
-			o.UI = testUI
-			if err := PProf(o); err != nil {
+			o1 := setDefaults(nil)
+			o1.Flagset = f
+			o1.Fetch = testFetcher{}
+			o1.Sym = testSymbolizer{}
+			o1.UI = testUI
+			if err := PProf(o1); err != nil {
 				t.Fatalf("%s %q:  %v", tc.source, tc.flags, err)
 			}
 			// Reset the pprof variables after the proto invocation
@@ -162,13 +162,13 @@ func TestParse(t *testing.T) {
 
 			// Second pprof invocation to read the profile from profile.proto
 			// and generate a report.
-			o = setDefaults(nil)
-			o.Flagset = f
-			o.Sym = testSymbolizeDemangler{}
-			o.Obj = new(mockObjTool)
-			o.UI = testUI
+			o2 := setDefaults(nil)
+			o2.Flagset = f
+			o2.Sym = testSymbolizeDemangler{}
+			o2.Obj = new(mockObjTool)
+			o2.UI = testUI
 
-			if err := PProf(o); err != nil {
+			if err := PProf(o2); err != nil {
 				t.Errorf("%s: %v", tc.source, err)
 			}
 			b, err := ioutil.ReadFile(outputTempFile.Name())

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -126,6 +126,17 @@ func TestParse(t *testing.T) {
 				f.bools["topproto"] = true
 			}
 
+			// Filters should not be applied on first pprof invocation.
+			delete(f.strings, "tagfocus")
+			delete(f.strings, "tagshow")
+			delete(f.strings, "taghide")
+			delete(f.strings, "tagignore")
+			delete(f.strings, "focus")
+			delete(f.strings, "show")
+			delete(f.strings, "hide")
+			delete(f.strings, "ignore")
+			delete(f.strings, "show_from")
+
 			// First pprof invocation to save the profile into a profile.proto.
 			o1 := setDefaults(nil)
 			o1.Flagset = f
@@ -152,13 +163,15 @@ func TestParse(t *testing.T) {
 			// Apply the flags for the second pprof run, and identify name of
 			// the file containing expected results
 			if flags[0] == "topproto" {
+				addFlags(&f, flags)
 				solution = solutionFilename(tc.source, &f)
 				delete(f.bools, "topproto")
 				f.bools["text"] = true
 			} else {
 				delete(f.bools, "proto")
-				addFlags(&f, flags[:1])
+				addFlags(&f, flags)
 				solution = solutionFilename(tc.source, &f)
+				fmt.Printf(solution)
 			}
 			// The add_comment flag is not idempotent so only apply it on the first run.
 			delete(f.strings, "add_comment")

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -109,9 +109,6 @@ func TestParse(t *testing.T) {
 
 			flags := strings.Split(tc.flags, ",")
 
-			// Skip the output format in the first flag, to output to a proto
-			addFlags(&f, flags[1:])
-
 			// Encode profile into a protobuf and decode it again.
 			protoTempFile, err := ioutil.TempFile("", "profile_proto")
 			if err != nil {
@@ -125,17 +122,6 @@ func TestParse(t *testing.T) {
 				f.bools["proto"] = false
 				f.bools["topproto"] = true
 			}
-
-			// Filters should not be applied on first pprof invocation.
-			delete(f.strings, "tagfocus")
-			delete(f.strings, "tagshow")
-			delete(f.strings, "taghide")
-			delete(f.strings, "tagignore")
-			delete(f.strings, "focus")
-			delete(f.strings, "show")
-			delete(f.strings, "hide")
-			delete(f.strings, "ignore")
-			delete(f.strings, "show_from")
 
 			// First pprof invocation to save the profile into a profile.proto.
 			o1 := setDefaults(nil)
@@ -171,10 +157,7 @@ func TestParse(t *testing.T) {
 				delete(f.bools, "proto")
 				addFlags(&f, flags)
 				solution = solutionFilename(tc.source, &f)
-				fmt.Printf(solution)
 			}
-			// The add_comment flag is not idempotent so only apply it on the first run.
-			delete(f.strings, "add_comment")
 
 			// Second pprof invocation to read the profile from profile.proto
 			// and generate a report.


### PR DESCRIPTION
We've had some discussion, and concluded that user-specified filters should be applied to the -proto output format.

This change makes it so that filters are applied to the -proto output.