### PR TITLE
Make tag filter of the form `-tagfilter=foo=1` work.

### DIFF
--- a/internal/driver/driver_focus.go
+++ b/internal/driver/driver_focus.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/pprof/profile"
 )
 
-var tagFilterRangeRx = regexp.MustCompile("([+-]?[[:digit:]]+)([[:alpha:]]+)")
+var tagFilterRangeRx = regexp.MustCompile("([+-]?[[:digit:]]+)([[:alpha:]]+)?")
 
 // applyFocus filters samples based on the focus/ignore options
 func applyFocus(prof *profile.Profile, numLabelUnits map[string]string, v variables, ui plugin.UI) error {

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -1455,6 +1455,55 @@ func TestNumericTagFilter(t *testing.T) {
 			map[string]string{"bytes": "bytes"},
 			false,
 		},
+		{
+			"Match exact value, unitless tag",
+			"pid=123",
+			map[string][]int64{"pid": {123}},
+			nil,
+			true,
+		},
+		{
+			"Match range, unitless tag",
+			"pid=123:123",
+			map[string][]int64{"pid": {123}},
+			nil,
+			true,
+		},
+		{
+			"Don't match range, unitless tag",
+			"pid=124:124",
+			map[string][]int64{"pid": {123}},
+			nil,
+			false,
+		},
+		{
+			"Match range without upper bound, unitless tag",
+			"pid=100:",
+			map[string][]int64{"pid": {123}},
+			nil,
+			true,
+		},
+		{
+			"Don't match range without upper bound, unitless tag",
+			"pid=200:",
+			map[string][]int64{"pid": {123}},
+			nil,
+			false,
+		},
+		{
+			"Match range without lower bound, unitless tag",
+			"pid=:200",
+			map[string][]int64{"pid": {123}},
+			nil,
+			true,
+		},
+		{
+			"Don't match range without lower bound, unitless tag",
+			"pid=:100",
+			map[string][]int64{"pid": {123}},
+			nil,
+			false,
+		},
 	}
 	for _, test := range tagFilterTests {
 		t.Run(test.desc, func(t *testing.T) {


### PR DESCRIPTION
Tag filters like `-tagfilter=foo=1` currently cannot be used to filter
by a unitless numeric tag as the tag filter regular expression expects
the unit part to be always present.  They can be made working by using
`-tagfilter=foo=1unit` instead, but that's weird syntax. So fix this by
merely making the unit part optional.

I was wondering if this simple fix could have any unintended effects but
as far as I can tell from testing it does not.