### PR TITLE
Fix keypress focus: updateUrl is not defined

### DIFF
--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -610,8 +610,9 @@ function viewer(baseUrl, nodes) {
 
   function handleKey(e) {
     if (e.keyCode != 13) return;
-    window.location.href =
-        updateUrl(new URL(window.location.href), 'f');
+    setHrefParams(window.location, function (params) {
+      params.set('f', search.value);
+    });
     e.preventDefault();
   }
 
@@ -650,9 +651,11 @@ function viewer(baseUrl, nodes) {
     })
 
     // add matching items that are not currently selected.
-    for (let n = 0; n < nodes.length; n++) {
-      if (!selected.has(n) && match(nodes[n])) {
-        select(n, document.getElementById('node' + n));
+    if (nodes) {
+      for (let n = 0; n < nodes.length; n++) {
+        if (!selected.has(n) && match(nodes[n])) {
+          select(n, document.getElementById('node' + n));
+        }
       }
     }
 


### PR DESCRIPTION
`updateUrl` was refactored in away in #414, leading to `Uncaught ReferenceError: updateUrl is not defined` (and the keypress no longer works).

For the `sourcelisting` page, [`nodes===null`](https://github.com/google/pprof/blob/master/internal/driver/webhtml.go#L1019), leading to: `Uncaught TypeError: Cannot read property 'length' of null`.

These fixes were validated through manual testing. I believe given the scope of the changes they are unlikely to cause distant regressions.

Fixes #463.