### PR TITLE
Force saving the module name for unsymbolized frames

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -564,12 +564,12 @@ func nodeInfo(l *profile.Location, line profile.Line, objfile string, o *Options
 	if fname := line.Function.Filename; fname != "" {
 		ni.File = filepath.Clean(fname)
 	}
-	if o.ObjNames {
-		ni.Objfile = objfile
-		ni.StartLine = int(line.Function.StartLine)
-	}
 	if o.OrigFnNames {
 		ni.OrigName = line.Function.SystemName
+	}
+	if o.ObjNames || (ni.Name == "" && ni.OrigName == "") {
+		ni.Objfile = objfile
+		ni.StartLine = int(line.Function.StartLine)
 	}
 	return ni
 }

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -512,9 +512,7 @@ func isNegative(n *Node) bool {
 
 // CreateNodes creates graph nodes for all locations in a profile. It
 // returns set of all nodes, plus a mapping of each location to the
-// set of corresponding nodes (one per location.Line). If kept is
-// non-nil, only nodes in that set are included; nodes that do not
-// match are represented as a nil.
+// set of corresponding nodes (one per location.Line).
 func CreateNodes(prof *profile.Profile, o *Options) (Nodes, map[uint64]Nodes) {
 	locations := make(map[uint64]Nodes, len(prof.Location))
 	nm := make(NodeMap, len(prof.Location))

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -316,7 +316,7 @@ func TestTrimTree(t *testing.T) {
 }
 
 func nodeTestProfile() *profile.Profile {
-	var mappings = []*profile.Mapping{
+	mappings := []*profile.Mapping{
 		{
 			ID:   1,
 			File: "symbolized_binary",
@@ -330,13 +330,11 @@ func nodeTestProfile() *profile.Profile {
 			File: "unsymbolized_library_2",
 		},
 	}
-
-	var functions = []*profile.Function{
+	functions := []*profile.Function{
 		{ID: 1, Name: "symname"},
 		{ID: 2},
 	}
-
-	var locations = []*profile.Location{
+	locations := []*profile.Location{
 		{
 			ID:      1,
 			Mapping: mappings[0],
@@ -356,7 +354,6 @@ func nodeTestProfile() *profile.Profile {
 			Mapping: mappings[2],
 		},
 	}
-
 	return &profile.Profile{
 		PeriodType: &profile.ValueType{Type: "cpu", Unit: "milliseconds"},
 		SampleType: []*profile.ValueType{
@@ -392,9 +389,8 @@ func TestCreateNodes(t *testing.T) {
 	}
 
 	nodes, _ := CreateNodes(testProfile, &Options{})
-
 	if len(nodes) != len(wantNodeSet) {
-		t.Errorf("want %d nodes, got %d", len(wantNodeSet), len(nodes))
+		t.Errorf("got %d nodes, want %d", len(nodes), len(wantNodeSet))
 	}
 	for _, node := range nodes {
 		if !wantNodeSet[node.Info] {

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -3,6 +3,8 @@ package graph
 import (
 	"fmt"
 	"testing"
+
+	"github.com/google/pprof/profile"
 )
 
 func edgeDebugString(edge *Edge) string {
@@ -309,6 +311,94 @@ func TestTrimTree(t *testing.T) {
 			t.Fatalf("Graphs do not match.\nExpected: %s\nFound: %s\n",
 				expectedNodesDebugString(test.expected),
 				graphDebugString(graph))
+		}
+	}
+}
+
+func nodeTestProfile() *profile.Profile {
+	var mappings = []*profile.Mapping{
+		{
+			ID:   1,
+			File: "symbolized_binary",
+		},
+		{
+			ID:   2,
+			File: "unsymbolized_library_1",
+		},
+		{
+			ID:   3,
+			File: "unsymbolized_library_2",
+		},
+	}
+
+	var functions = []*profile.Function{
+		{ID: 1, Name: "symname"},
+		{ID: 2},
+	}
+
+	var locations = []*profile.Location{
+		{
+			ID:      1,
+			Mapping: mappings[0],
+			Line: []profile.Line{
+				{Function: functions[0]},
+			},
+		},
+		{
+			ID:      2,
+			Mapping: mappings[1],
+			Line: []profile.Line{
+				{Function: functions[1]},
+			},
+		},
+		{
+			ID:      3,
+			Mapping: mappings[2],
+		},
+	}
+
+	return &profile.Profile{
+		PeriodType: &profile.ValueType{Type: "cpu", Unit: "milliseconds"},
+		SampleType: []*profile.ValueType{
+			{Type: "type", Unit: "unit"},
+		},
+		Sample: []*profile.Sample{
+			{
+				Location: []*profile.Location{locations[0]},
+				Value:    []int64{1},
+			},
+			{
+				Location: []*profile.Location{locations[1]},
+				Value:    []int64{1},
+			},
+			{
+				Location: []*profile.Location{locations[2]},
+				Value:    []int64{1},
+			},
+		},
+		Location: locations,
+		Function: functions,
+		Mapping:  mappings,
+	}
+}
+
+// Check that nodes are properly created for a simple profile.
+func TestCreateNodes(t *testing.T) {
+	testProfile := nodeTestProfile()
+	wantNodeSet := NodeSet{
+		{Name: "symname"}:                   true,
+		{Objfile: "unsymbolized_library_1"}: true,
+		{Objfile: "unsymbolized_library_2"}: true,
+	}
+
+	nodes, _ := CreateNodes(testProfile, &Options{})
+
+	if len(nodes) != len(wantNodeSet) {
+		t.Errorf("want %d nodes, got %d", len(wantNodeSet), len(nodes))
+	}
+	for _, node := range nodes {
+		if !wantNodeSet[node.Info] {
+			t.Errorf("unexpected node %v", node.Info)
 		}
 	}
 }


### PR DESCRIPTION
In some cases pprof isn't saving the module name in graph nodes, so
reports end up with nodes of the form '<unknown>'.

The module name is often stripped to allow symbolized frames from
different versions of a binary to be merge.

Force saving the objfile name if the name is unknown so we can print
some information for unsymbolized frames.