### PR TITLE
Fix the CI build failing on master from "go tool vet" command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_install:
 script:
   - gofmtdiff=$(gofmt -s -d .) && if [ -n "$gofmtdiff" ]; then printf 'gofmt -s found:\n%s\n' "$gofmtdiff" && exit 1; fi
   - golintlint=$(golint ./...) && if [ -n "$golintlint" ]; then printf 'golint found:\n%s\n' "$golintlint" && exit 1; fi
-  - go tool vet -all .
+  - go vet -all ./...
   - gosimple ./...
   - ./test.sh
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ them through the use of the native binutils tools (addr2line and nm).
 
 Prerequisites:
 
-- Go development kit. Requires Go 1.9 or newer.
+- Go development kit of a [supported version](https://golang.org/doc/devel/release.html#policy).
   Follow [these instructions](http://golang.org/doc/code.html) to install the 
   go tool and set up GOPATH.
 


### PR DESCRIPTION
Also update the text around supported Go versions - refer to the
Go's policy on that which is two latest major releases.