### PR TITLE
Correct help docs for specifying a binary

### DIFF
--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -296,18 +296,18 @@ var usageMsgHdr = `usage:
 
 Produce output in the specified format.
 
-   pprof <format> [options] [binary] <source> ...
+   pprof [binary] <format> [options] <source> ...
 
 Omit the format to get an interactive shell whose commands can be used
 to generate various views of a profile
 
-   pprof [options] [binary] <source> ...
+   pprof [binary] [options] <source> ...
 
 Omit the format and provide the "-http" flag to get an interactive web
 interface at the specified host:port that can be used to navigate through
 various views of a profile.
 
-   pprof -http [host]:[port] [options] [binary] <source> ...
+   pprof [binary] -http [host]:[port] [options] <source> ...
 
 Details:
 `


### PR DESCRIPTION
When the binary is specified after the options, it's treated like another profile.

I believe the binary needs to be specified first.