### PR TITLE
Expose sample_index argument through web ui

### DIFF
--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -201,6 +201,7 @@ func openBrowser(url string, o *plugin.Options) {
 		{"s", "show"},
 		{"i", "ignore"},
 		{"h", "hide"},
+		{"si", "sample_index"},
 	} {
 		if v := pprofVariables[p.key].value; v != "" {
 			q.Set(p.param, v)
@@ -232,6 +233,7 @@ func varsFromURL(u *gourl.URL) variables {
 	vars["show"].value = u.Query().Get("s")
 	vars["ignore"].value = u.Query().Get("i")
 	vars["hide"].value = u.Query().Get("h")
+	vars["sample_index"].value = u.Query().Get("si")
 	return vars
 }
 


### PR DESCRIPTION
The option is exposed in the web UI's query string under a
new `?si=<sample_index>` parameter. This is particularly
useful for heap profiles, where switching between the four
indices (alloc_objects, alloc_space, inuse_objects, and inuse_space)
is a common task.

We could add a menu to the UI to make discovery of these
options easier, but for now this seems sufficient.