### PR TITLE
profile: change error message to print string representation of wire type

### DIFF
--- a/profile/proto.go
+++ b/profile/proto.go
@@ -33,7 +33,10 @@
 
 package profile
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 type buffer struct {
 	field int // field tag
@@ -235,7 +238,7 @@ func decodeField(b *buffer, data []byte) ([]byte, error) {
 		b.u64 = uint64(le32(data[:4]))
 		data = data[4:]
 	default:
-		return nil, errors.New("unknown wire type: " + string(rune(b.typ)))
+		return nil, fmt.Errorf("unknown wire type: %d", b.typ)
 	}
 
 	return data, nil


### PR DESCRIPTION
The proto write type code stored in buffer stores unprintable values
(e.g. 2 when unmarshalling). The desired output when printing an error
message is the base-10 string representation of the integer (i.e. strconv.Itoa),
instead of the current behavior (string(int) or string(rune)), which return the
utf8 literal corresponding where the integer represents a unicode codepoint.

As pointed out by @ianlancetaylor in https://github.com/google/pprof/commit/4ac0da8#commitcomment-37524728,
commit 4ac0da8 preserves the previous incorrect behavior to pass a vet check,
whereas this change prints the desired output.

Updates golang/go#32479.