### PR TITLE
Fixed demangling fail on mac.

### DIFF
--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -223,7 +223,9 @@ func Demangle(prof *profile.Profile, force bool, demanglerMode string) {
 		if fn.Name != "" && fn.SystemName != fn.Name {
 			continue // Already demangled.
 		}
-		copy(o, options)
+		if(strings.HasPrefix(fn.SystemName, "__")) {
+			fn.SystemName = fn.SystemName[1:]
+		}
 		if demangled := demangle.Filter(fn.SystemName, o...); demangled != fn.SystemName {
 			fn.Name = demangled
 			continue


### PR DESCRIPTION
the demangle library doesn't like the double underscore names. This patch will trim one underscore to make it behave the same as mac's c++filt tool.