### PR TITLE
Remove extra version check on GNU objdump.

### DIFF
--- a/internal/binutils/binutils.go
+++ b/internal/binutils/binutils.go
@@ -233,7 +233,7 @@ func isLLVMObjdump(output string) bool {
 // and returns a boolean indicating if the given binary is a GNU
 // binutils objdump binary. No version check is performed.
 func isBuObjdump(output string) bool {
-	return strings.Contains(output, "GNU objdump") && strings.Contains(output, "Binutils")
+	return strings.Contains(output, "GNU objdump")
 }
 
 // findExe looks for an executable command on a set of paths.

--- a/internal/binutils/binutils_test.go
+++ b/internal/binutils/binutils_test.go
@@ -494,7 +494,7 @@ func TestObjdumpVersionChecks(t *testing.T) {
 		},
 		{
 			desc: "Invalid GNU objdump version string",
-			ver:  "GNU objdump (GNU Banutils) 2.34\nCopyright (C) 2020 Free Software Foundation, Inc.",
+			ver:  "GNU nm (GNU Binutils) 2.34\nCopyright (C) 2020 Free Software Foundation, Inc.",
 			want: false,
 		},
 	} {


### PR DESCRIPTION
Remove the extra version check to be compatible with different versions of GNU objdump (e.g. specialized version built internally within Google).