### PR TITLE
Remove support for go 1.12 and add support for go 1.14 in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,35 +5,35 @@ go_import_path: github.com/google/pprof
 matrix:
   include:
     - os: linux
-      go: 1.12.x
-    - os: linux
       go: 1.13.x
+    - os: linux
+      go: 1.14.x
     - os: linux
       go: master
     - os: osx
       osx_image: xcode8.3
-      go: 1.12.x
+      go: 1.13.x
     - os: osx
       osx_image: xcode8.3
-      go: 1.13.x
+      go: 1.14.x
     - os: osx
       osx_image: xcode8.3
       go: master
     - os: osx
       osx_image: xcode9.4
-      go: 1.12.x
+      go: 1.13.x
     - os: osx
       osx_image: xcode9.4
-      go: 1.13.x
+      go: 1.14.x
     - os: osx
       osx_image: xcode9.4
       go: master
     - os: osx
       osx_image: xcode10.1
-      go: 1.12.x
+      go: 1.13.x
     - os: osx
       osx_image: xcode10.1
-      go: 1.13.x
+      go: 1.14.x
     - os: osx
       osx_image: xcode10.1
       go: master


### PR DESCRIPTION
Since the release of go 1.14, go 1.12 is not supported any more: https://golang.org/doc/devel/release.html#policy.  