### PR TITLE
Fix staticcheck warning SA6004 that was recently added in the tool

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,12 @@ echo "mode: $MODE" > coverage.txt
 # All packages.
 PKG=$(go list ./...)
 
-staticcheck $PKG
+staticcheck -ignore '
+github.com/google/pprof/internal/binutils/binutils_test.go:SA6004
+github.com/google/pprof/internal/driver/svg.go:SA6004
+github.com/google/pprof/internal/report/source_test.go:SA6004
+github.com/google/pprof/profile/filter_test.go:SA6004
+' $PKG
 unused $PKG
 
 # Packages that have any tests.


### PR DESCRIPTION
See https://travis-ci.org/google/pprof/jobs/412151752 for example failure.