### PR TITLE
Make '-noinlines' a separate flag, introduce '-filefunctions' granularity

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -80,21 +80,21 @@ other.
 
 Some common pprof options are:
 
-* **-flat [default]:** Sort entries based on their flat weight, on text reports.
-* **-cum:** Sort entries based on cumulative weight, on text reports.
-* **-functions [default]:** Accumulate samples at the function level; profile
-  locations that describe the same function will be merged into a report entry.
-* **-lines:** Accumulate samples at the source line level; profile locations that
-  describe the same function will be merged into a report entry.
-* **-addresses:** Accumulate samples at the instruction address; profile locations
-  that describe the same function address will be merged into a report entry.
+* **-flat** [default], **-cum**: Sort entries based on their flat or cumulative
+  weight respectively, on text reports.
+* **-functions** [default], **-filefunctions**, **-files**, **-lines**,
+  **-addresses**: Generate the report using the specified granularity.
+* **-noinlines**: Attribute inlined functions to their first out-of-line caller.
+  For example, a command like `pprof -list foo -noinlines profile.pb.gz` can be
+  used to produce the annotated source listing attributing the metrics in the
+  inlined functions to the out-of-line calling line.
 * **-nodecount= _int_:** Maximum number of entries in the report. pprof will only print
   this many entries and will use heuristics to select which entries to trim.
 * **-focus= _regex_:** Only include samples that include a report entry matching
   *regex*.
 * **-ignore= _regex_:** Do not include samples that include a report entry matching
   *regex*.
-* **-show\_from= _regex_:** Do not show entries above the first one that 
+* **-show\_from= _regex_:** Do not show entries above the first one that
   matches *regex*.
 * **-show= _regex_:** Only show entries that match *regex*.
 * **-hide= _regex_:** Do not show entries that match *regex*.
@@ -209,12 +209,12 @@ default it will search for those tools in the current path, but it can also
 search for them in a directory pointed to by the environment variable
 `$PPROF_TOOLS`.
 
-* **-disasm= _regex_:** Generates an annotated source listing for functions matching
-  regex, with flat/cum weights for each source line.
-* **-list= _regex_:** Generates an annotated disassembly listing for functions
-  matching *regex*.
-* **-weblist= _regex_:** Generates a source/assembly combined annotated listing for
-  functions matching *regex*, and starts a web browser to display it.
+* **-list= _regex_:** Generates an annotated source listing for functions
+  matching *regex*, with flat/cum weights for each source line.
+* **-disasm= _regex_:** Generates an annotated disassembly listing for
+  functions matching *regex*.
+* **-weblist= _regex_:** Generates a source/assembly combined annotated listing
+  for functions matching *regex*, and starts a web browser to display it.
 
 ## Comparing profiles
 

--- a/internal/driver/commands.go
+++ b/internal/driver/commands.go
@@ -228,17 +228,17 @@ var pprofVariables = variables{
 	// Output granularity
 	"functions": &variable{boolKind, "t", "granularity", helpText(
 		"Aggregate at the function level.",
-		"Takes into account the filename/lineno where the function was defined.")},
+		"Ignores the filename where the function was defined.")},
+	"filefunctions": &variable{boolKind, "t", "granularity", helpText(
+		"Aggregate at the function level.",
+		"Takes into account the filename where the function was defined.")},
 	"files": &variable{boolKind, "f", "granularity", "Aggregate at the file level."},
 	"lines": &variable{boolKind, "f", "granularity", "Aggregate at the source code line level."},
 	"addresses": &variable{boolKind, "f", "granularity", helpText(
-		"Aggregate at the function level.",
+		"Aggregate at the address level.",
 		"Includes functions' addresses in the output.")},
-	"noinlines": &variable{boolKind, "f", "granularity", helpText(
-		"Aggregate at the function level.",
-		"Attributes inlined functions to their first out-of-line caller.")},
-	"addressnoinlines": &variable{boolKind, "f", "granularity", helpText(
-		"Aggregate at the function level, including functions' addresses in the output.",
+	"noinlines": &variable{boolKind, "f", "", helpText(
+		"Ignore inlines.",
 		"Attributes inlined functions to their first out-of-line caller.")},
 }
 

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -53,6 +53,9 @@ func TestParse(t *testing.T) {
 		flags, source string
 	}{
 		{"text,functions,flat", "cpu"},
+		{"text,functions,noinlines,flat", "cpu"},
+		{"text,filefunctions,noinlines,flat", "cpu"},
+		{"text,addresses,noinlines,flat", "cpu"},
 		{"tree,addresses,flat,nodecount=4", "cpusmall"},
 		{"text,functions,flat,nodecount=5,call_tree", "unknown"},
 		{"text,alloc_objects,flat", "heap_alloc"},
@@ -248,7 +251,8 @@ func testSourceURL(port int) string {
 func solutionFilename(source string, f *testFlags) string {
 	name := []string{"pprof", strings.TrimPrefix(source, testSourceURL(8000))}
 	name = addString(name, f, []string{"flat", "cum"})
-	name = addString(name, f, []string{"functions", "files", "lines", "addresses"})
+	name = addString(name, f, []string{"functions", "filefunctions", "files", "lines", "addresses"})
+	name = addString(name, f, []string{"noinlines"})
 	name = addString(name, f, []string{"inuse_space", "inuse_objects", "alloc_space", "alloc_objects"})
 	name = addString(name, f, []string{"relative_percentages"})
 	name = addString(name, f, []string{"seconds"})

--- a/internal/driver/interactive_test.go
+++ b/internal/driver/interactive_test.go
@@ -259,12 +259,13 @@ func TestInteractiveCommands(t *testing.T) {
 		{
 			"weblist  find -test",
 			map[string]string{
-				"functions":        "false",
-				"addressnoinlines": "true",
-				"nodecount":        "0",
-				"cum":              "false",
-				"flat":             "true",
-				"ignore":           "test",
+				"functions": "false",
+				"addresses": "true",
+				"noinlines": "true",
+				"nodecount": "0",
+				"cum":       "false",
+				"flat":      "true",
+				"ignore":    "test",
 			},
 		},
 		{

--- a/internal/driver/testdata/pprof.cpu.flat.addresses.noinlines.text
+++ b/internal/driver/testdata/pprof.cpu.flat.addresses.noinlines.text
@@ -1,0 +1,7 @@
+Showing nodes accounting for 1.12s, 100% of 1.12s total
+Dropped 1 node (cum <= 0.06s)
+      flat  flat%   sum%        cum   cum%
+     1.10s 98.21% 98.21%      1.10s 98.21%  0000000000001000 line1000 testdata/file1000.src:1
+     0.01s  0.89% 99.11%      1.01s 90.18%  0000000000002000 line2000 testdata/file2000.src:4
+     0.01s  0.89%   100%      1.01s 90.18%  0000000000003000 line3000 testdata/file3000.src:6
+         0     0%   100%      0.10s  8.93%  0000000000003001 line3000 testdata/file3000.src:9

--- a/internal/driver/testdata/pprof.cpu.flat.filefunctions.noinlines.text
+++ b/internal/driver/testdata/pprof.cpu.flat.filefunctions.noinlines.text
@@ -1,0 +1,5 @@
+Showing nodes accounting for 1.12s, 100% of 1.12s total
+      flat  flat%   sum%        cum   cum%
+     1.10s 98.21% 98.21%      1.10s 98.21%  line1000 testdata/file1000.src
+     0.01s  0.89% 99.11%      1.01s 90.18%  line2000 testdata/file2000.src
+     0.01s  0.89%   100%      1.12s   100%  line3000 testdata/file3000.src

--- a/internal/driver/testdata/pprof.cpu.flat.functions.noinlines.text
+++ b/internal/driver/testdata/pprof.cpu.flat.functions.noinlines.text
@@ -1,0 +1,5 @@
+Showing nodes accounting for 1.12s, 100% of 1.12s total
+      flat  flat%   sum%        cum   cum%
+     1.10s 98.21% 98.21%      1.10s 98.21%  line1000
+     0.01s  0.89% 99.11%      1.01s 90.18%  line2000
+     0.01s  0.89%   100%      1.12s   100%  line3000


### PR DESCRIPTION
This change consists of two relatively independent parts, but they are
both about handling the granularity, so bundling them together.

First, in #415 there is a discussion that having a granularity mode by
source lines but with inlines hidden would be useful. The agreement is
also that adding `-linenoinlines` granularity would make the granularity
flags too messy (and they are already somewhat messy with `-addresses`
and `-addressnoinlines`. So, it was proposed to make `-noinlines` a
separate flag, which is what this change does. Note that the flag is now
pulled out of the granularity group so it's a bit of backward
incompatible change but I think it is acceptable. For the example in
issue #415 the user would now be able to specify `-list foo -noinlines`
to produce annotated source where the metrics from the inlined functions
are attributed to the calling inliner line.

With this change, I am also dropping the `-addressnoinlines` granularity
which is now supported as `-addresses -noinlines` combination. I
couldn't find any usage of this option at least internally at Google, so
I think it's safe to remove it.

Second, I am adding a separate `-filefunctions` granularity which groups
the data by both function and file. This is a follow-up to #110 from the
past where we changed the `-functions` granularity to not group by file
(it used to), and since then there was a couple of reports where using
just function name alone would over-aggregate the data in cases when a
function with the same name is contained in multiple source files (e.g.
see b/18874275 internally).

Also, make a number of assorted documentation and `-help` fixes.