### PR TITLE
Update supported Xcode versions to fix Github Action failures.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         go: ['1.14', '1.15']
         os: ['macos-10.15']
-        xcode-version: ['12.1', '12.0.1', '11.7', '11.6', '11.5', '11.4.1', '11.3.1', '11.2.1']
+        xcode-version: ['12.1', '12.0', '11.7', '11.6', '11.5', '11.4.1', '11.3.1', '11.2.1']
     steps:
       - name: Update go version
         uses: actions/setup-go@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         go: ['1.14', '1.15']
         os: ['macos-10.15']
-        xcode-version: ['12.1', '12.0', '11.7', '11.6', '11.5', '11.4.1', '11.3.1', '11.2.1']
+        xcode-version: ['12.2', '12.1', '12.0', '11.7', '11.6', '11.5', '11.4.1', '11.3.1', '11.2.1']
     steps:
       - name: Update go version
         uses: actions/setup-go@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         go: ['1.14', '1.15']
         os: ['macos-10.15']
-        xcode-version: ['12.0', '11.7', '11.6', '11.5', '11.4.1', '11.3.1', '11.2.1', '11.1', '11.0']
+        xcode-version: ['12.1', '12.0.1', '11.7', '11.6', '11.5', '11.4.1', '11.3.1', '11.2.1']
     steps:
       - name: Update go version
         uses: actions/setup-go@v2


### PR DESCRIPTION
More specifically, we drop support for Xcode 11.0, 11.1 and add support for Xcode 12.1

Github Action supports the following Xcode versions: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode