### PR TITLE
Enable symbolization of data objects with the llvm symbolizer

### DIFF
--- a/internal/binutils/testdata/fake-llvm-symbolizer
+++ b/internal/binutils/testdata/fake-llvm-symbolizer
@@ -23,12 +23,21 @@ while read line; do
   # line has form:
   #    filename 0xaddr
   # Emit dummy output that matches llvm-symbolizer output format.
-  set -- $line
-  fname=$1
-  addr=$2
-  echo "Inlined_$addr"
-  echo "$fname.h"
-  echo "Func_$addr"
-  echo "$fname.c:2"
-  echo
+  set -- ${line}
+  kind=$1
+  fname=$2
+  addr=$3
+  case ${kind} in
+  CODE)
+    echo "Inlined_${addr}"
+    echo "${fname}.h"
+    echo "Func_${addr}"
+    echo "${fname}.c:2:1"
+    echo;;
+  DATA)
+    echo "${fname}_${addr}"
+    echo "${addr} 8"
+    echo;;
+  *) echo ${kind} ${fname} ${addr};;
+  esac
 done

--- a/internal/elfexec/elfexec.go
+++ b/internal/elfexec/elfexec.go
@@ -283,3 +283,83 @@ func FindTextProgHeader(f *elf.File) *elf.ProgHeader {
 	}
 	return nil
 }
+
+// FindProgHeaderForMapping returns the loadable program segment header that is
+// fully contained in the runtime mapping with file offset pgoff and memory size
+// memsz, or an error if the segment cannot be determined.
+func FindProgHeaderForMapping(f *elf.File, pgoff, memsz uint64) (*elf.ProgHeader, error) {
+	var headers []*elf.ProgHeader
+	loadables := 0
+	for _, p := range f.Progs {
+		if p.Type == elf.PT_LOAD && pgoff <= p.Off && p.Off+p.Memsz <= pgoff+memsz {
+			headers = append(headers, &p.ProgHeader)
+		}
+		if p.Type == elf.PT_LOAD {
+			loadables++
+		}
+	}
+	if len(headers) == 1 {
+		return headers[0], nil
+	}
+	// Some ELF files don't contain any program segments, e.g. .ko loadable kernel
+	// modules. Don't return an error in such cases.
+	if loadables == 0 {
+		return nil, nil
+	}
+	if len(headers) == 0 {
+		return nil, fmt.Errorf("no program header matches file offset %x and memory size %x", pgoff, memsz)
+	}
+
+	// Segments are mapped page aligned. In some cases, segments may be smaller
+	// than a page, which causes the next segment to start at a file offset that
+	// is logically on the same page if we were to align file offsets by page.
+	// Example:
+	//  LOAD           0x0000000000000000 0x0000000000400000 0x0000000000400000
+	//                 0x00000000000006fc 0x00000000000006fc  R E    0x200000
+	//  LOAD           0x0000000000000e10 0x0000000000600e10 0x0000000000600e10
+	//                 0x0000000000000230 0x0000000000000238  RW     0x200000
+	//
+	// In this case, perf records the following mappings for this executable:
+	// 0 0 [0xc0]: PERF_RECORD_MMAP2 87867/87867: [0x400000(0x1000) @ 0 00:3c 512041 0]: r-xp exename
+	// 0 0 [0xc0]: PERF_RECORD_MMAP2 87867/87867: [0x600000(0x2000) @ 0 00:3c 512041 0]: rw-p exename
+	//
+	// Both mappings have file offset 0. The first mapping is one page length and
+	// it can include only the first loadable segment. Due to page alignment, the
+	// second mapping starts also at file offset 0, and it spans two pages. It can
+	// include both the first and the second loadable segments. We must return the
+	// correct program header to compute the correct base offset.
+	//
+	// We cannot use the mapping protections to distinguish between segments,
+	// because protections are not passed through to this function.
+	// We cannot use the start address to differentiate between segments, because
+	// with ASLR, the mapping start address can be any value.
+	//
+	// We use a heuristic to compute the minimum mapping size required for a
+	// segment, assuming mappings are 4k page aligned, and return the segment that
+	// matches the given mapping size.
+	const pageSize = 4096
+
+	// The memory size based heuristic makes sense only if the mapping size is a
+	// multiple of 4k page size.
+	if memsz%pageSize != 0 {
+		return nil, fmt.Errorf("mapping size = %x and %d segments match the passed in mapping", memsz, len(headers))
+	}
+
+	// Return an error if no segment, or multiple segments match the size, so we can debug.
+	var ph *elf.ProgHeader
+	pageMask := ^uint64(pageSize - 1)
+	for _, h := range headers {
+		wantSize := (h.Vaddr+h.Memsz+pageSize-1)&pageMask - (h.Vaddr & pageMask)
+		if wantSize != memsz {
+			continue
+		}
+		if ph != nil {
+			return nil, fmt.Errorf("found second program header (%#v) that matches memsz %x, first program header is %#v", *h, memsz, *ph)
+		}
+		ph = h
+	}
+	if ph == nil {
+		return nil, fmt.Errorf("found %d matching program headers, but none matches mapping size %x", len(headers), memsz)
+	}
+	return ph, nil
+}


### PR DESCRIPTION
This PR adds support for symbolizing virtual data addresses with the llvm-symbolizer. As a prerequisite, we have to compute the correct GetBase offset for data mappings, regardless of which local symbolizer is used. 

One of the commits, changes the current behavior from always computing a base offset relative to the executable program segment, to an approach that tries to identify the program segment associated with a given mapping and computing the offset relative to that segment. This change is enabled only for user space mappings. For kernel mappings, we continue to look for the kernel executable segment.

With this change, we drop support for fake mappings that span the entire address space. From an offline discussion with aalexand@:
- fake mappings were added by https://github.com/google/pprof/pull/89 to handle profiles with no mappings that would be generated by golang runtime sometimes;
- local experiments by aalexand@ show the fake mapping is present in Go 1.7 heap profiles, but not in Go 1.8 profiles. This may be related to the fact that the older Go versions didn't use profile.proto and generated legacy text format instead;
- Go 1.7 is not a supported version anymore, so we are OK with dropping support for the fake mapping.