### PR TITLE
Escape labels when generating graph

### DIFF
--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -127,7 +127,7 @@ func (b *builder) addLegend() {
 	}
 	title := labels[0]
 	fmt.Fprintf(b, `subgraph cluster_L { "%s" [shape=box fontsize=16`, title)
-	fmt.Fprintf(b, ` label="%s\l"`, strings.Join(labels, `\l`))
+	fmt.Fprintf(b, ` label="%s\l"`, strings.Join(escapeForDot(labels), `\l`))
 	if b.config.LegendURL != "" {
 		fmt.Fprintf(b, ` URL="%s" target="_blank"`, b.config.LegendURL)
 	}
@@ -471,4 +471,15 @@ func min64(a, b int64) int64 {
 		return a
 	}
 	return b
+}
+
+// escapeForDot escapes double quotes and backslashes, and replaces Graphviz's
+// "center" character (\n) with a left-justified character.
+// See https://graphviz.org/doc/info/attrs.html#k:escString for more info.
+func escapeForDot(in []string) []string {
+	var out = make([]string, len(in))
+	for i := range in {
+		out[i] = strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(in[i], `\`, `\\`), `"`, `\"`), "\n", `\l`)
+	}
+	return out
 }

--- a/internal/graph/testdata/compose1.dot
+++ b/internal/graph/testdata/compose1.dot
@@ -1,6 +1,6 @@
 digraph "testtitle" {
 node [style=filled fillcolor="#f8f8f8"]
-subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\l" tooltip="testtitle"] }
+subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabel3: \"foo\"\l" tooltip="testtitle"] }
 N1 [label="src\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="src (25)" color="#b23c00" fillcolor="#edddd5"]
 N2 [label="dest\n15 (15.00%)\nof 25 (25.00%)" id="node2" fontsize=24 shape=box tooltip="dest (25)" color="#b23c00" fillcolor="#edddd5"]
 N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="src -> dest (10)" labeltooltip="src -> dest (10)"]

--- a/internal/graph/testdata/compose2.dot
+++ b/internal/graph/testdata/compose2.dot
@@ -1,6 +1,6 @@
 digraph "testtitle" {
 node [style=filled fillcolor="#f8f8f8"]
-subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\l" tooltip="testtitle"] }
+subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabel3: \"foo\"\l" tooltip="testtitle"] }
 N1 [label="SRC10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=24 shape=folder tooltip="src (25)" color="#b23c00" fillcolor="#edddd5" style="bold,filled" peripheries=2 URL="www.google.com" target="_blank"]
 N2 [label="dest\n0 of 25 (25.00%)" id="node2" fontsize=8 shape=box tooltip="dest (25)" color="#b23c00" fillcolor="#edddd5"]
 N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="src -> dest (10)" labeltooltip="src -> dest (10)"]

--- a/internal/graph/testdata/compose3.dot
+++ b/internal/graph/testdata/compose3.dot
@@ -1,6 +1,6 @@
 digraph "testtitle" {
 node [style=filled fillcolor="#f8f8f8"]
-subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\l" tooltip="testtitle"] }
+subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabel3: \"foo\"\l" tooltip="testtitle"] }
 N1 [label="src\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="src (25)" color="#b23c00" fillcolor="#edddd5"]
 N1_0 [label = "tag1" id="N1_0" fontsize=8 shape=box3d tooltip="10"]
 N1 -> N1_0 [label=" 10" weight=100 tooltip="10" labeltooltip="10"]

--- a/internal/graph/testdata/compose4.dot
+++ b/internal/graph/testdata/compose4.dot
@@ -1,4 +1,4 @@
 digraph "testtitle" {
 node [style=filled fillcolor="#f8f8f8"]
-subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\l" tooltip="testtitle"] }
+subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabel3: \"foo\"\l" tooltip="testtitle"] }
 }

--- a/internal/graph/testdata/compose5.dot
+++ b/internal/graph/testdata/compose5.dot
@@ -1,6 +1,6 @@
 digraph "testtitle" {
 node [style=filled fillcolor="#f8f8f8"]
-subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\l" tooltip="testtitle"] }
+subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabel3: \"foo\"\l" tooltip="testtitle"] }
 N1 [label="src\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="src (25)" color="#b23c00" fillcolor="#edddd5"]
 N1_0 [label = "tag1" id="N1_0" fontsize=8 shape=box3d tooltip="10"]
 N1 -> N1_0 [label=" 10" weight=100 tooltip="10" labeltooltip="10"]

--- a/internal/graph/testdata/compose6.dot
+++ b/internal/graph/testdata/compose6.dot
@@ -1,6 +1,6 @@
 digraph "testtitle" {
 node [style=filled fillcolor="#f8f8f8"]
-subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\l" URL="http://example.com" target="_blank" tooltip="testtitle"] }
+subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabel3: \"foo\"\l" URL="http://example.com" target="_blank" tooltip="testtitle"] }
 N1 [label="src\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="src (25)" color="#b23c00" fillcolor="#edddd5"]
 N2 [label="dest\n15 (15.00%)\nof 25 (25.00%)" id="node2" fontsize=24 shape=box tooltip="dest (25)" color="#b23c00" fillcolor="#edddd5"]
 N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="src -> dest (10)" labeltooltip="src -> dest (10)"]

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1207,7 +1207,7 @@ func reportLabels(rpt *Report, g *graph.Graph, origCount, droppedNodes, droppedE
 	// Help new users understand the graph.
 	// A new line is intentionally added here to better show this message.
 	if fullHeaders {
-		label = append(label, "\\lSee https://git.io/JfYMW for how to read the graph")
+		label = append(label, "\nSee https://git.io/JfYMW for how to read the graph")
 	}
 
 	return label


### PR DESCRIPTION
Profile comments can have various special symbols which are then inserted as labels when generating graphs. If symbols are not escaped, graph generation can fail. This PR fixes that. 