### PR TITLE
Remove the "seconds" parameter to fix tests.

### DIFF
--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -663,7 +663,6 @@ func TestHTTPSWithServerCertFetch(t *testing.T) {
 	address := "https://" + "localhost:" + portStr + "/debug/pprof/goroutine"
 	s := &source{
 		Sources:   []string{address},
-		Seconds:   10,
 		Timeout:   10,
 		Symbolize: "remote",
 	}

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -575,7 +575,6 @@ func TestHTTPSInsecure(t *testing.T) {
 	address := "https+insecure://" + l.Addr().String() + "/debug/pprof/goroutine"
 	s := &source{
 		Sources:   []string{address},
-		Seconds:   10,
 		Timeout:   10,
 		Symbolize: "remote",
 	}


### PR DESCRIPTION
Fixes: #526

Due to https://go.googlesource.com/go/+/2ff1e3e, the behavior changes to
> Providing the "seconds" parameter to other types of profiles is an error.