### PR TITLE
Recognize an executable without symbols

### DIFF
--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -15,6 +15,7 @@
 package driver
 
 import (
+	"debug/elf"
 	"errors"
 	"fmt"
 	"os"
@@ -95,7 +96,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 	// Recognize first argument as an executable or buildid override.
 	if len(args) > 1 {
 		arg0 := args[0]
-		if file, err := o.Obj.Open(arg0, 0, ^uint64(0), 0); err == nil {
+		if file, err := o.Obj.Open(arg0, 0, ^uint64(0), 0); err == nil || err == elf.ErrNoSymbols {
 			file.Close()
 			execName = arg0
 			args = args[1:]


### PR DESCRIPTION
When a binary provided to pprof has no symbols, it is not recognized as a binary. This happens because the err value is only checked against 'nil'.

This PR fixes this issue by checking the err value against elf.ErrNoSymbols in addition to nil.