### PR TITLE
settings: Only call MkdirAll on save

### DIFF
--- a/internal/driver/settings.go
+++ b/internal/driver/settings.go
@@ -61,7 +61,7 @@ func writeSettings(fname string, settings *settings) error {
 	// XDG specifies permissions 0700 when creating settings dirs:
 	// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 	if err := os.MkdirAll(filepath.Dir(fname), 0700); err != nil {
-		return err
+		return fmt.Errorf("failed to create settings directory: %w", err)
 	}
 
 	if err := ioutil.WriteFile(fname, data, 0644); err != nil {

--- a/internal/driver/settings.go
+++ b/internal/driver/settings.go
@@ -28,11 +28,7 @@ func settingsFileName() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	dir = filepath.Join(dir, "pprof")
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "settings.json"), nil
+	return filepath.Join(dir, "pprof", "settings.json"), nil
 }
 
 // readSettings reads settings from fname.
@@ -60,6 +56,17 @@ func writeSettings(fname string, settings *settings) error {
 	if err != nil {
 		return fmt.Errorf("could not encode settings: %w", err)
 	}
+
+	// create the settings directory if it does not exist
+	fdir := filepath.Dir(fname)
+	if _, err := os.Stat(fdir); os.IsNotExist(err) {
+		// XDG specifies permissions 0700 when creating settings dirs:
+		// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+		if err := os.MkdirAll(fdir, 0700); err != nil {
+			return err
+		}
+	}
+
 	if err := ioutil.WriteFile(fname, data, 0644); err != nil {
 		return fmt.Errorf("failed to write settings: %w", err)
 	}

--- a/internal/driver/settings.go
+++ b/internal/driver/settings.go
@@ -58,13 +58,10 @@ func writeSettings(fname string, settings *settings) error {
 	}
 
 	// create the settings directory if it does not exist
-	fdir := filepath.Dir(fname)
-	if _, err := os.Stat(fdir); os.IsNotExist(err) {
-		// XDG specifies permissions 0700 when creating settings dirs:
-		// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-		if err := os.MkdirAll(fdir, 0700); err != nil {
-			return err
-		}
+	// XDG specifies permissions 0700 when creating settings dirs:
+	// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+	if err := os.MkdirAll(filepath.Dir(fname), 0700); err != nil {
+		return err
 	}
 
 	if err := ioutil.WriteFile(fname, data, 0644); err != nil {


### PR DESCRIPTION
Previously settingsFileName() created the ~/.config/pprof directory
if it did not exist. However, this is not possible for user nobody,
since its home directory is set to "/nonexistent". Instead, only
create the directory when we actually attempt to save the file, so
the error will happen at the appropriate interaction. This als
prevents pprof from creating empty settings directories.

Fixes the following error when running pprof's web UI as user nobody:

    mkdir /nonexistent: permission denied