### PR TITLE
Disable segment selection for a mapping

### DIFF
--- a/internal/binutils/binutils.go
+++ b/internal/binutils/binutils.go
@@ -450,22 +450,7 @@ func (b *binrep) openELF(name string, start, limit, offset uint64) (plugin.ObjFi
 		}
 	}
 
-	var ph *elf.ProgHeader
-	// For user space executables, find the actual program segment that is
-	// associated with the given mapping. Skip this search if limit <= start.
-	// We cannot use just a check on the start address of the mapping to tell if
-	// it's a kernel / .ko module mapping, because with quipper address remapping
-	// enabled, the address would be in the lower half of the address space.
-	if stextOffset == nil && start < limit && limit < (uint64(1)<<63) {
-		ph, err = elfexec.FindProgHeaderForMapping(ef, offset, limit-start)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find program header for file %q, mapping pgoff %x, memsz=%x: %v", name, offset, limit-start, err)
-		}
-	} else {
-		// For the kernel, find the program segment that includes the .text section.
-		ph = elfexec.FindTextProgHeader(ef)
-	}
-
+	ph := elfexec.FindTextProgHeader(ef)
 	base, err := elfexec.GetBase(&ef.FileHeader, ph, stextOffset, start, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("could not identify base for %s: %v", name, err)

--- a/internal/binutils/binutils_test.go
+++ b/internal/binutils/binutils_test.go
@@ -661,10 +661,6 @@ func TestOpenELF(t *testing.T) {
 		wantBase             uint64
 	}{
 		{"exec mapping", 0x5400000, 0x5401000, 0, false, 0x5000000},
-		{"short data mapping", 0x5600e00, 0x5602000, 0xe00, false, 0x5000000},
-		{"page aligned data mapping", 0x5600000, 0x5602000, 0, false, 0x5000000},
-		{"no matching segment", 0x5600000, 0x5602000, 0x2000, true, 0},
-		{"multiple matching segments, wrong size", 0x5600000, 0x5603000, 0, true, 0},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			b := binrep{}


### PR DESCRIPTION
This change restores the old behavior in pprof of always  selecting
the executable segment  when computing the base for a mapping.

This is a temporary rollback, while we fix issues with the new segment
matching heuristic.