### PR TITLE
Add sample index selector to web ui

### DIFF
--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -249,6 +249,21 @@ table tr td {
     </div>
   </div>
 
+  {{$sampleLen := len .SampleTypes}}
+  {{if gt $sampleLen 1}}
+  <div id="sample" class="menu-item">
+    <div class="menu-name">
+      Sample
+      <i class="downArrow"></i>
+    </div>
+    <div class="submenu">
+      {{range .SampleTypes}}
+      <a href="?si={{.}}" id="{{.}}">{{.}}</a>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
   <div id="refine" class="menu-item">
     <div class="menu-name">
       Refine
@@ -718,9 +733,18 @@ function viewer(baseUrl, nodes) {
     return str.replace(/([\\\.?+*\[\](){}|^$])/g, '\\$1');
   }
 
+  function setSampleIndexLink(id) {
+    const elem = document.getElementById(id);
+    if (elem != null) {
+      setHrefParams(elem, function (params) {
+        params.set("si", id);
+      });
+    }
+  }
+
   // Update id's href to reflect current selection whenever it is
   // liable to be followed.
-  function makeLinkDynamic(id) {
+  function makeSearchLinkDynamic(id) {
     const elem = document.getElementById(id);
     if (elem == null) return;
 
@@ -736,19 +760,32 @@ function viewer(baseUrl, nodes) {
     elem.addEventListener('touchstart', updater);
 
     function updater() {
-      elem.href = updateUrl(new URL(elem.href), param);
+      // The selection can be in one of two modes: regexp-based or
+      // list-based.  Construct regular expression depending on mode.
+      let re = regexpActive
+        ? search.value
+        : Array.from(selected.keys()).map(key => quotemeta(nodes[key])).join('|');
+
+      setHrefParams(elem, function (params) {
+        if (re != '') {
+          // For focus/show, forget old parameter.  For others, add to re.
+          if (param != 'f' && param != 's' && params.has(param)) {
+            const old = params.get(param);
+            if (old != '') {
+              re += '|' + old;
+            }
+          }
+          params.set(param, re);
+        } else {
+          params.delete(param);
+        }
+      });
     }
   }
 
-  // Update URL to reflect current selection.
-  function updateUrl(url, param) {
+  function setHrefParams(elem, paramSetter) {
+    let url = new URL(elem.href);
     url.hash = '';
-
-    // The selection can be in one of two modes: regexp-based or
-    // list-based.  Construct regular expression depending on mode.
-    let re = regexpActive
-      ? search.value
-      : Array.from(selected.keys()).map(key => quotemeta(nodes[key])).join('|');
 
     // Copy params from this page's URL.
     const params = url.searchParams;
@@ -756,20 +793,10 @@ function viewer(baseUrl, nodes) {
       params.set(p[0], p[1]);
     }
 
-    if (re != '') {
-      // For focus/show, forget old parameter.  For others, add to re.
-      if (param != 'f' && param != 's' && params.has(param)) {
-        const old = params.get(param);
-         if (old != '') {
-          re += '|' + old;
-        }
-      }
-      params.set(param, re);
-    } else {
-      params.delete(param);
-    }
+    // Give the params to the setter to modify.
+    paramSetter(params);
 
-    return url.toString();
+    elem.href = url.toString();
   }
 
   function handleTopClick(e) {
@@ -826,7 +853,10 @@ function viewer(baseUrl, nodes) {
 
   const ids = ['topbtn', 'graphbtn', 'peek', 'list', 'disasm',
                'focus', 'ignore', 'hide', 'show'];
-  ids.forEach(makeLinkDynamic);
+  ids.forEach(makeSearchLinkDynamic);
+
+  const sampleIDs = [{{range .SampleTypes}}'{{.}}', {{end}}];
+  sampleIDs.forEach(setSampleIndexLink);
 
   // Bind action to button with specified id.
   function addAction(id, action) {

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -69,16 +69,17 @@ func (ec *errorCatcher) PrintErr(args ...interface{}) {
 
 // webArgs contains arguments passed to templates in webhtml.go.
 type webArgs struct {
-	Title      string
-	Errors     []string
-	Total      int64
-	Legend     []string
-	Help       map[string]string
-	Nodes      []string
-	HTMLBody   template.HTML
-	TextBody   string
-	Top        []report.TextItem
-	FlameGraph template.JS
+	Title       string
+	Errors      []string
+	Total       int64
+	SampleTypes []string
+	Legend      []string
+	Help        map[string]string
+	Nodes       []string
+	HTMLBody    template.HTML
+	TextBody    string
+	Top         []report.TextItem
+	FlameGraph  template.JS
 }
 
 func serveWebInterface(hostport string, p *profile.Profile, o *plugin.Options) error {
@@ -264,6 +265,7 @@ func (ui *webInterface) render(w http.ResponseWriter, tmpl string,
 	data.Title = file + " " + profile
 	data.Errors = errList
 	data.Total = rpt.Total()
+	data.SampleTypes = sampleTypes(ui.prof)
 	data.Legend = legend
 	data.Help = ui.help
 	html := &bytes.Buffer{}


### PR DESCRIPTION
This is a follow-up change to #412 which adds a selector to the web
ui for selecting the sample index of a profile to view. The selector
is hidden for profiles with only a single sample type.

<img width="578" alt="screen shot 2018-08-23 at 10 41 13 pm" src="https://user-images.githubusercontent.com/5438456/44562051-afcee300-a725-11e8-9893-99ae7349b51c.png">
