### PR TITLE
Fix wrong flag passed to objdump command when diassembling.

### DIFF
--- a/internal/binutils/binutils.go
+++ b/internal/binutils/binutils.go
@@ -255,7 +255,7 @@ func (bu *Binutils) Disasm(file string, start, end uint64, intelSyntax bool) ([]
 	if !b.objdumpFound {
 		return nil, errors.New("cannot disasm: no objdump tool available")
 	}
-	args := []string{"--disassemble-all", "--demangle", "--no-show-raw-insn",
+	args := []string{"--disassemble", "--demangle", "--no-show-raw-insn",
 		"--line-numbers", fmt.Sprintf("--start-address=%#x", start),
 		fmt.Sprintf("--stop-address=%#x", end)}
 


### PR DESCRIPTION
We were passing the wrong flag (--disassemble-all instead of
--disassemble). This mistake ended up generating bogus instruction
output by looking for covered addresses in non-executable sections
(e.g, we were finding data in the ".debug_info" section and
incorrectly interpreting it as instructions.