### PR TITLE
Fix ELF base calculation for exec mapping with offset != 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ addons:
       - graphviz
 
 before_install:
-  - go get -u github.com/golang/lint/golint honnef.co/go/tools/cmd/...
+  - go get -u golang.org/x/lint/golint honnef.co/go/tools/cmd/...
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && -z $SKIP_BINUTILS ]]; then brew install binutils ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" && -z $SKIP_GRAPHVIZ ]]; then brew install graphviz; fi

--- a/internal/elfexec/elfexec.go
+++ b/internal/elfexec/elfexec.go
@@ -178,8 +178,7 @@ func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint6
 		pageOffsetPpc64 = 0xc000000000000000
 	)
 
-	if start == 0 && offset == 0 &&
-		(limit == ^uint64(0) || limit == 0) {
+	if start == 0 && offset == 0 && (limit == ^uint64(0) || limit == 0) {
 		// Some tools may introduce a fake mapping that spans the entire
 		// address space. Assume that the address has already been
 		// adjusted, so no additional base adjustment is necessary.
@@ -189,9 +188,21 @@ func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint6
 	switch fh.Type {
 	case elf.ET_EXEC:
 		if loadSegment == nil {
-			// Fixed-address executable, no adjustment.
+			// Assume fixed-address executable and so no adjustment.
 			return 0, nil
 		}
+		if stextOffset == nil && start > 0 && start < 0x8000000000000000 {
+			// A regular user-mode executable. Compute the base offset using same
+			// arithmetics as in ET_DYN case below, see the explanation there.
+			// Ideally, the condition would just be "stextOffset == nil" as that
+			// represents the address of _stext symbol in the vmlinux image. Alas,
+			// the caller may skip reading it from the binary (it's expensive to scan
+			// all the symbols) and so it may be nil even for the kernel executable.
+			// So additionally check that the start is within the user-mode half of
+			// the 64-bit address space.
+			return start - offset + loadSegment.Off - loadSegment.Vaddr, nil
+		}
+		// Various kernel heuristics and cases follow.
 		if start == 0 && limit != 0 {
 			// ChromeOS remaps its kernel to 0. Nothing else should come
 			// down this path. Empirical values:
@@ -201,12 +212,6 @@ func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint6
 				return -*stextOffset, nil
 			}
 			return -loadSegment.Vaddr, nil
-		}
-		if loadSegment.Vaddr-loadSegment.Off == start-offset {
-			return offset, nil
-		}
-		if loadSegment.Vaddr == start-offset {
-			return offset, nil
 		}
 		if start >= loadSegment.Vaddr && limit > start && (offset == 0 || offset == pageOffsetPpc64 || offset == start) {
 			// Some kernels look like:
@@ -230,7 +235,7 @@ func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint6
 			//       start=0x198 limit=0x2f9fffff offset=0
 			//       VADDR=0xffffffff81000000
 			// stextOffset=0xffffffff81000198
-			return -(*stextOffset - start), nil
+			return start - *stextOffset, nil
 		}
 
 		return 0, fmt.Errorf("Don't know how to handle EXEC segment: %v start=0x%x limit=0x%x offset=0x%x", *loadSegment, start, limit, offset)

--- a/internal/elfexec/elfexec_test.go
+++ b/internal/elfexec/elfexec_test.go
@@ -51,7 +51,7 @@ func TestGetBase(t *testing.T) {
 		wanterr              bool
 	}{
 		{"exec", fhExec, nil, nil, 0x400000, 0, 0, 0, false},
-		{"exec offset", fhExec, lsOffset, nil, 0x400000, 0x800000, 0, 0, false},
+		{"exec offset", fhExec, lsOffset, nil, 0x400000, 0x800000, 0, 0x200000, false},
 		{"exec offset 2", fhExec, lsOffset, nil, 0x200000, 0x600000, 0, 0, false},
 		{"exec nomap", fhExec, nil, nil, 0, 0, 0, 0, false},
 		{"exec kernel", fhExec, kernelHeader, uint64p(0xffffffff81000198), 0xffffffff82000198, 0xffffffff83000198, 0, 0x1000000, false},
@@ -85,7 +85,7 @@ func TestGetBase(t *testing.T) {
 			continue
 		}
 		if base != tc.want {
-			t.Errorf("%s: want %x, got %x", tc.label, tc.want, base)
+			t.Errorf("%s: want 0x%x, got 0x%x", tc.label, tc.want, base)
 		}
 	}
 }


### PR DESCRIPTION
I was looking at a report where pprof wouldn't symbolize the data
collected for a Chrome binary using Linux perf (b/112303003). The mmap
information is:

start: 000000000272e000, limit: 0000000006b09000, offset: 000000000252f000

The ELF file header:

elf.FileHeader{Class:elf.ELFCLASS64, Data:elf.ELFDATA2LSB, Version:elf.EV_CURRENT, OSABI:elf.ELFOSABI_NONE, ABIVersion:0x0, ByteOrder:binary.LittleEndian, Type:elf.ET_EXEC, Machine:elf.EM_X86_64, Entry:0x272e000}

The code segment:

elf.ProgHeader{Type:elf.PT_LOAD, Flags:elf.PF_X+elf.PF_R, Off:0x252f000,
Vaddr:0x272e000, Paddr:0x272e000, Filesz:0x43da610, Memsz:0x43da610,
Align:0x1000}

The dynamic loader here mapped 0x6b09000-0x272e000 = 0x43db000 bytes
starting 0x252f000 file offset into 0x272e000 virtual address, exactly
as instructed by the program header (so, no ASLR). Thus, the base
adjustment should be zero. Yet, the current GetBase produced the base of
0x252f000 which is wrong. The reason for that is that the ET_EXEC branch
of GetBase doesn't handle the general case of non-zero mmap file offset,
but rather only supports a couple of special cases. This change makes
handling the case of user-mode ET_EXEC more generic.