### PR TITLE
Change llvm-symbolizer to use --inlines

### DIFF
--- a/internal/binutils/addr2liner_llvm.go
+++ b/internal/binutils/addr2liner_llvm.go
@@ -70,7 +70,7 @@ func newLLVMSymbolizer(cmd, file string, base uint64) (*llvmSymbolizer, error) {
 	}
 
 	j := &llvmSymbolizerJob{
-		cmd: exec.Command(cmd, "-inlining", "-demangle=false"),
+		cmd: exec.Command(cmd, "--inlines", "-demangle=false"),
 	}
 
 	var err error


### PR DESCRIPTION
The single dash -inlining is exotic. Change it to the double-dash and canonical
option --inlines (canonical in the sense that --inlines is also supported by
addr2line). The one-dash long option is discouraged due to its collision with
grouped short options.

-demangle=false is also exotic but not changed. It is currently
implemented as a legacy alias (llvm/llvm-project@c558c22cab9a555d2e521102b775759381e9727f).
We can change it to --no-demangle once support for llvm-symbolizer < 9.0 is
dropped (https://reviews.llvm.org/D56773).