### PR TITLE
Filter out null characters in tags.

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -686,6 +686,8 @@ func defaultLabelFormat(v int64, key string) string {
 func (m TagMap) findOrAddTag(label, unit string, value int64) *Tag {
 	l := m[label]
 	if l == nil {
+		// Filter out all null characters since dot is not able to parse them
+		label = strings.ReplaceAll(label, "\000", "")
 		l = &Tag{
 			Name:  label,
 			Unit:  unit,


### PR DESCRIPTION
Null characters in tags will lead to null characters in labels, and `dot` is not able to parse such labels.