### PR TITLE
Handle large mappings in FindProgHeaderForMapping

### DIFF
--- a/internal/elfexec/elfexec_test.go
+++ b/internal/elfexec/elfexec_test.go
@@ -112,6 +112,17 @@ func TestFindProgHeaderForMapping(t *testing.T) {
 			{ProgHeader: elf.ProgHeader{Type: elf.PT_DYNAMIC, Flags: elf.PF_R | elf.PF_W, Off: 0xe28, Vaddr: 0x600e28, Paddr: 0x600e28, Filesz: 0x1d0, Memsz: 0x1d0, Align: 8}},
 		},
 	}
+	mediumELFFile := elf.File{
+		Progs: []*elf.Prog{
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_PHDR, Flags: elf.PF_R, Off: 0x40, Vaddr: 0x40, Paddr: 0x40, Filesz: 0x268, Memsz: 0x268, Align: 8}},
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_INTERP, Flags: elf.PF_R, Off: 0x2a8, Vaddr: 0x2a8, Paddr: 0x2a8, Filesz: 0x28, Memsz: 0x28, Align: 1}},
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_X, Off: 0, Vaddr: 0, Paddr: 0, Filesz: 0x51800, Memsz: 0x51800, Align: 0x200000}},
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_W, Off: 0x51800, Vaddr: 0x251800, Paddr: 0x251800, Filesz: 0x24a8, Memsz: 0x24e8, Align: 0x200000}},
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_W, Off: 0x53d00, Vaddr: 0x453d00, Paddr: 0x453d00, Filesz: 0x13a58, Memsz: 0x91a198, Align: 0x200000}},
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_TLS, Flags: elf.PF_R, Off: 0x51800, Vaddr: 0x51800, Paddr: 0x51800, Filesz: 0x0, Memsz: 0x38, Align: 0x8}},
+			{ProgHeader: elf.ProgHeader{Type: elf.PT_DYNAMIC, Flags: elf.PF_R | elf.PF_W, Off: 0x51d00, Vaddr: 0x251d00, Paddr: 0x251d00, Filesz: 0x1ef0, Memsz: 0x1ef0, Align: 8}},
+		},
+	}
 	largeELFFile := elf.File{
 		Progs: []*elf.Prog{
 			{ProgHeader: elf.ProgHeader{Type: elf.PT_PHDR, Flags: elf.PF_R, Off: 0x40, Vaddr: 0x40, Paddr: 0x40, Filesz: 0x268, Memsz: 0x268, Align: 8}},
@@ -164,6 +175,13 @@ func TestFindProgHeaderForMapping(t *testing.T) {
 			pgoff:     0,
 			memsz:     0x3000,
 			wantError: true,
+		},
+		{
+			desc:  "medium ELF file / large mapping includes all address space",
+			file:  &mediumELFFile,
+			pgoff: 0,
+			memsz: 0xd6e000,
+			want:  &elf.ProgHeader{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_X, Off: 0, Vaddr: 0, Paddr: 0, Filesz: 0x51800, Memsz: 0x51800, Align: 0x200000},
 		},
 		{
 			desc:  "large ELF file / executable mapping",

--- a/profile/merge.go
+++ b/profile/merge.go
@@ -231,7 +231,6 @@ func (pm *profileMerger) mapLocation(src *Location) *Location {
 	}
 
 	if l, ok := pm.locationsByID[src.ID]; ok {
-		pm.locationsByID[src.ID] = l
 		return l
 	}
 


### PR DESCRIPTION
In some cases, the loader maps the entire program address space in a single
runtime mapping that starts from the file offset of the first segment but
encompasses additional segments. Such mappings may be split later when
samples are detected in the following segments. However, a perf.data file
still includes the large initial mapping, which should be associated with
the first segment both before and after an eventual splitting. For each
segment, we compute the aligned file offset of its mapping assuming 4k page
alignment, and we filter out program segments that have aligned file
offsets greater than the given mapping file offset.