### PR TITLE
Replace Base() with ObjAddr() in the plugin.ObjFile interface.

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -159,8 +159,8 @@ type ObjFile interface {
 	// Name returns the underlying file name, if available.
 	Name() string
 
-	// Base returns the base address to use when looking up symbols in the file.
-	Base() uint64
+	// ObjAddr returns the objdump address corresponding to a runtime address.
+	ObjAddr(addr uint64) (uint64, error)
 
 	// BuildID returns the GNU build ID of the file, or an empty string.
 	BuildID() string

--- a/internal/binutils/binutils.go
+++ b/internal/binutils/binutils.go
@@ -508,8 +508,8 @@ func (f *file) Name() string {
 	return f.name
 }
 
-func (f *file) Base() uint64 {
-	return f.base
+func (f *file) ObjAddr(addr uint64) (uint64, error) {
+	return addr - f.base, nil
 }
 
 func (f *file) BuildID() string {

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -1619,9 +1619,9 @@ func (m *mockFile) Name() string {
 	return m.name
 }
 
-// Base returns the base address to use when looking up symbols in the file.
-func (m *mockFile) Base() uint64 {
-	return m.base
+// ObjAddr returns the objdump address corresponding to a runtime address.
+func (m *mockFile) ObjAddr(addr uint64) (uint64, error) {
+	return addr - m.base, nil
 }
 
 // BuildID returns the GNU build ID of the file, or an empty string.

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -168,7 +168,7 @@ func (testObj) Disasm(file string, start, end uint64, intelSyntax bool) ([]plugi
 type testFile struct{ name, buildID string }
 
 func (f testFile) Name() string                                               { return f.name }
-func (testFile) Base() uint64                                                 { return 0 }
+func (testFile) ObjAddr(addr uint64) (uint64, error)                          { return addr, nil }
 func (f testFile) BuildID() string                                            { return f.buildID }
 func (testFile) SourceLine(addr uint64) ([]plugin.Frame, error)               { return nil, nil }
 func (testFile) Symbols(r *regexp.Regexp, addr uint64) ([]*plugin.Sym, error) { return nil, nil }

--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -146,10 +146,10 @@ const fakeSource = "testdata/file1000.src"
 
 type fakeObj struct{}
 
-func (f fakeObj) Close() error    { return nil }
-func (f fakeObj) Name() string    { return "testbin" }
-func (f fakeObj) Base() uint64    { return 0 }
-func (f fakeObj) BuildID() string { return "" }
+func (f fakeObj) Close() error                        { return nil }
+func (f fakeObj) Name() string                        { return "testbin" }
+func (f fakeObj) ObjAddr(addr uint64) (uint64, error) { return addr, nil }
+func (f fakeObj) BuildID() string                     { return "" }
 func (f fakeObj) SourceLine(addr uint64) ([]plugin.Frame, error) {
 	return nil, fmt.Errorf("SourceLine unimplemented")
 }

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -131,8 +131,9 @@ type ObjFile interface {
 	// Name returns the underlyinf file name, if available
 	Name() string
 
-	// Base returns the base address to use when looking up symbols in the file.
-	Base() uint64
+	// ObjAddr returns the objdump (linker) address corresponding to a runtime
+	// address, and an error.
+	ObjAddr(addr uint64) (uint64, error)
 
 	// BuildID returns the GNU build ID of the file, or an empty string.
 	BuildID() string

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -321,9 +321,18 @@ func (sp *sourcePrinter) expandAddresses(rpt *Report, addrs map[uint64]bool, fla
 	}
 
 	for _, r := range ranges {
-		base := r.obj.Base()
-		insts, err := sp.objectTool.Disasm(r.mapping.File, r.begin-base, r.end-base,
-			rpt.options.IntelSyntax)
+		objBegin, err := r.obj.ObjAddr(r.begin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to compute objdump address for range start %x: %v\n", r.begin, err)
+			continue
+		}
+		objEnd, err := r.obj.ObjAddr(r.end)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to compute objdump address for range end %x: %v\n", r.end, err)
+			continue
+		}
+		base := r.begin - objBegin
+		insts, err := sp.objectTool.Disasm(r.mapping.File, objBegin, objEnd, rpt.options.IntelSyntax)
 		if err != nil {
 			// TODO(sanjay): Report that the covered addresses are missing.
 			continue

--- a/internal/symbolizer/symbolizer_test.go
+++ b/internal/symbolizer/symbolizer_test.go
@@ -279,8 +279,8 @@ func (mockObjFile) Name() string {
 	return ""
 }
 
-func (mockObjFile) Base() uint64 {
-	return 0
+func (mockObjFile) ObjAddr(addr uint64) (uint64, error) {
+	return addr, nil
 }
 
 func (mockObjFile) BuildID() string {


### PR DESCRIPTION
Modify the plugin.ObjFile interface by replacing the "Base() uint64" method
with an "ObjAddr(addr uint64) (uint64, error)" method. The latter computes
the objdump address corresponding to the given runtime address.

The change removes direct access to the base value, but enables us to delay
computing the base until it is actually needed.