### PR TITLE
Allow to ignore build ID when reading local files.

### DIFF
--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -38,6 +38,7 @@ type source struct {
 	HTTPHostport       string
 	HTTPDisableBrowser bool
 	Comment            string
+	IgnoreBuildID      bool
 }
 
 // parseFlags parses the command lines through the specified flags package
@@ -68,6 +69,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 
 	flagHTTP := flag.String("http", "", "Present interactive web UI at the specified http host:port")
 	flagNoBrowser := flag.Bool("no_browser", false, "Skip opening a browswer for the interactive web UI")
+	flagIgnoreBuildID := flag.Bool("ignore_buildid", false, "Ignore build ID when reading local symbol files.")
 
 	// Flags used during command processing
 	installedFlags := installFlags(flag)
@@ -148,6 +150,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 		HTTPHostport:       *flagHTTP,
 		HTTPDisableBrowser: *flagNoBrowser,
 		Comment:            *flagAddComment,
+		IgnoreBuildID:      *flagIgnoreBuildID,
 	}
 
 	if err := source.addBaseProfiles(*flagBase, *flagDiffBase); err != nil {

--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -69,7 +69,7 @@ func parseFlags(o *plugin.Options) (*source, []string, error) {
 
 	flagHTTP := flag.String("http", "", "Present interactive web UI at the specified http host:port")
 	flagNoBrowser := flag.Bool("no_browser", false, "Skip opening a browswer for the interactive web UI")
-	flagIgnoreBuildID := flag.Bool("ignore_buildid", false, "Ignore build ID when reading local symbol files.")
+	flagIgnoreBuildID := flag.Bool("force_ignore_buildid", false, "Ignore build ID when reading local symbol files.")
 
 	// Flags used during command processing
 	installedFlags := installFlags(flag)

--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -423,7 +423,7 @@ mapping:
 				if f, err := obj.Open(name, m.Start, m.Limit, m.Offset); err == nil {
 					defer f.Close()
 					fileBuildID := f.BuildID()
-					if m.BuildID != "" && m.BuildID != fileBuildID {
+					if !s.IgnoreBuildID && m.BuildID != "" && m.BuildID != fileBuildID {
 						ui.PrintErr("Ignoring local file " + name + ": build-id mismatch (" + m.BuildID + " != " + fileBuildID + ")")
 					} else {
 						m.File = name

--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -426,6 +426,9 @@ mapping:
 					if !s.IgnoreBuildID && m.BuildID != "" && m.BuildID != fileBuildID {
 						ui.PrintErr("Ignoring local file " + name + ": build-id mismatch (" + m.BuildID + " != " + fileBuildID + ")")
 					} else {
+						if s.IgnoreBuildID && m.BuildID != "" && m.BuildID != fileBuildID {
+							ui.PrintErr("Using local focal file " + name + " with build-id mismatch (" + m.BuildID + " != " + fileBuildID + ") because --force_ignore_buildid was specified. THIS CAN LEAD TO COMPLETELY INCORRECT RESULTS. PROCEED WITH CAUTION.")
+						}
 						m.File = name
 						continue mapping
 					}

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -118,7 +118,7 @@ func TestSymbolizationPathIgnoreBuildID(t *testing.T) {
 		env, file, buildID, want string
 		msgCount                 int
 	}{
-		{"/alternate/architecture", "/usr/bin/binary", "WRONG", "/alternate/architecture/binary", 0},
+		{"/alternate/architecture", "/usr/bin/binary", "WRONG", "/alternate/architecture/binary", 1},
 		{"/alternate/architecture", "/usr/bin/binary", "abcde10001", "/alternate/architecture/binary", 0},
 	} {
 		os.Setenv("PPROF_BINARY_PATH", tc.env)


### PR DESCRIPTION
I ran into a case where the Build IDs did not literally match (they had
different padding), but I knew it would be fine to use them. It would be
nice to have a escape hatch flag for these situations.

Please take a look. Thanks!