### PR TITLE
profile: avoid string(int) conversion

### DIFF
--- a/profile/proto.go
+++ b/profile/proto.go
@@ -235,7 +235,7 @@ func decodeField(b *buffer, data []byte) ([]byte, error) {
 		b.u64 = uint64(le32(data[:4]))
 		data = data[4:]
 	default:
-		return nil, errors.New("unknown wire type: " + string(b.typ))
+		return nil, errors.New("unknown wire type: " + string(rune(b.typ)))
 	}
 
 	return data, nil


### PR DESCRIPTION
As per the vet check being introduced in 1.15
(https://github.com/golang/go/issues/32479), conversions of the form
string(int) are flagged by go vet. The suggested fix is to instead use
string(rune).

Additionally, since google/pprof is vendored into the go tree, we avoid
test failures from vet flagging this dependency (see
CL https://go-review.googlesource.com/c/go/+/220977).