### PR TITLE
[Bug Fix] Propagate query args during URL redirect to preserve heap allocation type

### DIFF
--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -126,6 +126,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 	si = sampleIndex(flagInUseObjects, si, "inuse_objects", "-inuse_objects", o.UI)
 	si = sampleIndex(flagAllocSpace, si, "alloc_space", "-alloc_space", o.UI)
 	si = sampleIndex(flagAllocObjects, si, "alloc_objects", "-alloc_objects", o.UI)
+
 	pprofVariables.set("sample_index", si)
 
 	if *flagMeanDelay {

--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -126,7 +126,6 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 	si = sampleIndex(flagInUseObjects, si, "inuse_objects", "-inuse_objects", o.UI)
 	si = sampleIndex(flagAllocSpace, si, "alloc_space", "-alloc_space", o.UI)
 	si = sampleIndex(flagAllocObjects, si, "alloc_objects", "-alloc_objects", o.UI)
-
 	pprofVariables.set("sample_index", si)
 
 	if *flagMeanDelay {

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -184,13 +184,10 @@ func defaultWebServer(args *plugin.HTTPServerArgs) error {
 	return s.Serve(ln)
 }
 
-func redirectWithQuery(url string) http.HandlerFunc {
-	urlWithQuery := url
+func redirectWithQuery(path string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if queryStr := r.URL.Query().Encode(); queryStr != "" {
-			urlWithQuery = urlWithQuery + "?" + queryStr
-		}
-		http.Redirect(w, r, urlWithQuery, http.StatusTemporaryRedirect)
+		pathWithQuery := &gourl.URL{Path: path, RawQuery: r.URL.RawQuery}
+		http.Redirect(w, r, pathWithQuery.String(), http.StatusTemporaryRedirect)
 	}
 }
 

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -185,11 +185,12 @@ func defaultWebServer(args *plugin.HTTPServerArgs) error {
 }
 
 func redirectWithQuery(url string) http.HandlerFunc {
+	urlWithQuery := url
 	return func(w http.ResponseWriter, r *http.Request) {
 		if queryStr := r.URL.Query().Encode(); queryStr != "" {
-			url = url + "?" + queryStr
+			urlWithQuery = urlWithQuery + "?" + queryStr
 		}
-		http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+		http.Redirect(w, r, urlWithQuery, http.StatusTemporaryRedirect)
 	}
 }
 

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -186,14 +186,10 @@ func defaultWebServer(args *plugin.HTTPServerArgs) error {
 
 func redirectWithQuery(url string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var (
-			urlWithQuery = url
-			queryStr     = r.URL.Query().Encode()
-		)
-		if queryStr != "" {
-			urlWithQuery = urlWithQuery + "?" + queryStr
+		if queryStr := r.URL.Query().Encode(); queryStr != "" {
+			url = url + "?" + queryStr
 		}
-		http.Redirect(w, r, urlWithQuery, http.StatusTemporaryRedirect)
+		http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 	}
 }
 

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -179,9 +179,22 @@ func defaultWebServer(args *plugin.HTTPServerArgs) error {
 	// https://github.com/google/pprof/pull/348
 	mux := http.NewServeMux()
 	mux.Handle("/ui/", http.StripPrefix("/ui", handler))
-	mux.Handle("/", http.RedirectHandler("/ui/", http.StatusTemporaryRedirect))
+	mux.Handle("/", redirectWithQuery("/ui"))
 	s := &http.Server{Handler: mux}
 	return s.Serve(ln)
+}
+
+func redirectWithQuery(url string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var (
+			urlWithQuery = url
+			queryStr     = r.URL.Query().Encode()
+		)
+		if queryStr != "" {
+			urlWithQuery = urlWithQuery + "?" + queryStr
+		}
+		http.Redirect(w, r, urlWithQuery, http.StatusTemporaryRedirect)
+	}
 }
 
 func isLocalhost(host string) bool {


### PR DESCRIPTION
Master branch of PPROF has a bug introduced 8 months ago by #348 which breaks invocations like:

`pprof -http localhost:8080 -alloc_space <FILE>`

If you run that command, it will display `inuse_space` instead of `alloc_space`. The reason is that the decision to display `alloc_space` is propagated as a query arg, and the `http.RedirectHandler` that the existing code is using doesn't propagate them.

I verified the bug exists (and is fixed in this P.R) by running the same command described above.