### PR TITLE
Support relative paths for binaries

### DIFF
--- a/internal/binutils/binutils.go
+++ b/internal/binutils/binutils.go
@@ -179,7 +179,11 @@ func (bu *Binutils) Open(name string, start, limit, offset uint64) (plugin.ObjFi
 	// This uses magic numbers, mainly to provide better error messages but
 	// it should also help speed.
 
-	if _, err := os.Stat(name); err != nil {
+	abspath, err := filepath.Abs(name)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := os.Stat(abspath); err != nil {
 		// For testing, do not require file name to exist.
 		if strings.Contains(b.addr2line, "testdata/") {
 			return &fileAddr2Line{file: file{b: b, name: name}}, nil


### PR DESCRIPTION
Open in Binutils may fail if the path to the file is not absolute. 

```
$ PPROF_BINARY_PATH=. go run /Users/username/go/src/github.com/google/pprof/pprof.go ./kubelet-containerd.pb.gz
File: kubelet
Build ID: ccfe84cf2189a82ee5382ab4b869fc207f0a8a46
Type: cpu
Time: Feb 26, 2019 at 10:53am (PST)
Duration: 2mins, Total samples = 11.99s ( 9.99%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) ^D

$ go version
go version go1.12 darwin/amd64

$ uname -a
Darwin  18.2.0 Darwin Kernel Version 18.2.0: Thu Dec 20 20:46:53 PST 2018; root:xnu-4903.241.1~1/RELEASE_X86_64 x86_64

```