### PR TITLE
Do not drop legacy profile alloc metrics when they are equal to in-use ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ script:
   - gofmtdiff=$(gofmt -s -d .) && if [ -n "$gofmtdiff" ]; then printf 'gofmt -s found:\n%s\n' "$gofmtdiff" && exit 1; fi
   - golintlint=$(golint ./...) && if [ -n "$golintlint" ]; then printf 'golint found:\n%s\n' "$golintlint" && exit 1; fi
   - go vet -all ./...
-  - gosimple ./...
   - ./test.sh
 
 after_success:


### PR DESCRIPTION
Fixes #432.

In #432 the user has a number of collected heap profiles in the legacy
format that they ask pprof to merge and open and the merge fails.

The reason for the error is that one of the profiles has the alloc
metric values equal to the in-use ones in the header line. Since pprof
legacy profile parser drops the alloc metrics in this case, the profiles
can't be merged since the merge requires that the sample types are the
same between merged profiles.

This PR makes the parser stop dropping the alloc metrics in this case.
This behavior seems more correct anyway as there doesn't seem to be a
strong reason for such implicit behavior and in case of parsing
profile.proto profiles there isn't such implicit behavior either. But
may be I am missing some history here, so please review.