### PR TITLE
Parse numeric labels with a value of zero if units are specified.

### DIFF
--- a/profile/encode.go
+++ b/profile/encode.go
@@ -308,7 +308,7 @@ func (p *Profile) postDecode() error {
 			if l.strX != 0 {
 				value, err = getString(p.stringTable, &l.strX, err)
 				labels[key] = append(labels[key], value)
-			} else if l.numX != 0 {
+			} else if l.numX != 0 || l.unitX != 0 {
 				numValues := numLabels[key]
 				units := numUnits[key]
 				if l.unitX != 0 {

--- a/profile/proto_test.go
+++ b/profile/proto_test.go
@@ -142,6 +142,16 @@ var all = &Profile{
 				"alignment": {"kilobytes", "kilobytes"},
 			},
 		},
+		{
+			Location: []*Location{testL[1], testL[2], testL[0], testL[1]},
+			Value:    []int64{30, 40},
+			NumLabel: map[string][]int64{
+				"size": {0},
+			},
+			NumUnit: map[string][]string{
+				"size": {"bytes"},
+			},
+		},
 	},
 	Function: testF,
 	Mapping:  testM,


### PR DESCRIPTION
By default, a numeric label with a value of zero is interpreted as an
empty label which will be ignored during parsing. However, a zero value
can be a valid label value. Instead of ignoring it altogether, parse it
as a zero-valued numeric label if num_unit is set.