### PR TITLE
fix regex for shortening java names in graph and flame view

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	javaRegExp = regexp.MustCompile(`^(?:[a-z]\w*\.)*([A-Z][\w\$]*\.(?:<init>|[a-z]\w*(?:\$\d+)?))(?:(?:\()|$)`)
+	javaRegExp = regexp.MustCompile(`^(?:[a-z]\w*\.)*([A-Z][\w\$]*\.(?:<init>|[a-z][\w\$]*(?:\$\d+)?))(?:(?:\()|$)`)
 	goRegExp   = regexp.MustCompile(`^(?:[\w\-\.]+\/)+(.+)`)
 	cppRegExp  = regexp.MustCompile(`^(?:(?:\(anonymous namespace\)::)(\w+$))|(?:(?:\(anonymous namespace\)::)?(?:[_a-zA-Z]\w*\::|)*(_*[A-Z]\w*::~?[_a-zA-Z]\w*)$)`)
 )

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -475,6 +475,14 @@ func TestShortenFunctionName(t *testing.T) {
 			"foo",
 			"foo",
 		},
+		{
+			"com.google.perftools.gwp.benchmark.FloatBench.lambda$run$0",
+			"FloatBench.lambda$run$0",
+		},
+		{
+			"java.bar.foo.FooBar.run$0",
+			"FooBar.run$0",
+		},
 	}
 	for _, tc := range testcases {
 		name := ShortenFunctionName(tc.name)


### PR DESCRIPTION
Fixes #429 