### PR TITLE
Add missing `escapeForDot()` to labels for function names

### DIFF
--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -192,8 +192,14 @@ func TestParse(t *testing.T) {
 				t.Fatalf("reading solution file %s: %v", solution, err)
 			}
 			if runtime.GOOS == "windows" {
-				sbuf = bytes.Replace(sbuf, []byte("testdata/"), []byte("testdata\\"), -1)
-				sbuf = bytes.Replace(sbuf, []byte("/path/to/"), []byte("\\path\\to\\"), -1)
+				if flags[0] == "dot" {
+					// The .dot test has the paths inside strings, so \ must be escaped.
+					sbuf = bytes.Replace(sbuf, []byte("testdata/"), []byte(`testdata\\`), -1)
+					sbuf = bytes.Replace(sbuf, []byte("/path/to/"), []byte(`\\path\\to\\`), -1)
+				} else {
+					sbuf = bytes.Replace(sbuf, []byte("testdata/"), []byte(`testdata\`), -1)
+					sbuf = bytes.Replace(sbuf, []byte("/path/to/"), []byte(`\path\to\`), -1)
+				}
 			}
 
 			if flags[0] == "svg" {

--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -474,7 +474,7 @@ func min64(a, b int64) int64 {
 	return b
 }
 
-// Applies escapeForDot to all strings in the given slice.
+// escapeAllForDot applies escapeForDot to all strings in the given slice.
 func escapeAllForDot(in []string) []string {
 	var out = make([]string, len(in))
 	for i := range in {

--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -127,7 +127,7 @@ func (b *builder) addLegend() {
 	}
 	title := labels[0]
 	fmt.Fprintf(b, `subgraph cluster_L { "%s" [shape=box fontsize=16`, title)
-	fmt.Fprintf(b, ` label="%s\l"`, strings.Join(escapeForDot(labels), `\l`))
+	fmt.Fprintf(b, ` label="%s\l"`, strings.Join(escapeAllForDot(labels), `\l`))
 	if b.config.LegendURL != "" {
 		fmt.Fprintf(b, ` URL="%s" target="_blank"`, b.config.LegendURL)
 	}
@@ -187,7 +187,7 @@ func (b *builder) addNode(node *Node, nodeID int, maxFlat float64) {
 
 	// Create DOT attribute for node.
 	attr := fmt.Sprintf(`label="%s" id="node%d" fontsize=%d shape=%s tooltip="%s (%s)" color="%s" fillcolor="%s"`,
-		label, nodeID, fontSize, shape, escapeStringForDot(node.Info.PrintableName()), cumValue,
+		label, nodeID, fontSize, shape, escapeForDot(node.Info.PrintableName()), cumValue,
 		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), false),
 		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), true))
 
@@ -305,8 +305,8 @@ func (b *builder) addEdge(edge *Edge, from, to int, hasNodelets bool) {
 		arrow = "..."
 	}
 	tooltip := fmt.Sprintf(`"%s %s %s (%s)"`,
-		escapeStringForDot(edge.Src.Info.PrintableName()), arrow,
-		escapeStringForDot(edge.Dest.Info.PrintableName()), w)
+		escapeForDot(edge.Src.Info.PrintableName()), arrow,
+		escapeForDot(edge.Dest.Info.PrintableName()), w)
 	attr = fmt.Sprintf(`%s tooltip=%s labeltooltip=%s`, attr, tooltip, tooltip)
 
 	if edge.Residual {
@@ -383,7 +383,7 @@ func dotColor(score float64, isBackground bool) string {
 
 func multilinePrintableName(info *NodeInfo) string {
 	infoCopy := *info
-	infoCopy.Name = escapeStringForDot(ShortenFunctionName(infoCopy.Name))
+	infoCopy.Name = escapeForDot(ShortenFunctionName(infoCopy.Name))
 	infoCopy.Name = strings.Replace(infoCopy.Name, "::", `\n`, -1)
 	infoCopy.Name = strings.Replace(infoCopy.Name, ".", `\n`, -1)
 	if infoCopy.File != "" {
@@ -474,16 +474,18 @@ func min64(a, b int64) int64 {
 	return b
 }
 
-// escapeForDot escapes double quotes and backslashes, and replaces Graphviz's
-// "center" character (\n) with a left-justified character.
-// See https://graphviz.org/doc/info/attrs.html#k:escString for more info.
-func escapeForDot(in []string) []string {
+// Applies escapeForDot to all strings in the given slice.
+func escapeAllForDot(in []string) []string {
 	var out = make([]string, len(in))
 	for i := range in {
-		out[i] = escapeStringForDot(in[i])
+		out[i] = escapeForDot(in[i])
 	}
 	return out
 }
-func escapeStringForDot(str string) string {
+
+// escapeForDot escapes double quotes and backslashes, and replaces Graphviz's
+// "center" character (\n) with a left-justified character.
+// See https://graphviz.org/doc/info/attrs.html#k:escString for more info.
+func escapeForDot(str string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`), "\n", `\l`)
 }

--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -187,7 +187,7 @@ func (b *builder) addNode(node *Node, nodeID int, maxFlat float64) {
 
 	// Create DOT attribute for node.
 	attr := fmt.Sprintf(`label="%s" id="node%d" fontsize=%d shape=%s tooltip="%s (%s)" color="%s" fillcolor="%s"`,
-		label, nodeID, fontSize, shape, node.Info.PrintableName(), cumValue,
+		escapeForDot(label), nodeID, fontSize, shape, node.Info.PrintableName(), cumValue,
 		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), false),
 		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), true))
 
@@ -247,7 +247,7 @@ func (b *builder) addNodelets(node *Node, nodeID int) bool {
 			continue
 		}
 		weight := b.config.FormatValue(w)
-		nodelets += fmt.Sprintf(`N%d_%d [label = "%s" id="N%d_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", nodeID, i, t.Name, nodeID, i, weight)
+		nodelets += fmt.Sprintf(`N%d_%d [label = "%s" id="N%d_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", nodeID, i, escapeForDot(t.Name), nodeID, i, weight)
 		nodelets += fmt.Sprintf(`N%d -> N%d_%d [label=" %s" weight=100 tooltip="%s" labeltooltip="%s"]`+"\n", nodeID, nodeID, i, weight, weight, weight)
 		if nts := lnts[t.Name]; nts != nil {
 			nodelets += b.numericNodelets(nts, maxNodelets, flatTags, fmt.Sprintf(`N%d_%d`, nodeID, i))

--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -149,7 +149,6 @@ func (b *builder) addNode(node *Node, nodeID int, maxFlat float64) {
 	} else {
 		label = multilinePrintableName(&node.Info)
 	}
-	// label = strings.Replace(label, `"`, `\"`, -1)
 
 	flatValue := b.config.FormatValue(flat)
 	if flat != 0 {

--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -486,5 +486,5 @@ func escapeForDot(in []string) []string {
 	return out
 }
 func escapeStringForDot(str string) string {
-		return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`), "\n", `\l`)
+	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`), "\n", `\l`)
 }

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -142,8 +142,8 @@ func TestComposeWithNamesThatNeedEscaping(t *testing.T) {
 	g := baseGraph()
 	a, c := baseAttrsAndConfig()
 
-  g.Nodes[0].Info = NodeInfo{Name: "var\"src\""};
-  g.Nodes[1].Info = NodeInfo{Name: "var\"#dest#\""};
+	g.Nodes[0].Info = NodeInfo{Name: "var\"src\""}
+	g.Nodes[1].Info = NodeInfo{Name: "var\"#dest#\""}
 
 	// Set edge to be Residual.
 	g.Nodes[0].Out[g.Nodes[1]].Residual = true

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -141,10 +141,8 @@ func TestComposeWithStandardGraphAndURL(t *testing.T) {
 func TestComposeWithNamesThatNeedEscaping(t *testing.T) {
 	g := baseGraph()
 	a, c := baseAttrsAndConfig()
-
-	g.Nodes[0].Info = NodeInfo{Name: "var\"src\""}
-	g.Nodes[1].Info = NodeInfo{Name: "var\"#dest#\""}
-
+	g.Nodes[0].Info = NodeInfo{Name: `var"src"`}
+	g.Nodes[1].Info = NodeInfo{Name: `var"#dest#"`}
 	// Set edge to be Residual.
 	g.Nodes[0].Out[g.Nodes[1]].Residual = true
 

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -143,8 +143,6 @@ func TestComposeWithNamesThatNeedEscaping(t *testing.T) {
 	a, c := baseAttrsAndConfig()
 	g.Nodes[0].Info = NodeInfo{Name: `var"src"`}
 	g.Nodes[1].Info = NodeInfo{Name: `var"#dest#"`}
-	// Set edge to be Residual.
-	g.Nodes[0].Out[g.Nodes[1]].Residual = true
 
 	var buf bytes.Buffer
 	ComposeDot(&buf, g, a, c)

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -76,7 +76,7 @@ func TestComposeWithTagsAndResidualEdge(t *testing.T) {
 	}
 	g.Nodes[0].NumericTags[""] = TagMap{
 		"b": &Tag{
-			Name: "var\"tag2\"",
+			Name: "tag2",
 			Cum:  20,
 			Flat: 20,
 			Unit: "ms",
@@ -136,6 +136,22 @@ func TestComposeWithStandardGraphAndURL(t *testing.T) {
 	ComposeDot(&buf, g, a, c)
 
 	compareGraphs(t, buf.Bytes(), "compose6.dot")
+}
+
+func TestComposeWithNamesThatNeedEscaping(t *testing.T) {
+	g := baseGraph()
+	a, c := baseAttrsAndConfig()
+
+  g.Nodes[0].Info = NodeInfo{Name: "var\"src\""};
+  g.Nodes[1].Info = NodeInfo{Name: "var\"#dest#\""};
+
+	// Set edge to be Residual.
+	g.Nodes[0].Out[g.Nodes[1]].Residual = true
+
+	var buf bytes.Buffer
+	ComposeDot(&buf, g, a, c)
+
+	compareGraphs(t, buf.Bytes(), "compose7.dot")
 }
 
 func baseGraph() *Graph {

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -375,8 +375,8 @@ func TestEscapeForDot(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			if got := escapeForDot(tc.input); !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("escapeForDot(%s) = %s, want %s", tc.input, got, tc.want)
+			if got := escapeAllForDot(tc.input); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("escapeAllForDot(%s) = %s, want %s", tc.input, got, tc.want)
 			}
 		})
 	}

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -76,7 +76,7 @@ func TestComposeWithTagsAndResidualEdge(t *testing.T) {
 	}
 	g.Nodes[0].NumericTags[""] = TagMap{
 		"b": &Tag{
-			Name: "tag2",
+			Name: "var\"tag2\"",
 			Cum:  20,
 			Flat: 20,
 			Unit: "ms",

--- a/internal/graph/testdata/compose3.dot
+++ b/internal/graph/testdata/compose3.dot
@@ -4,7 +4,7 @@ subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabe
 N1 [label="src\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="src (25)" color="#b23c00" fillcolor="#edddd5"]
 N1_0 [label = "tag1" id="N1_0" fontsize=8 shape=box3d tooltip="10"]
 N1 -> N1_0 [label=" 10" weight=100 tooltip="10" labeltooltip="10"]
-NN1_0 [label = "var\"tag2\"" id="NN1_0" fontsize=8 shape=box3d tooltip="20"]
+NN1_0 [label = "tag2" id="NN1_0" fontsize=8 shape=box3d tooltip="20"]
 N1 -> NN1_0 [label=" 20" weight=100 tooltip="20" labeltooltip="20"]
 N2 [label="dest\n15 (15.00%)\nof 25 (25.00%)" id="node2" fontsize=24 shape=box tooltip="dest (25)" color="#b23c00" fillcolor="#edddd5"]
 N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="src ... dest (10)" labeltooltip="src ... dest (10)" style="dotted" minlen=2]

--- a/internal/graph/testdata/compose3.dot
+++ b/internal/graph/testdata/compose3.dot
@@ -4,7 +4,7 @@ subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabe
 N1 [label="src\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="src (25)" color="#b23c00" fillcolor="#edddd5"]
 N1_0 [label = "tag1" id="N1_0" fontsize=8 shape=box3d tooltip="10"]
 N1 -> N1_0 [label=" 10" weight=100 tooltip="10" labeltooltip="10"]
-NN1_0 [label = "tag2" id="NN1_0" fontsize=8 shape=box3d tooltip="20"]
+NN1_0 [label = "var\"tag2\"" id="NN1_0" fontsize=8 shape=box3d tooltip="20"]
 N1 -> NN1_0 [label=" 20" weight=100 tooltip="20" labeltooltip="20"]
 N2 [label="dest\n15 (15.00%)\nof 25 (25.00%)" id="node2" fontsize=24 shape=box tooltip="dest (25)" color="#b23c00" fillcolor="#edddd5"]
 N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="src ... dest (10)" labeltooltip="src ... dest (10)" style="dotted" minlen=2]

--- a/internal/graph/testdata/compose7.dot
+++ b/internal/graph/testdata/compose7.dot
@@ -3,5 +3,5 @@ node [style=filled fillcolor="#f8f8f8"]
 subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabel3: \"foo\"\l" tooltip="testtitle"] }
 N1 [label="var\"src\"\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="var\"src\" (25)" color="#b23c00" fillcolor="#edddd5"]
 N2 [label="var\"#dest#\"\n15 (15.00%)\nof 25 (25.00%)" id="node2" fontsize=24 shape=box tooltip="var\"#dest#\" (25)" color="#b23c00" fillcolor="#edddd5"]
-N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="var\"src\" ... var\"#dest#\" (10)" labeltooltip="var\"src\" ... var\"#dest#\" (10)" style="dotted" minlen=2]
+N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="var\"src\" ... var\"#dest#\" (10)" labeltooltip="var\"src\" ... var\"#dest#\" (10)" style="dotted"]
 }

--- a/internal/graph/testdata/compose7.dot
+++ b/internal/graph/testdata/compose7.dot
@@ -3,5 +3,5 @@ node [style=filled fillcolor="#f8f8f8"]
 subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabel3: \"foo\"\l" tooltip="testtitle"] }
 N1 [label="var\"src\"\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="var\"src\" (25)" color="#b23c00" fillcolor="#edddd5"]
 N2 [label="var\"#dest#\"\n15 (15.00%)\nof 25 (25.00%)" id="node2" fontsize=24 shape=box tooltip="var\"#dest#\" (25)" color="#b23c00" fillcolor="#edddd5"]
-N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="var\"src\" ... var\"#dest#\" (10)" labeltooltip="var\"src\" ... var\"#dest#\" (10)" style="dotted"]
+N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="var\"src\" -> var\"#dest#\" (10)" labeltooltip="var\"src\" -> var\"#dest#\" (10)"]
 }

--- a/internal/graph/testdata/compose7.dot
+++ b/internal/graph/testdata/compose7.dot
@@ -1,0 +1,7 @@
+digraph "testtitle" {
+node [style=filled fillcolor="#f8f8f8"]
+subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabel3: \"foo\"\l" tooltip="testtitle"] }
+N1 [label="var\"src\"\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="var\"src\" (25)" color="#b23c00" fillcolor="#edddd5"]
+N2 [label="var\"#dest#\"\n15 (15.00%)\nof 25 (25.00%)" id="node2" fontsize=24 shape=box tooltip="var\"#dest#\" (25)" color="#b23c00" fillcolor="#edddd5"]
+N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="var\"src\" ... var\"#dest#\" (10)" labeltooltip="var\"src\" ... var\"#dest#\" (10)" style="dotted" minlen=2]
+}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -80,7 +80,12 @@ func TestSource(t *testing.T) {
 			t.Fatalf("%s: %v", tc.want, err)
 		}
 		if runtime.GOOS == "windows" {
-			gold = bytes.Replace(gold, []byte("testdata/"), []byte("testdata\\"), -1)
+			if tc.rpt.options.OutputFormat == Dot {
+				// The .dot test has the paths inside strings, so \ must be escaped.
+				gold = bytes.Replace(gold, []byte("testdata/"), []byte(`testdata\\`), -1)
+			} else {
+				gold = bytes.Replace(gold, []byte("testdata/"), []byte(`testdata\`), -1)
+			}
 		}
 		if string(b.String()) != string(gold) {
 			d, err := proftest.Diff(gold, b.Bytes())


### PR DESCRIPTION
In some programming languages, e.g. JuliaLang, function names can contain arbitrary characters. For example, in julia, functions with non-identifier characters are represented via the string macro `var"..."`, which allows constructing identifiers that wouldn't otherwise parse.

These names are handled correctly by `pprof` in the FlameGraph view, but before this commit, they would produce an invalid dot file.

This fixes the dot graph export for names that contain `"`.

## Review Guidelines

- All of the code changes are in the `internal/graph/dotgraph.go` file, and consist of escaping a few more callsites that produce text that will go in a string in the `.dot` file.
- The rest of the files are modifications to the tests:
    1. We added a new test to test string escaping in the newly escaped parts of the `.dot` file.
    2. We fixed a bunch of windows tests, which were previously validating incorrect escaping of `\`, and had to be updated once we started correctly escaping `"...\..."` to `"...\\..."` on Windows.




Fixes https://github.com/JuliaPerf/PProf.jl/issues/30.