### PR TITLE
Add flamegraph to list of dynamic search links

### DIFF
--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -853,7 +853,7 @@ function viewer(baseUrl, nodes) {
     toptable.addEventListener('touchstart', handleTopClick);
   }
 
-  const ids = ['topbtn', 'graphbtn', 'peek', 'list', 'disasm',
+  const ids = ['topbtn', 'graphbtn', 'flamegraph', 'peek', 'list', 'disasm',
                'focus', 'ignore', 'hide', 'show', 'show-from'];
   ids.forEach(makeSearchLinkDynamic);
 


### PR DESCRIPTION
This adds `flamegraph` to the list of dynamic search links so that query parameters (esp. regex filters) are retained when navigating to/from the flamegraph view. This seems to just be an oversight since flamegraph was added later as a visualization option.

I have tested it manually by applying filters in the "Graph" view and then navigating to "Flame Graph". You can also see that, after this change, the `href` for the flamegraph link is dynamically updated with any query parameters like the other links:

![fix-flamegraph](https://user-images.githubusercontent.com/814226/57802624-4192dc00-770b-11e9-9073-3f3d5901f436.png)

Previously, the `href` would always be fixed with `./flamegraph` (from the template), so navigating to the flamegraph would reset all filters and other query parameters.

Fixes #431