### PR TITLE
Fix Github Action and modify supported xcode/macOS versions in both Github Action and Travis CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }}
     strategy:
       matrix:
-        go: ['1.13', '1.14']
+        go: ['1.14', '1.15']
         os: ['macos-10.15']
         xcode-version: ['12.0', '11.7', '11.6', '11.5', '11.4.1', '11.3.1', '11.2.1', '11.1', '11.0']
     steps:
@@ -70,7 +70,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIR }} 
     strategy:
       matrix:
-        go: ['1.13', '1.14']
+        go: ['1.14', '1.15']
         os: ['ubuntu-20.04', 'ubuntu-18.04', 'ubuntu-16.04'] 
     steps:
       - name: Update go version
@@ -114,7 +114,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        go: ['1.13', '1.14']
+        go: ['1.14', '1.15']
     steps:
       - name: Update go version
         uses: actions/setup-go@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         go: ['1.13', '1.14']
         os: ['macos-10.15']
-        xcode-version: ['11.6', '11.5', '11.4.1', '11.3.1', '11.2.1', '11.1', '11.0', '10.3']
+        xcode-version: ['12.0', '11.7', '11.6', '11.5', '11.4.1', '11.3.1', '11.2.1', '11.1', '11.0']
     steps:
       - name: Update go version
         uses: actions/setup-go@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,19 +13,19 @@ matrix:
       go: master
     - os: osx
       osx_image: xcode10.3
-      go: 1.13.x
+      go: 1.14.x
     - os: osx
       osx_image: xcode10.3
-      go: 1.14.x
+      go: 1.15.x
     - os: osx
       osx_image: xcode11.3
       go: master
     - os: osx
       osx_image: xcode11.3
-      go: 1.13.x
+      go: 1.14.x
     - os: osx
       osx_image: xcode11.3
-      go: 1.14.x
+      go: 1.15.x
     - os: osx
       osx_image: xcode11.6
       go: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,25 +12,25 @@ matrix:
       osx_image: xcode10.3
       go: master
     - os: osx
-      osx_image: xcode11
-      go: master
+      osx_image: xcode10.3
+      go: 1.13.x
     - os: osx
-      osx_image: xcode11.1
-      go: master
-    - os: osx
-      osx_image: xcode11.2
-      go: master
+      osx_image: xcode10.3
+      go: 1.14.x
     - os: osx
       osx_image: xcode11.3
       go: master
     - os: osx
-      osx_image: xcode11.4
-      go: master
+      osx_image: xcode11.3
+      go: 1.13.x
     - os: osx
-      osx_image: xcode11.5
-      go: master
+      osx_image: xcode11.3
+      go: 1.14.x
     - os: osx
       osx_image: xcode11.6
+      go: master
+    - os: osx
+      osx_image: xcode12
       go: master
 
 addons:


### PR DESCRIPTION
Fixes #566 

* Issues to address:
  * Xcode version 10.3 has issue with macOS 10.15 in Github Action. See https://github.com/google/pprof/pull/560#issuecomment-699088881.
  * We do not currently have a comprehensive coverage on different xcode / macOS versions.

* Existing limitations
  * Github Action only supports macOS 10.15.
  * Github Action doesn't support Golang master branch.
  * Travis CI will time out if there are too many tests and there is no way to get around that.
  * Travis CI cannot freely switch xcode and macOS version. They are bundled together as `osx_image`, see https://docs.travis-ci.com/user/reference/osx/.

* Solution
  * Get rid of xcode 10.3 in Github Action.
  * Support {xcode 10.3, macOS 10.14.4} and {xcode 11.3, macOS 10.14.6} with Golang = {1.13, 1.14, master} in Travis since that will cover two minor xcode versions with macOS 10.14.
  * Support golang master for xcode 11.6 and xcode 11.2 since that is not covered by Github Action.

This PR also adds tests for xcode 12.0 and 11.7.
  