### PR TITLE
Continuous Fuzzing Integration via Fuzzit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
       go: 1.12.x
     - os: linux
       go: master
+      env: WITH_FUZZIT=1
     - os: osx
       osx_image: xcode8.3
       go: 1.11.x
@@ -55,6 +56,11 @@ script:
   - golintlint=$(golint ./...) && if [ -n "$golintlint" ]; then printf 'golint found:\n%s\n' "$golintlint" && exit 1; fi
   - go vet -all ./...
   - ./test.sh
+  - ./fuzzit.sh
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+env:
+  global:
+    secure: "f5iqvHrpwpgTT670w8Zu/Cwc8/jukjf1QDt82W0/a7WunV/TJ4S0MTh1vM6qyvChC1r9xzBYWWiNcCyLkUdSMkY1hxVAIQ4tjy2zUWS26iYJ4oVfO4E0KuUp6YoBQXfQiyGzhTMrsGsMXXKMV3Ger/S3GPEy2eMD3qJteSGm1MW1lrs2SHLR/7H2G2a6dD4oEA732Sy/lXUkpr3CELGPs5LCjek7FcaXcgtrtF46zAd1kAhRtlbD28WRMvJNefdrhhSvM/mSQTVYp9btBoz6R/WS6+qD2COo8sZrpgxQjwMCKJrPdlPnrTzTBezUBqhjo9LEJYw06HAVD4KYQc3JTFeGegHhT0raCopLNCV0vy+D3yJfaBirshNKmXAP5AiQzL8VW1KOFsQa+LOd9I3o/7eYr2hu//ne4GFVlNXhYBM5+wuRZ+DLOUV2s4W3LZM9KqBfXB+I8ijTfgiu8NsaAQBqX62RYN0xqfwEKf/NjITtVggxEHREn6cGmSCumLD29MZzdTODURMy1V6yGcrzhGhgRyRRmYa3xxI/F0udDIM4bVPJjAa72kRTfme+koQ9q/AWRErxEAW36A6FyfMnr8PHBgzCh+I1zx9wCNwcgDkM2tKJbLhcz3XyjOV2PsJ6GMdQd9djSaIk/zrH7+JOGQKjC7Ztr6WGlMInV9VtO9Y="

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.org/google/pprof.svg?branch=master)](https://travis-ci.org/google/pprof)
 [![codecov](https://codecov.io/gh/google/pprof/graph/badge.svg)](https://codecov.io/gh/google/pprof)
+[![fuzzit](https://app.fuzzit.dev/badge?org_id=google-pprof&branch=master)](https://fuzzit.dev)
 
 # Introduction
 

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -xe
+
+# limit fuzzing to only one config from the matrix
+if [ -z "${WITH_FUZZIT}" ]; then
+    exit 0
+fi
+
+# go-fuzz doesn't support modules yet, so ensure we do everything
+# the old style GOPATH way
+export GO111MODULE="off"
+
+# install go-fuzz
+go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+
+# target name can only contain lower-case letters (a-z), digits (0-9) and a dash (-)
+# to add another target, make sure to create it with `fuzzit create target`
+# before using `fuzzit create job`
+TARGET="fuzzer"
+
+go-fuzz-build -libfuzzer -o ${TARGET}.a github.com/google/pprof/fuzz
+clang -fsanitize=fuzzer ${TARGET}.a -o ${TARGET}
+
+# install fuzzit for talking to fuzzit.dev service
+# or latest version:
+# https://github.com/fuzzitdev/fuzzit/releases/latest/download/fuzzit_Linux_x86_64
+wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.23/fuzzit_Linux_x86_64
+chmod a+x fuzzit
+
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    TYPE=fuzzing
+else
+    TYPE=local-regression
+fi
+
+# upload fuzz target for long fuzz testing on fuzzit.dev server 
+# or run locally for regression, depending on --type
+./fuzzit create job --type $TYPE google-pprof/${TARGET} ${TARGET}


### PR DESCRIPTION
Hi Team,

I'm Yevgeny (Founder of [Fuzzit](https://fuzzit.dev))

This PR adds a continuous fuzzing integration to pprof travis pipeline via [Fuzzit](https://fuzzit.dev) service.

This means the following:

- Every time new code is pushed to master new fuzzers are built and push to fuzzit where they run continuously generate new test-cases and alerts if new crashes are found
- Every pull-request the fuzzers runs through a quick regression tests with the generated test-cases from the previous step. If something new/old bugs are introduced you will see this immediately in the Travis check.

To take ownership of the organisation, please login to https://app.fuzzit.dev and let me know your account.

Please review and feel free to comment/ask questions.