### PR TITLE
Change order of commands returned by browser()

### DIFF
--- a/internal/driver/commands.go
+++ b/internal/driver/commands.go
@@ -341,6 +341,7 @@ func browsers() []string {
 	if userBrowser := os.Getenv("BROWSER"); userBrowser != "" {
 		cmds = append(cmds, userBrowser)
 	}
+	cmds = append(cmds, []string{"chrome", "google-chrome", "chromium", "firefox"}...)
 	switch runtime.GOOS {
 	case "darwin":
 		cmds = append(cmds, "/usr/bin/open")
@@ -348,12 +349,11 @@ func browsers() []string {
 		cmds = append(cmds, "cmd /c start")
 	default:
 		if os.Getenv("DISPLAY") != "" {
-			// xdg-open is only for use in a desktop environment.
 			cmds = append(cmds, "xdg-open")
 		}
 		cmds = append(cmds, "sensible-browser")
 	}
-	return append(cmds, []string{"chrome", "google-chrome", "chromium", "firefox"}...)
+	return cmds
 }
 
 var kcachegrind = []string{"kcachegrind"}

--- a/internal/driver/commands.go
+++ b/internal/driver/commands.go
@@ -336,6 +336,9 @@ func listHelp(c string, redirect bool) string {
 }
 
 // browsers returns a list of commands to attempt for web visualization.
+// Commands which definitely will open a browser are prioritized over other
+// commands like xdg-open,  which may not open the javascript embedded SVG
+// files produced by the -web command in a browser.
 func browsers() []string {
 	var cmds []string
 	if userBrowser := os.Getenv("BROWSER"); userBrowser != "" {


### PR DESCRIPTION
The browser() function prioritize opening commands which definitely open browsers, since this function is used as a command to open the svg graphs, and these graphs have embedded javascript which makes them easier to navigate.

Fixes #402 