### PR TITLE
Fix Travis build call to staticcheck

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -23,13 +23,7 @@ echo "mode: $MODE" > coverage.txt
 # All packages.
 PKG=$(go list ./...)
 
-staticcheck -ignore '
-github.com/google/pprof/internal/binutils/binutils_test.go:SA6004
-github.com/google/pprof/internal/driver/svg.go:SA6004
-github.com/google/pprof/internal/report/source_test.go:SA6004
-github.com/google/pprof/profile/filter_test.go:SA6004
-' $PKG
-unused $PKG
+staticcheck $PKG
 
 # Packages that have any tests.
 PKG=$(go list -f '{{if .TestGoFiles}} {{.ImportPath}} {{end}}' ./...)


### PR DESCRIPTION
`staticcheck`'s `-ignore` flag [has been removed](http://staticcheck.io/changes/2019.1) in favor of [Linter directives](http://staticcheck.io/docs/#ignoring-problems), and the `unused` tool was merged into `staticcheck`, breaking the Travis build. These lint ignores may not be necessary anymore anyway due to improvements in the static checker.