### PR TITLE
feat: reuse seenEdge and seenNode to reduce garbage collection pressure

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -319,6 +319,8 @@ func New(prof *profile.Profile, o *Options) *Graph {
 // nodes.
 func newGraph(prof *profile.Profile, o *Options) (*Graph, map[uint64]Nodes) {
 	nodes, locationMap := CreateNodes(prof, o)
+	seenNode := make(map[*Node]bool)
+	seenEdge := make(map[nodePair]bool)
 	for _, sample := range prof.Sample {
 		var w, dw int64
 		w = o.SampleValue(sample.Value)
@@ -328,8 +330,12 @@ func newGraph(prof *profile.Profile, o *Options) (*Graph, map[uint64]Nodes) {
 		if dw == 0 && w == 0 {
 			continue
 		}
-		seenNode := make(map[*Node]bool, len(sample.Location))
-		seenEdge := make(map[nodePair]bool, len(sample.Location))
+		for k := range seenNode {
+			delete(seenNode, k)
+		}
+		for k := range seenEdge {
+			delete(seenEdge, k)
+		}
 		var parent *Node
 		// A residual edge goes over one or more nodes that were not kept.
 		residual := false


### PR DESCRIPTION
I changed to reuse seenEdge and seenNode.
I have a profile with 40,000 samples and each loop consumes a lot of time in allocating memory.
I avoided this by using the map-clearing range idiom.

benchmark:
```go
func BenchmarkNewGraph(b *testing.B) {
	f, err := os.Open("testdata/a.pb.gz")
	if err != nil {
		b.Fatal(err)
	}
	defer f.Close()
	p, err := profile.Parse(f)
	if err != nil {
		b.Fatal(err)
	}
	cfg := defaultConfig()
	options := &plugin.Options{
		UI:  &proftest.TestUI{},
		Obj: fakeObjTool{},
	}
	_, r, err := generateRawReport(p, []string{"svg"}, cfg, options)
	if err != nil {
		b.Fatal(err)
	}
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		report.GetDOT(r)
	}
}
```

result:
```
name        old time/op    new time/op    delta
NewGraph-8     2.38s ±10%     1.59s ± 8%  -33.01%  (p=0.000 n=10+10)

name        old alloc/op   new alloc/op   delta
NewGraph-8     975MB ± 0%      47MB ± 2%  -95.19%  (p=0.000 n=9+10)

name        old allocs/op  new allocs/op  delta
NewGraph-8      979k ± 0%      545k ± 2%  -44.31%  (p=0.000 n=10+10)
```

