### PR TITLE
webhtml: reenable sort option for flamegraphs

### DIFF
--- a/internal/driver/webhtml.go
+++ b/internal/driver/webhtml.go
@@ -1094,6 +1094,7 @@ function viewer(baseUrl, nodes) {
       .transitionDuration(750)
       .transitionEase(d3.easeCubic)
       .inverted(true)
+      .sort(true)
       .title('')
       .tooltip(false)
       .details(document.getElementById('flamegraphdetails'));


### PR DESCRIPTION
This sorts flamegraph elements lexicographically such that two similar profiles can be compared side-by-side to eyeball differences in flamegraph profile shapes and sizes.

Flamegraph elements prior to #367 were sorted, but since then, it has been difficult to eyeball 2 similar profiles side-by-side, as the elements appear in a somewhat random order.

## Before sorting profile comparison:
<img width="1440" alt="Screenshot 2019-10-21 at 22 50 25" src="https://user-images.githubusercontent.com/1525809/67246072-64ad7e80-f455-11e9-8265-d88369ddb4ad.png">

## After sorting profile comparison:
<img width="1440" alt="Screenshot 2019-10-21 at 22 50 18" src="https://user-images.githubusercontent.com/1525809/67246079-67a86f00-f455-11e9-91c9-cdcaf2ef2fa2.png">