### PR TITLE
fix how template function names are simplified (follow-up to #498)

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -28,9 +28,18 @@ import (
 )
 
 var (
-	javaRegExp               = regexp.MustCompile(`^(?:[a-z]\w*\.)*([A-Z][\w\$]*\.(?:<init>|[a-z][\w\$]*(?:\$\d+)?))(?:(?:\()|$)`)
-	goRegExp                 = regexp.MustCompile(`^(?:[\w\-\.]+\/)+(.+)`)
-	cppRegExp                = regexp.MustCompile(`^(?:[_a-zA-Z]\w*::)+(_*[A-Z]\w*::~?[_a-zA-Z]\w*)`)
+	// Removes package name and method arugments for Java method names.
+	// See tests for examples.
+	javaRegExp = regexp.MustCompile(`^(?:[a-z]\w*\.)*([A-Z][\w\$]*\.(?:<init>|[a-z][\w\$]*(?:\$\d+)?))(?:(?:\()|$)`)
+	// Removes package name and method arugments for Go function names.
+	// See tests for examples.
+	goRegExp = regexp.MustCompile(`^(?:[\w\-\.]+\/)+(.+)`)
+	// Strips C++ namespace prefix from a C++ function / method name.
+	// NOTE: Make sure to keep the template parameters in the name. Normally,
+	// template parameters are stripped from the C++ names but when
+	// -symbolize=demangle=templates flag is used, they will not be.
+	// See tests for examples.
+	cppRegExp                = regexp.MustCompile(`^(?:[_a-zA-Z]\w*::)+(_*[A-Z]\w*::~?[_a-zA-Z]\w*(?:<.*>)?)`)
 	cppAnonymousPrefixRegExp = regexp.MustCompile(`^\(anonymous namespace\)::`)
 )
 

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -476,8 +476,8 @@ func TestShortenFunctionName(t *testing.T) {
 			"Foo::bar",
 		},
 		{
-			"Foo::bar::baz<float, long, int>::operator()",
-			"Foo::bar::baz<float, long, int>::operator()",
+			"cpp::namespace::Class::method<float, long, int>()",
+			"Class::method<float, long, int>",
 		},
 		{
 			"foo",


### PR DESCRIPTION
For C++ functions, the template parameters should be kept as part of shortened names.
Generally, template parameters are stripped from the C++ names but when `-symbolize=demangle=templates` flag is used, they will not be. In this case, we want to display the template parameter as part of the name. 

This change also adds comments to explain how regexps for shortening function names are used.

