### PR TITLE
webhtml: fix search input svg icon

### DIFF
--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -14,10 +14,12 @@
 
 package driver
 
-import "html/template"
+import (
+	"html/template"
 
-import "github.com/google/pprof/third_party/d3"
-import "github.com/google/pprof/third_party/d3flamegraph"
+	"github.com/google/pprof/third_party/d3"
+	"github.com/google/pprof/third_party/d3flamegraph"
+)
 
 // addTemplates adds a set of template definitions to templates.
 func addTemplates(templates *template.Template) {
@@ -91,7 +93,7 @@ a {
   text-align: left;
 }
 .header input {
-  background: white url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' style='pointer-events:none;display:block;width:100%25;height:100%25;fill:#757575'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61.0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") no-repeat 4px center/20px 20px;
+  background: white url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' style='pointer-events:none;display:block;width:100%25;height:100%25;fill:%23757575'%3E%3Cpath d='M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61.0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") no-repeat 4px center/20px 20px;
   border: 1px solid #d1d2d3;
   border-radius: 2px 0 0 2px;
   padding: 0.25em;


### PR DESCRIPTION
I have noticed, that in the web ui, the icon of magnifier glass of the search input isn't rendered. Of all browsers that I've checked Safari is the only one that renders the icon, while in Firefox and Chrome the icon is missing:

<img width="778" alt="Screenshot 2019-09-24 at 12 00 43" src="https://user-images.githubusercontent.com/88045/65502706-9ddce800-dec3-11e9-9d72-64d30fca1a96.png">

This PR fixes, what I believe was a typo, by escaping the hex value of icon's fill colour.

**Update** After the fix:
<img width="921" alt="Screenshot 2019-09-24 at 20 16 27" src="https://user-images.githubusercontent.com/88045/65538736-4876fa00-df08-11e9-8d2a-f55d7fb0e693.png">
