### PR TITLE
Remove potential Go module versions from shortened names

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -35,7 +35,7 @@ var (
 	// See tests for examples.
 	goRegExp = regexp.MustCompile(`^(?:[\w\-\.]+\/)+(.+)`)
 	// Checks for a package name that could be a module version.
-	goVerRegExp = regexp.MustCompile(`^v[2-9]+\.`)
+	goVerRegExp = regexp.MustCompile(`^v([2-9]|[1-9][0-9]+)\.`)
 	// Strips C++ namespace prefix from a C++ function / method name.
 	// NOTE: Make sure to keep the template parameters in the name. Normally,
 	// template parameters are stripped from the C++ names but when
@@ -467,7 +467,6 @@ func shortenGoFunc(f string, name string) string {
 			end = idx
 		}
 	}
-
 	return f[end+1:]
 }
 

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -35,7 +35,7 @@ var (
 	// See tests for examples.
 	goRegExp = regexp.MustCompile(`^(?:[\w\-\.]+\/)+(.+)`)
 	// Removes potential module versions in a package path.
-	goVerRegExp = regexp.MustCompile(`^(.*)/v(?:[2-9]|[1-9][0-9]+)([./].*)$`)
+	goVerRegExp = regexp.MustCompile(`^(.*?)/v(?:[2-9]|[1-9][0-9]+)([./].*)$`)
 	// Strips C++ namespace prefix from a C++ function / method name.
 	// NOTE: Make sure to keep the template parameters in the name. Normally,
 	// template parameters are stripped from the C++ names but when

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -459,7 +459,8 @@ func shortenGoFunc(f string, name string) string {
 		return name
 	}
 
-	// The shortened name could start with a module version (like "v2"). Go back one slash.
+	// The shortened name could start with a module version (like "v2"). Go
+	// back one slash.
 	end := len(f) - len(name) - 1
 	if end >= 0 {
 		prefix := f[:end]

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -34,8 +34,8 @@ var (
 	// Removes package name and method arugments for Go function names.
 	// See tests for examples.
 	goRegExp = regexp.MustCompile(`^(?:[\w\-\.]+\/)+(.+)`)
-	// Checks for a package name that could be a module version.
-	goVerRegExp = regexp.MustCompile(`^v([2-9]|[1-9][0-9]+)\.`)
+	// Removes potential module versions in a package path.
+	goVerRegExp = regexp.MustCompile(`^(.*)/v(?:[2-9]|[1-9][0-9]+)([./].*)$`)
 	// Strips C++ namespace prefix from a C++ function / method name.
 	// NOTE: Make sure to keep the template parameters in the name. Normally,
 	// template parameters are stripped from the C++ names but when
@@ -442,33 +442,13 @@ func newTree(prof *profile.Profile, o *Options) (g *Graph) {
 // ShortenFunctionName returns a shortened version of a function's name.
 func ShortenFunctionName(f string) string {
 	f = cppAnonymousPrefixRegExp.ReplaceAllString(f, "")
+	f = goVerRegExp.ReplaceAllString(f, `${1}${2}`)
 	for _, re := range []*regexp.Regexp{goRegExp, javaRegExp, cppRegExp} {
 		if matches := re.FindStringSubmatch(f); len(matches) >= 2 {
-			name := strings.Join(matches[1:], "")
-			if re == goRegExp {
-				return shortenGoFunc(f, name)
-			}
-			return name
+			return strings.Join(matches[1:], "")
 		}
 	}
 	return f
-}
-
-func shortenGoFunc(f string, name string) string {
-	if !goVerRegExp.MatchString(name) {
-		return name
-	}
-
-	// The shortened name could start with a module version (like "v2"). Go
-	// back one slash.
-	end := len(f) - len(name) - 1
-	if end >= 0 {
-		prefix := f[:end]
-		if idx := strings.LastIndex(prefix, "/"); idx >= 0 {
-			end = idx
-		}
-	}
-	return f[end+1:]
 }
 
 // TrimTree trims a Graph in forest form, keeping only the nodes in kept. This

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -452,6 +452,18 @@ func TestShortenFunctionName(t *testing.T) {
 			"redis.v3.(*baseClient).(github.com/blah/blah/vendor/gopkg.in/redis.v3.process)-fm",
 		},
 		{
+			"github.com/jackc/pgx/v4.(*Conn).Query",
+			"pgx/v4.(*Conn).Query",
+		},
+		{
+			"github.com/jackc/pgx/v4/stdlib.connector.Connect",
+			"stdlib.connector.Connect",
+		},
+		{
+			"example.org/v2xyz.Foo",
+			"v2xyz.Foo",
+		},
+		{
 			"java.util.concurrent.ThreadPoolExecutor$Worker.run",
 			"ThreadPoolExecutor$Worker.run",
 		},

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -453,7 +453,7 @@ func TestShortenFunctionName(t *testing.T) {
 		},
 		{
 			"github.com/foo/bar/v4.(*Foo).Bar",
-			"bar/v4.(*Foo).Bar",
+			"bar.(*Foo).Bar",
 		},
 		{
 			"github.com/foo/bar/v4/baz.Foo.Bar",
@@ -461,7 +461,7 @@ func TestShortenFunctionName(t *testing.T) {
 		},
 		{
 			"github.com/foo/bar/v123.(*Foo).Bar",
-			"bar/v123.(*Foo).Bar",
+			"bar.(*Foo).Bar",
 		},
 		{
 			"github.com/foobar/v0.(*Foo).Bar",

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -452,12 +452,24 @@ func TestShortenFunctionName(t *testing.T) {
 			"redis.v3.(*baseClient).(github.com/blah/blah/vendor/gopkg.in/redis.v3.process)-fm",
 		},
 		{
-			"github.com/jackc/pgx/v4.(*Conn).Query",
-			"pgx/v4.(*Conn).Query",
+			"github.com/foo/bar/v4.(*Foo).Bar",
+			"bar/v4.(*Foo).Bar",
 		},
 		{
-			"github.com/jackc/pgx/v4/stdlib.connector.Connect",
-			"stdlib.connector.Connect",
+			"github.com/foo/bar/v4/baz.Foo.Bar",
+			"baz.Foo.Bar",
+		},
+		{
+			"github.com/foo/bar/v123.(*Foo).Bar",
+			"bar/v123.(*Foo).Bar",
+		},
+		{
+			"github.com/foobar/v0.(*Foo).Bar",
+			"v0.(*Foo).Bar",
+		},
+		{
+			"github.com/foobar/v1.(*Foo).Bar",
+			"v1.(*Foo).Bar",
 		},
 		{
 			"example.org/v2xyz.Foo",

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -476,6 +476,14 @@ func TestShortenFunctionName(t *testing.T) {
 			"v2xyz.Foo",
 		},
 		{
+			"github.com/foo/bar/v4/v4.(*Foo).Bar",
+			"v4.(*Foo).Bar",
+		},
+		{
+			"github.com/foo/bar/v4/foo/bar/v4.(*Foo).Bar",
+			"v4.(*Foo).Bar",
+		},
+		{
 			"java.util.concurrent.ThreadPoolExecutor$Worker.run",
 			"ThreadPoolExecutor$Worker.run",
 		},


### PR DESCRIPTION
Fixes #515.

Remove potential module path versions (v2, v3, v4, etc) from the input string before extracting a shortened name.  This makes it easier to tell which packages are which if the versions happen to match.

An example similar to my report:

![image](https://user-images.githubusercontent.com/48577114/96214159-a1f50100-0f2f-11eb-9675-1b8a1bc08b72.png)

