### PR TITLE
Update setup-xcode version to solve the deprecation issue.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
           path: ${{ env.WORKING_DIR }}
 
       - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@1.0
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ matrix.xcode-version }}
 


### PR DESCRIPTION
Context: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This is resolved in setup-xcode's new version: https://github.com/maxim-lobanov/setup-xcode/issues/12#issuecomment-728796567