### PR TITLE
chore: run Github Actions CI daily

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    - cron: '0 2 * * *' # Run every day, at 2AM UTC.
 env:
   GOPATH: ${{ github.workspace }}
   WORKING_DIR: ./src/github.com/google/pprof/


### PR DESCRIPTION
I saw failures in https://github.com/google/pprof/pull/559 that didn't seem related to my change, and wanted to be able to check if these tests had passed recently. Running our CI daily will allow us to do this.