### PR TITLE
Use demangled symbols in disassembly report

### DIFF
--- a/internal/binutils/binutils.go
+++ b/internal/binutils/binutils.go
@@ -381,7 +381,7 @@ func (f *file) Close() error {
 
 func (f *file) Symbols(r *regexp.Regexp, addr uint64) ([]*plugin.Sym, error) {
 	// Get from nm a list of symbols sorted by address.
-	cmd := exec.Command(f.b.nm, "-n", f.name)
+	cmd := exec.Command(f.b.nm, "-n", "-C", f.name)
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("%v: %v", cmd.Args, err)


### PR DESCRIPTION
In the current disassembly report, not all symbols are demangled. This results in readability challenges with examining the report. 

This PR uses the -C option with objdump to demangle symbols, and updates disassembly parser to extract demangled symbols and ignore the corresponding demangled symbols.

This PR does not demangle the symbols itself but relies on 'objdump' to perform the demangling.

