### PR TITLE
Escape Nodelet/tag names for Dot as well

### DIFF
--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -127,7 +127,7 @@ func (b *builder) addLegend() {
 	}
 	title := labels[0]
 	fmt.Fprintf(b, `subgraph cluster_L { "%s" [shape=box fontsize=16`, title)
-	fmt.Fprintf(b, ` label="%s\l"`, strings.Join(escapeAllForDot(labels, LeftJustify), `\l`))
+	fmt.Fprintf(b, ` label="%s\l"`, strings.Join(escapeAllForDot(labels, leftJustify), `\l`))
 	if b.config.LegendURL != "" {
 		fmt.Fprintf(b, ` URL="%s" target="_blank"`, b.config.LegendURL)
 	}
@@ -187,7 +187,7 @@ func (b *builder) addNode(node *Node, nodeID int, maxFlat float64) {
 
 	// Create DOT attribute for node.
 	attr := fmt.Sprintf(`label="%s" id="node%d" fontsize=%d shape=%s tooltip="%s (%s)" color="%s" fillcolor="%s"`,
-		label, nodeID, fontSize, shape, escapeForDot(node.Info.PrintableName(), CenterJustify), cumValue,
+		label, nodeID, fontSize, shape, escapeForDot(node.Info.PrintableName(), centerJustify), cumValue,
 		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), false),
 		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), true))
 
@@ -247,7 +247,7 @@ func (b *builder) addNodelets(node *Node, nodeID int) bool {
 			continue
 		}
 		weight := b.config.FormatValue(w)
-		nodelets += fmt.Sprintf(`N%d_%d [label = "%s" id="N%d_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", nodeID, i, escapeForDot(t.Name, CenterJustify), nodeID, i, weight)
+		nodelets += fmt.Sprintf(`N%d_%d [label = "%s" id="N%d_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", nodeID, i, escapeForDot(t.Name, centerJustify), nodeID, i, weight)
 		nodelets += fmt.Sprintf(`N%d -> N%d_%d [label=" %s" weight=100 tooltip="%s" labeltooltip="%s"]`+"\n", nodeID, nodeID, i, weight, weight, weight)
 		if nts := lnts[t.Name]; nts != nil {
 			nodelets += b.numericNodelets(nts, maxNodelets, flatTags, fmt.Sprintf(`N%d_%d`, nodeID, i))
@@ -274,7 +274,7 @@ func (b *builder) numericNodelets(nts []*Tag, maxNumNodelets int, flatTags bool,
 		}
 		if w != 0 {
 			weight := b.config.FormatValue(w)
-			nodelets += fmt.Sprintf(`N%s_%d [label = "%s" id="N%s_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", source, j, escapeForDot(t.Name, CenterJustify), source, j, weight)
+			nodelets += fmt.Sprintf(`N%s_%d [label = "%s" id="N%s_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", source, j, escapeForDot(t.Name, centerJustify), source, j, weight)
 			nodelets += fmt.Sprintf(`%s -> N%s_%d [label=" %s" weight=100 tooltip="%s" labeltooltip="%s"%s]`+"\n", source, source, j, weight, weight, weight, attr)
 		}
 	}
@@ -305,8 +305,8 @@ func (b *builder) addEdge(edge *Edge, from, to int, hasNodelets bool) {
 		arrow = "..."
 	}
 	tooltip := fmt.Sprintf(`"%s %s %s (%s)"`,
-		escapeForDot(edge.Src.Info.PrintableName(), CenterJustify), arrow,
-		escapeForDot(edge.Dest.Info.PrintableName(), CenterJustify), w)
+		escapeForDot(edge.Src.Info.PrintableName(), centerJustify), arrow,
+		escapeForDot(edge.Dest.Info.PrintableName(), centerJustify), w)
 	attr = fmt.Sprintf(`%s tooltip=%s labeltooltip=%s`, attr, tooltip, tooltip)
 
 	if edge.Residual {
@@ -383,7 +383,7 @@ func dotColor(score float64, isBackground bool) string {
 
 func multilinePrintableName(info *NodeInfo) string {
 	infoCopy := *info
-	infoCopy.Name = escapeForDot(ShortenFunctionName(infoCopy.Name), CenterJustify)
+	infoCopy.Name = escapeForDot(ShortenFunctionName(infoCopy.Name), centerJustify)
 	infoCopy.Name = strings.Replace(infoCopy.Name, "::", `\n`, -1)
 	infoCopy.Name = strings.Replace(infoCopy.Name, ".", `\n`, -1)
 	if infoCopy.File != "" {
@@ -474,16 +474,16 @@ func min64(a, b int64) int64 {
 	return b
 }
 
-type DotJustifyType int64
+type dotJustifyType int64
 
 const (
-	LeftJustify   DotJustifyType = 0
-	CenterJustify DotJustifyType = 1
-	RightJustify  DotJustifyType = 2
+	leftJustify   dotJustifyType = 0
+	centerJustify dotJustifyType = 1
+	rightJustify  dotJustifyType = 2
 )
 
 // Applies escapeForDot to all strings in the given slice.
-func escapeAllForDot(in []string, justify DotJustifyType) []string {
+func escapeAllForDot(in []string, justify dotJustifyType) []string {
 	var out = make([]string, len(in))
 	for i := range in {
 		out[i] = escapeForDot(in[i], justify)
@@ -494,14 +494,14 @@ func escapeAllForDot(in []string, justify DotJustifyType) []string {
 // escapeForDot escapes double quotes and backslashes, and replaces Graphviz's
 // "center" character (\n) with a left-justified character.
 // See https://graphviz.org/doc/info/attrs.html#k:escString for more info.
-func escapeForDot(str string, justify DotJustifyType) string {
+func escapeForDot(str string, justify dotJustifyType) string {
 	var newline string
 	switch justify {
-	case LeftJustify:
+	case leftJustify:
 		newline = `\l`
-	case CenterJustify:
+	case centerJustify:
 		newline = `\n`
-	case RightJustify:
+	case rightJustify:
 		newline = `\r`
 	}
 	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`), "\n", newline)

--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -127,7 +127,7 @@ func (b *builder) addLegend() {
 	}
 	title := labels[0]
 	fmt.Fprintf(b, `subgraph cluster_L { "%s" [shape=box fontsize=16`, title)
-	fmt.Fprintf(b, ` label="%s\l"`, strings.Join(escapeForDot(labels), `\l`))
+	fmt.Fprintf(b, ` label="%s\l"`, strings.Join(escapeAllForDot(labels), `\l`))
 	if b.config.LegendURL != "" {
 		fmt.Fprintf(b, ` URL="%s" target="_blank"`, b.config.LegendURL)
 	}
@@ -187,7 +187,7 @@ func (b *builder) addNode(node *Node, nodeID int, maxFlat float64) {
 
 	// Create DOT attribute for node.
 	attr := fmt.Sprintf(`label="%s" id="node%d" fontsize=%d shape=%s tooltip="%s (%s)" color="%s" fillcolor="%s"`,
-		label, nodeID, fontSize, shape, escapeStringForDot(node.Info.PrintableName()), cumValue,
+		label, nodeID, fontSize, shape, escapeForDot(node.Info.PrintableName()), cumValue,
 		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), false),
 		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), true))
 
@@ -305,8 +305,8 @@ func (b *builder) addEdge(edge *Edge, from, to int, hasNodelets bool) {
 		arrow = "..."
 	}
 	tooltip := fmt.Sprintf(`"%s %s %s (%s)"`,
-		escapeStringForDot(edge.Src.Info.PrintableName()), arrow,
-		escapeStringForDot(edge.Dest.Info.PrintableName()), w)
+		escapeForDot(edge.Src.Info.PrintableName()), arrow,
+		escapeForDot(edge.Dest.Info.PrintableName()), w)
 	attr = fmt.Sprintf(`%s tooltip=%s labeltooltip=%s`, attr, tooltip, tooltip)
 
 	if edge.Residual {
@@ -383,7 +383,7 @@ func dotColor(score float64, isBackground bool) string {
 
 func multilinePrintableName(info *NodeInfo) string {
 	infoCopy := *info
-	infoCopy.Name = escapeStringForDot(ShortenFunctionName(infoCopy.Name))
+	infoCopy.Name = escapeForDot(ShortenFunctionName(infoCopy.Name))
 	infoCopy.Name = strings.Replace(infoCopy.Name, "::", `\n`, -1)
 	infoCopy.Name = strings.Replace(infoCopy.Name, ".", `\n`, -1)
 	if infoCopy.File != "" {
@@ -474,16 +474,18 @@ func min64(a, b int64) int64 {
 	return b
 }
 
-// escapeForDot escapes double quotes and backslashes, and replaces Graphviz's
-// "center" character (\n) with a left-justified character.
-// See https://graphviz.org/doc/info/attrs.html#k:escString for more info.
-func escapeForDot(in []string) []string {
+// Applies escapeForDot to all strings in the given slice.
+func escapeAllForDot(in []string) []string {
 	var out = make([]string, len(in))
 	for i := range in {
-		out[i] = escapeStringForDot(in[i])
+		out[i] = escapeForDot(in[i])
 	}
 	return out
 }
-func escapeStringForDot(str string) string {
+
+// escapeForDot escapes double quotes and backslashes, and replaces Graphviz's
+// "center" character (\n) with a left-justified character.
+// See https://graphviz.org/doc/info/attrs.html#k:escString for more info.
+func escapeForDot(str string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`), "\n", `\l`)
 }

--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -187,7 +187,7 @@ func (b *builder) addNode(node *Node, nodeID int, maxFlat float64) {
 
 	// Create DOT attribute for node.
 	attr := fmt.Sprintf(`label="%s" id="node%d" fontsize=%d shape=%s tooltip="%s (%s)" color="%s" fillcolor="%s"`,
-		label, nodeID, fontSize, shape, node.Info.PrintableName(), cumValue,
+		escapeForDot(label), nodeID, fontSize, shape, node.Info.PrintableName(), cumValue,
 		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), false),
 		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), true))
 
@@ -247,7 +247,7 @@ func (b *builder) addNodelets(node *Node, nodeID int) bool {
 			continue
 		}
 		weight := b.config.FormatValue(w)
-		nodelets += fmt.Sprintf(`N%d_%d [label = "%s" id="N%d_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", nodeID, i, t.Name, nodeID, i, weight)
+		nodelets += fmt.Sprintf(`N%d_%d [label = "%s" id="N%d_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", nodeID, i, escapeForDot(t.Name), nodeID, i, weight)
 		nodelets += fmt.Sprintf(`N%d -> N%d_%d [label=" %s" weight=100 tooltip="%s" labeltooltip="%s"]`+"\n", nodeID, nodeID, i, weight, weight, weight)
 		if nts := lnts[t.Name]; nts != nil {
 			nodelets += b.numericNodelets(nts, maxNodelets, flatTags, fmt.Sprintf(`N%d_%d`, nodeID, i))

--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -149,7 +149,6 @@ func (b *builder) addNode(node *Node, nodeID int, maxFlat float64) {
 	} else {
 		label = multilinePrintableName(&node.Info)
 	}
-	// label = strings.Replace(label, `"`, `\"`, -1)
 
 	flatValue := b.config.FormatValue(flat)
 	if flat != 0 {

--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -127,7 +127,7 @@ func (b *builder) addLegend() {
 	}
 	title := labels[0]
 	fmt.Fprintf(b, `subgraph cluster_L { "%s" [shape=box fontsize=16`, title)
-	fmt.Fprintf(b, ` label="%s\l"`, strings.Join(escapeAllForDot(labels), `\l`))
+	fmt.Fprintf(b, ` label="%s\l"`, strings.Join(escapeAllForDot(labels, LeftJustify), `\l`))
 	if b.config.LegendURL != "" {
 		fmt.Fprintf(b, ` URL="%s" target="_blank"`, b.config.LegendURL)
 	}
@@ -187,7 +187,7 @@ func (b *builder) addNode(node *Node, nodeID int, maxFlat float64) {
 
 	// Create DOT attribute for node.
 	attr := fmt.Sprintf(`label="%s" id="node%d" fontsize=%d shape=%s tooltip="%s (%s)" color="%s" fillcolor="%s"`,
-		label, nodeID, fontSize, shape, escapeForDot(node.Info.PrintableName()), cumValue,
+		label, nodeID, fontSize, shape, escapeForDot(node.Info.PrintableName(), CenterJustify), cumValue,
 		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), false),
 		dotColor(float64(node.CumValue())/float64(abs64(b.config.Total)), true))
 
@@ -247,7 +247,7 @@ func (b *builder) addNodelets(node *Node, nodeID int) bool {
 			continue
 		}
 		weight := b.config.FormatValue(w)
-		nodelets += fmt.Sprintf(`N%d_%d [label = "%s" id="N%d_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", nodeID, i, escapeForDot(t.Name), nodeID, i, weight)
+		nodelets += fmt.Sprintf(`N%d_%d [label = "%s" id="N%d_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", nodeID, i, escapeForDot(t.Name, CenterJustify), nodeID, i, weight)
 		nodelets += fmt.Sprintf(`N%d -> N%d_%d [label=" %s" weight=100 tooltip="%s" labeltooltip="%s"]`+"\n", nodeID, nodeID, i, weight, weight, weight)
 		if nts := lnts[t.Name]; nts != nil {
 			nodelets += b.numericNodelets(nts, maxNodelets, flatTags, fmt.Sprintf(`N%d_%d`, nodeID, i))
@@ -274,7 +274,7 @@ func (b *builder) numericNodelets(nts []*Tag, maxNumNodelets int, flatTags bool,
 		}
 		if w != 0 {
 			weight := b.config.FormatValue(w)
-			nodelets += fmt.Sprintf(`N%s_%d [label = "%s" id="N%s_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", source, j, escapeForDot(t.Name), source, j, weight)
+			nodelets += fmt.Sprintf(`N%s_%d [label = "%s" id="N%s_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", source, j, escapeForDot(t.Name, CenterJustify), source, j, weight)
 			nodelets += fmt.Sprintf(`%s -> N%s_%d [label=" %s" weight=100 tooltip="%s" labeltooltip="%s"%s]`+"\n", source, source, j, weight, weight, weight, attr)
 		}
 	}
@@ -305,8 +305,8 @@ func (b *builder) addEdge(edge *Edge, from, to int, hasNodelets bool) {
 		arrow = "..."
 	}
 	tooltip := fmt.Sprintf(`"%s %s %s (%s)"`,
-		escapeForDot(edge.Src.Info.PrintableName()), arrow,
-		escapeForDot(edge.Dest.Info.PrintableName()), w)
+		escapeForDot(edge.Src.Info.PrintableName(), CenterJustify), arrow,
+		escapeForDot(edge.Dest.Info.PrintableName(), CenterJustify), w)
 	attr = fmt.Sprintf(`%s tooltip=%s labeltooltip=%s`, attr, tooltip, tooltip)
 
 	if edge.Residual {
@@ -383,7 +383,7 @@ func dotColor(score float64, isBackground bool) string {
 
 func multilinePrintableName(info *NodeInfo) string {
 	infoCopy := *info
-	infoCopy.Name = escapeForDot(ShortenFunctionName(infoCopy.Name))
+	infoCopy.Name = escapeForDot(ShortenFunctionName(infoCopy.Name), CenterJustify)
 	infoCopy.Name = strings.Replace(infoCopy.Name, "::", `\n`, -1)
 	infoCopy.Name = strings.Replace(infoCopy.Name, ".", `\n`, -1)
 	if infoCopy.File != "" {
@@ -474,11 +474,19 @@ func min64(a, b int64) int64 {
 	return b
 }
 
+type DotJustifyType int64
+
+const (
+	LeftJustify   DotJustifyType = 0
+	CenterJustify DotJustifyType = 1
+	RightJustify  DotJustifyType = 2
+)
+
 // Applies escapeForDot to all strings in the given slice.
-func escapeAllForDot(in []string) []string {
+func escapeAllForDot(in []string, justify DotJustifyType) []string {
 	var out = make([]string, len(in))
 	for i := range in {
-		out[i] = escapeForDot(in[i])
+		out[i] = escapeForDot(in[i], justify)
 	}
 	return out
 }
@@ -486,6 +494,15 @@ func escapeAllForDot(in []string) []string {
 // escapeForDot escapes double quotes and backslashes, and replaces Graphviz's
 // "center" character (\n) with a left-justified character.
 // See https://graphviz.org/doc/info/attrs.html#k:escString for more info.
-func escapeForDot(str string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`), "\n", `\n`)
+func escapeForDot(str string, justify DotJustifyType) string {
+	var newline string
+	switch justify {
+	case LeftJustify:
+		newline = `\l`
+	case CenterJustify:
+		newline = `\n`
+	case RightJustify:
+		newline = `\r`
+	}
+	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`), "\n", newline)
 }

--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -247,7 +247,7 @@ func (b *builder) addNodelets(node *Node, nodeID int) bool {
 			continue
 		}
 		weight := b.config.FormatValue(w)
-		nodelets += fmt.Sprintf(`N%d_%d [label = "%s" id="N%d_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", nodeID, i, t.Name, nodeID, i, weight)
+		nodelets += fmt.Sprintf(`N%d_%d [label = "%s" id="N%d_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", nodeID, i, escapeForDot(t.Name), nodeID, i, weight)
 		nodelets += fmt.Sprintf(`N%d -> N%d_%d [label=" %s" weight=100 tooltip="%s" labeltooltip="%s"]`+"\n", nodeID, nodeID, i, weight, weight, weight)
 		if nts := lnts[t.Name]; nts != nil {
 			nodelets += b.numericNodelets(nts, maxNodelets, flatTags, fmt.Sprintf(`N%d_%d`, nodeID, i))
@@ -274,7 +274,7 @@ func (b *builder) numericNodelets(nts []*Tag, maxNumNodelets int, flatTags bool,
 		}
 		if w != 0 {
 			weight := b.config.FormatValue(w)
-			nodelets += fmt.Sprintf(`N%s_%d [label = "%s" id="N%s_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", source, j, t.Name, source, j, weight)
+			nodelets += fmt.Sprintf(`N%s_%d [label = "%s" id="N%s_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", source, j, escapeForDot(t.Name), source, j, weight)
 			nodelets += fmt.Sprintf(`%s -> N%s_%d [label=" %s" weight=100 tooltip="%s" labeltooltip="%s"%s]`+"\n", source, source, j, weight, weight, weight, attr)
 		}
 	}
@@ -487,5 +487,5 @@ func escapeAllForDot(in []string) []string {
 // "center" character (\n) with a left-justified character.
 // See https://graphviz.org/doc/info/attrs.html#k:escString for more info.
 func escapeForDot(str string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`), "\n", `\l`)
+	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`), "\n", `\n`)
 }

--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -486,5 +486,5 @@ func escapeForDot(in []string) []string {
 	return out
 }
 func escapeStringForDot(str string) string {
-		return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`), "\n", `\l`)
+	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(str, `\`, `\\`), `"`, `\"`), "\n", `\l`)
 }

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -142,8 +142,8 @@ func TestComposeWithNamesThatNeedEscaping(t *testing.T) {
 	g := baseGraph()
 	a, c := baseAttrsAndConfig()
 
-  g.Nodes[0].Info = NodeInfo{Name: "var\"src\""};
-  g.Nodes[1].Info = NodeInfo{Name: "var\"#dest#\""};
+	g.Nodes[0].Info = NodeInfo{Name: "var\"src\""}
+	g.Nodes[1].Info = NodeInfo{Name: "var\"#dest#\""}
 
 	// Set edge to be Residual.
 	g.Nodes[0].Out[g.Nodes[1]].Residual = true

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -383,8 +383,27 @@ func TestEscapeForDot(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			if got := escapeAllForDot(tc.input); !reflect.DeepEqual(got, tc.want) {
+			if got := escapeAllForDot(tc.input, LeftJustify); !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("escapeAllForDot(%s) = %s, want %s", tc.input, got, tc.want)
+			}
+		})
+	}
+
+	// Test the different options for justifying text newlines in Dot
+	for _, justify := range []DotJustifyType{LeftJustify, CenterJustify, RightJustify} {
+		t.Run("Dot newline justification", func(t *testing.T) {
+			input := []string{"Line 1\nLine 2"}
+			var want []string
+			switch justify {
+			case LeftJustify:
+				want = []string{`Line 1\lLine 2`}
+			case CenterJustify:
+				want = []string{`Line 1\nLine 2`}
+			case RightJustify:
+				want = []string{`Line 1\rLine 2`}
+			}
+			if got := escapeAllForDot(input, justify); !reflect.DeepEqual(got, want) {
+				t.Errorf("escapeAllForDot(%s) = %s, want %s", input, got, want)
 			}
 		})
 	}

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -76,7 +76,7 @@ func TestComposeWithTagsAndResidualEdge(t *testing.T) {
 	}
 	g.Nodes[0].NumericTags[""] = TagMap{
 		"b": &Tag{
-			Name: "var\"tag2\"",
+			Name: "tag2",
 			Cum:  20,
 			Flat: 20,
 			Unit: "ms",
@@ -136,6 +136,22 @@ func TestComposeWithStandardGraphAndURL(t *testing.T) {
 	ComposeDot(&buf, g, a, c)
 
 	compareGraphs(t, buf.Bytes(), "compose6.dot")
+}
+
+func TestComposeWithNamesThatNeedEscaping(t *testing.T) {
+	g := baseGraph()
+	a, c := baseAttrsAndConfig()
+
+  g.Nodes[0].Info = NodeInfo{Name: "var\"src\""};
+  g.Nodes[1].Info = NodeInfo{Name: "var\"#dest#\""};
+
+	// Set edge to be Residual.
+	g.Nodes[0].Out[g.Nodes[1]].Residual = true
+
+	var buf bytes.Buffer
+	ComposeDot(&buf, g, a, c)
+
+	compareGraphs(t, buf.Bytes(), "compose7.dot")
 }
 
 func baseGraph() *Graph {

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -375,8 +375,8 @@ func TestEscapeForDot(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			if got := escapeForDot(tc.input); !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("escapeForDot(%s) = %s, want %s", tc.input, got, tc.want)
+			if got := escapeAllForDot(tc.input); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("escapeAllForDot(%s) = %s, want %s", tc.input, got, tc.want)
 			}
 		})
 	}

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -383,23 +383,23 @@ func TestEscapeForDot(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			if got := escapeAllForDot(tc.input, LeftJustify); !reflect.DeepEqual(got, tc.want) {
+			if got := escapeAllForDot(tc.input, leftJustify); !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("escapeAllForDot(%s) = %s, want %s", tc.input, got, tc.want)
 			}
 		})
 	}
 
 	// Test the different options for justifying text newlines in Dot
-	for _, justify := range []DotJustifyType{LeftJustify, CenterJustify, RightJustify} {
+	for _, justify := range []dotJustifyType{leftJustify, centerJustify, rightJustify} {
 		t.Run("Dot newline justification", func(t *testing.T) {
 			input := []string{"Line 1\nLine 2"}
 			var want []string
 			switch justify {
-			case LeftJustify:
+			case leftJustify:
 				want = []string{`Line 1\lLine 2`}
-			case CenterJustify:
+			case centerJustify:
 				want = []string{`Line 1\nLine 2`}
-			case RightJustify:
+			case rightJustify:
 				want = []string{`Line 1\rLine 2`}
 			}
 			if got := escapeAllForDot(input, justify); !reflect.DeepEqual(got, want) {

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -76,7 +76,7 @@ func TestComposeWithTagsAndResidualEdge(t *testing.T) {
 	}
 	g.Nodes[0].NumericTags[""] = TagMap{
 		"b": &Tag{
-			Name: "tag2",
+			Name: "var\"tag2\"",
 			Cum:  20,
 			Flat: 20,
 			Unit: "ms",

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -142,8 +142,16 @@ func TestComposeWithNamesThatNeedEscaping(t *testing.T) {
 	g := baseGraph()
 	a, c := baseAttrsAndConfig()
 
+	// Change node names to have `"` in them, which need to be escaped for dot.
 	g.Nodes[0].Info = NodeInfo{Name: "var\"src\""}
 	g.Nodes[1].Info = NodeInfo{Name: "var\"#dest#\""}
+
+	// Add tag to Node 1 with `"` in name.
+	g.Nodes[0].LabelTags["a"] = &Tag{
+		Name: "var\"tag1\"",
+		Cum:  10,
+		Flat: 10,
+	}
 
 	// Set edge to be Residual.
 	g.Nodes[0].Out[g.Nodes[1]].Residual = true

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -522,7 +522,7 @@ func joinLabels(s *profile.Sample) string {
 		}
 	}
 	sort.Strings(labels)
-	return strings.Join(labels, `\n`)
+	return strings.Join(labels, "\n")  // This will be escaped downstream if needed.
 }
 
 // isNegative returns true if the node is considered as "negative" for the

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -522,7 +522,7 @@ func joinLabels(s *profile.Sample) string {
 		}
 	}
 	sort.Strings(labels)
-	return strings.Join(labels, "\n")  // This will be escaped downstream if needed.
+	return strings.Join(labels, "\n") // This will be escaped downstream if needed.
 }
 
 // isNegative returns true if the node is considered as "negative" for the

--- a/internal/graph/testdata/compose3.dot
+++ b/internal/graph/testdata/compose3.dot
@@ -4,7 +4,7 @@ subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabe
 N1 [label="src\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="src (25)" color="#b23c00" fillcolor="#edddd5"]
 N1_0 [label = "tag1" id="N1_0" fontsize=8 shape=box3d tooltip="10"]
 N1 -> N1_0 [label=" 10" weight=100 tooltip="10" labeltooltip="10"]
-NN1_0 [label = "var\"tag2\"" id="NN1_0" fontsize=8 shape=box3d tooltip="20"]
+NN1_0 [label = "tag2" id="NN1_0" fontsize=8 shape=box3d tooltip="20"]
 N1 -> NN1_0 [label=" 20" weight=100 tooltip="20" labeltooltip="20"]
 N2 [label="dest\n15 (15.00%)\nof 25 (25.00%)" id="node2" fontsize=24 shape=box tooltip="dest (25)" color="#b23c00" fillcolor="#edddd5"]
 N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="src ... dest (10)" labeltooltip="src ... dest (10)" style="dotted" minlen=2]

--- a/internal/graph/testdata/compose3.dot
+++ b/internal/graph/testdata/compose3.dot
@@ -4,7 +4,7 @@ subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabe
 N1 [label="src\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="src (25)" color="#b23c00" fillcolor="#edddd5"]
 N1_0 [label = "tag1" id="N1_0" fontsize=8 shape=box3d tooltip="10"]
 N1 -> N1_0 [label=" 10" weight=100 tooltip="10" labeltooltip="10"]
-NN1_0 [label = "tag2" id="NN1_0" fontsize=8 shape=box3d tooltip="20"]
+NN1_0 [label = "var\"tag2\"" id="NN1_0" fontsize=8 shape=box3d tooltip="20"]
 N1 -> NN1_0 [label=" 20" weight=100 tooltip="20" labeltooltip="20"]
 N2 [label="dest\n15 (15.00%)\nof 25 (25.00%)" id="node2" fontsize=24 shape=box tooltip="dest (25)" color="#b23c00" fillcolor="#edddd5"]
 N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="src ... dest (10)" labeltooltip="src ... dest (10)" style="dotted" minlen=2]

--- a/internal/graph/testdata/compose7.dot
+++ b/internal/graph/testdata/compose7.dot
@@ -3,5 +3,5 @@ node [style=filled fillcolor="#f8f8f8"]
 subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabel3: \"foo\"\l" tooltip="testtitle"] }
 N1 [label="var\"src\"\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="var\"src\" (25)" color="#b23c00" fillcolor="#edddd5"]
 N2 [label="var\"#dest#\"\n15 (15.00%)\nof 25 (25.00%)" id="node2" fontsize=24 shape=box tooltip="var\"#dest#\" (25)" color="#b23c00" fillcolor="#edddd5"]
-N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="var\"src\" ... var\"#dest#\" (10)" labeltooltip="var\"src\" ... var\"#dest#\" (10)" style="dotted" minlen=2]
+N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="var\"src\" ... var\"#dest#\" (10)" labeltooltip="var\"src\" ... var\"#dest#\" (10)" style="dotted"]
 }

--- a/internal/graph/testdata/compose7.dot
+++ b/internal/graph/testdata/compose7.dot
@@ -1,0 +1,7 @@
+digraph "testtitle" {
+node [style=filled fillcolor="#f8f8f8"]
+subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabel3: \"foo\"\l" tooltip="testtitle"] }
+N1 [label="var\"src\"\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="var\"src\" (25)" color="#b23c00" fillcolor="#edddd5"]
+N2 [label="var\"#dest#\"\n15 (15.00%)\nof 25 (25.00%)" id="node2" fontsize=24 shape=box tooltip="var\"#dest#\" (25)" color="#b23c00" fillcolor="#edddd5"]
+N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="var\"src\" ... var\"#dest#\" (10)" labeltooltip="var\"src\" ... var\"#dest#\" (10)" style="dotted" minlen=2]
+}

--- a/internal/graph/testdata/compose7.dot
+++ b/internal/graph/testdata/compose7.dot
@@ -2,6 +2,8 @@ digraph "testtitle" {
 node [style=filled fillcolor="#f8f8f8"]
 subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabel3: \"foo\"\l" tooltip="testtitle"] }
 N1 [label="var\"src\"\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="var\"src\" (25)" color="#b23c00" fillcolor="#edddd5"]
+N1_0 [label = "var\"tag1\"" id="N1_0" fontsize=8 shape=box3d tooltip="10"]
+N1 -> N1_0 [label=" 10" weight=100 tooltip="10" labeltooltip="10"]
 N2 [label="var\"#dest#\"\n15 (15.00%)\nof 25 (25.00%)" id="node2" fontsize=24 shape=box tooltip="var\"#dest#\" (25)" color="#b23c00" fillcolor="#edddd5"]
-N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="var\"src\" ... var\"#dest#\" (10)" labeltooltip="var\"src\" ... var\"#dest#\" (10)" style="dotted"]
+N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="var\"src\" ... var\"#dest#\" (10)" labeltooltip="var\"src\" ... var\"#dest#\" (10)" style="dotted" minlen=2]
 }


### PR DESCRIPTION
This escaping requirement was previously leaking into the implementation
of `graph.go`, by writing `\n` directly instead of "\n". This meant that
if it was displayed in a different program besides `dot`, it would have
been potentially incorrectly escaped.

Now, this commit moves all the escaping directly into dotgraph, which is
more encapsulated, and also allows us to escape other characters in the
name which need escaping.

This required adding a justify option to escapeForDot to preserve old behavior.
This allows tag newlines to stay center justified, and legend label
newlines to stay left justified, as they were before we started escaping
them for Dot.

--

This was meant to be opened as a follow-up PR to https://github.com/google/pprof/pull/564, but apparently I can't adjust it to use a fork's branch as a diffbase. that's disappointing. I will close this in favor of https://github.com/NHDaly/pprof/pull/1 for now.