### PR TITLE
Source listing now handles locations that do not fall in a known mapping

### DIFF
--- a/internal/driver/testdata/pprof.cpu.flat.addresses.weblist
+++ b/internal/driver/testdata/pprof.cpu.flat.addresses.weblist
@@ -20,14 +20,7 @@ h1 {
 .inlinesrc {
   color: #000066;
 }
-.deadsrc {
-cursor: pointer;
-}
-.deadsrc:hover {
-background-color: #eeeeee;
-}
 .livesrc {
-color: #0000ff;
 cursor: pointer;
 }
 .livesrc:hover {
@@ -63,12 +56,12 @@ Type: cpu<br>
 Duration: 10s, Total samples = 1.12s (11.20%)<br>Total: 1.12s</div><h2>line1000</h2><p class="filename">testdata/file1000.src</p>
 <pre onClick="pprof_toggle_asm(event)">
   Total:       1.10s      1.10s (flat, cum) 98.21%
-<span class=line>      1</span> <span class=deadsrc>       1.10s      1.10s           line1 </span><span class=asm>               1.10s      1.10s     1000:     instruction one                                                              <span class=unimportant>file1000.src:1</span>
+<span class=line>      1</span> <span class=livesrc>       1.10s      1.10s           line1 </span><span class=asm>               1.10s      1.10s     1000:     instruction one                                                              <span class=unimportant>file1000.src:1</span>
                    .          .     1001:     instruction two                                                              <span class=unimportant>file1000.src:1</span>
                                      ⋮
                    .          .     1003:     instruction four                                                             <span class=unimportant>file1000.src:1</span>
 </span>
-<span class=line>      2</span> <span class=deadsrc>           .          .           line2 </span><span class=asm>                   .          .     1002:     instruction three                                                            <span class=unimportant>file1000.src:2</span>
+<span class=line>      2</span> <span class=livesrc>           .          .           line2 </span><span class=asm>                   .          .     1002:     instruction three                                                            <span class=unimportant>file1000.src:2</span>
 </span>
 <span class=line>      3</span> <span class=nop>           .          .           line3 </span>
 <span class=line>      4</span> <span class=nop>           .          .           line4 </span>
@@ -84,13 +77,13 @@ Duration: 10s, Total samples = 1.12s (11.20%)<br>Total: 1.12s</div><h2>line1000<
 <span class=line>      3</span> <span class=nop>           .          .           line3 </span>
 <span class=line>      4</span> <span class=nop>           .          .           line4 </span>
 <span class=line>      5</span> <span class=nop>           .          .           line5 </span>
-<span class=line>      6</span> <span class=deadsrc>        10ms      1.01s           line6 </span><span class=asm>                                          <span class=inlinesrc>    line5                                                                       </span> <span class=unimportant>file3000.src:5</span>
+<span class=line>      6</span> <span class=livesrc>        10ms      1.01s           line6 </span><span class=asm>                                          <span class=inlinesrc>    line5                                                                       </span> <span class=unimportant>file3000.src:5</span>
                                           <span class=inlinesrc>        line2                                                                   </span> <span class=unimportant>file3000.src:2</span>
                 10ms      1.01s     3000:             instruction one                                                      <span class=unimportant>file3000.src:2</span>
 </span>
 <span class=line>      7</span> <span class=nop>           .          .           line7 </span>
 <span class=line>      8</span> <span class=nop>           .          .           line8 </span>
-<span class=line>      9</span> <span class=deadsrc>           .      110ms           line9 </span><span class=asm>                                          <span class=inlinesrc>    line8                                                                       </span> <span class=unimportant>file3000.src:8</span>
+<span class=line>      9</span> <span class=livesrc>           .      110ms           line9 </span><span class=asm>                                          <span class=inlinesrc>    line8                                                                       </span> <span class=unimportant>file3000.src:8</span>
                    .      100ms     3001:         instruction two                                                          <span class=unimportant>file3000.src:8</span>
                                           <span class=inlinesrc>    line5                                                                       </span> <span class=unimportant>file3000.src:5</span>
                    .       10ms     3002:         instruction three                                                        <span class=unimportant>file3000.src:5</span>

--- a/internal/report/source_html.go
+++ b/internal/report/source_html.go
@@ -40,14 +40,7 @@ h1 {
 .inlinesrc {
   color: #000066;
 }
-.deadsrc {
-cursor: pointer;
-}
-.deadsrc:hover {
-background-color: #eeeeee;
-}
 .livesrc {
-color: #0000ff;
 cursor: pointer;
 }
 .livesrc:hover {

--- a/internal/report/source_test.go
+++ b/internal/report/source_test.go
@@ -58,7 +58,7 @@ func TestSyntheticSource(t *testing.T) {
 	makeLoc := func(name, fname string, line int64) *profile.Location {
 		return &profile.Location{
 			Line: []profile.Line{
-				profile.Line{
+				{
 					Function: &profile.Function{Name: name, Filename: fname},
 					Line:     line,
 				},
@@ -71,11 +71,11 @@ func TestSyntheticSource(t *testing.T) {
 	bar50 := makeLoc("bar", "bar.go", 50)
 	prof := &profile.Profile{
 		Sample: []*profile.Sample{
-			&profile.Sample{
+			{
 				Value:    []int64{9},
 				Location: []*profile.Location{foo100, bar50},
 			},
-			&profile.Sample{
+			{
 				Value:    []int64{17},
 				Location: []*profile.Location{bar50},
 			},

--- a/internal/report/source_test.go
+++ b/internal/report/source_test.go
@@ -54,9 +54,26 @@ func TestWebList(t *testing.T) {
 	}
 }
 
-func TestSyntheticSource(t *testing.T) {
+func TestSourceSyntheticAddress(t *testing.T) {
+	testSourceMapping(t, true)
+}
+
+func TestSourceMissingMapping(t *testing.T) {
+	testSourceMapping(t, false)
+}
+
+// testSourceMapping checks that source info is found even when no applicable
+// Mapping/objectFile exists. The locations used in the test are either zero
+// (if zeroAddress is true), or non-zero (otherwise).
+func testSourceMapping(t *testing.T, zeroAddress bool) {
+	nextAddr := uint64(0)
+
 	makeLoc := func(name, fname string, line int64) *profile.Location {
+		if !zeroAddress {
+			nextAddr++
+		}
 		return &profile.Location{
+			Address: nextAddr,
 			Line: []profile.Line{
 				{
 					Function: &profile.Function{Name: name, Filename: fname},

--- a/internal/report/synth.go
+++ b/internal/report/synth.go
@@ -1,0 +1,70 @@
+package report
+
+import (
+	"github.com/google/pprof/internal/plugin"
+	"github.com/google/pprof/profile"
+)
+
+// synthAsm is the special value for instructions added by syntheticAddress.
+const synthAsm = ""
+
+// synthCode holds synthesized code that we generate we find addresses
+// in a profile that do not correspond to any known mappings.
+type synthCode struct {
+	mappings mappingList
+	next     uint64                       // Counter used to generate synthesized addresses.
+	loc      map[uint64]*profile.Location // Location for each synthesized address
+	addr     map[*profile.Location]uint64 // Synthesized address assigned to a location
+}
+
+// address returns the synthetic address for loc, creating one if needed.
+func (s *synthCode) address(loc *profile.Location) uint64 {
+	if addr, ok := s.addr[loc]; ok {
+		return addr
+	}
+
+	if s.loc == nil {
+		s.loc = map[uint64]*profile.Location{}
+		s.addr = map[*profile.Location]uint64{}
+
+		// Initialize counter for assigning synthetic addresses.
+		// For now, assume that there are available addresses past the last mapping.
+		if len(s.mappings) > 0 {
+			s.next = s.mappings[len(s.mappings)-1].Limit
+		} else {
+			s.next = 1
+		}
+	}
+
+	addr := s.next
+	s.next++
+	s.loc[addr] = loc
+	s.addr[loc] = addr
+	return addr
+}
+
+// contains returns true if addr is a synthesized address.
+func (s *synthCode) contains(addr uint64) bool {
+	_, ok := s.loc[addr]
+	return ok
+}
+
+// frames returns the []plugin.Frame list for the specified synthesized address.
+// The result will typically have length 1, but may be longer if address corresponds
+// to inlined calls.
+func (s *synthCode) frames(addr uint64) []plugin.Frame {
+	loc := s.loc[addr]
+	stack := make([]plugin.Frame, 0, len(loc.Line))
+	for _, line := range loc.Line {
+		fn := line.Function
+		if fn == nil {
+			continue
+		}
+		stack = append(stack, plugin.Frame{
+			Func: fn.Name,
+			File: fn.Filename,
+			Line: int(line.Line),
+		})
+	}
+	return stack
+}

--- a/internal/report/synth.go
+++ b/internal/report/synth.go
@@ -13,7 +13,7 @@ const synthAsm = ""
 type synthCode struct {
 	mappings mappingList
 	next     uint64                       // Counter used to generate synthesized addresses.
-	loc      map[uint64]*profile.Location // Location for each synthesized address
+	loc      map[uint64]*profile.Location // Location for registered addresses.
 	addr     map[*profile.Location]uint64 // Synthesized address assigned to a location
 }
 
@@ -22,9 +22,7 @@ func (s *synthCode) address(loc *profile.Location) uint64 {
 	if addr, ok := s.addr[loc]; ok {
 		return addr
 	}
-
-	if s.loc == nil {
-		s.loc = map[uint64]*profile.Location{}
+	if s.addr == nil {
 		s.addr = map[*profile.Location]uint64{}
 
 		// Initialize counter for assigning synthetic addresses.
@@ -35,16 +33,25 @@ func (s *synthCode) address(loc *profile.Location) uint64 {
 			s.next = 1
 		}
 	}
-
 	addr := s.next
 	s.next++
-	s.loc[addr] = loc
 	s.addr[loc] = addr
 	return addr
 }
 
-// contains returns true if addr is a synthesized address.
-func (s *synthCode) contains(addr uint64) bool {
+// registerAddress records the location for addr.
+func (s *synthCode) registerAddress(addr uint64, loc *profile.Location) {
+	if _, ok := s.loc[addr]; ok {
+		return
+	}
+	if s.loc == nil {
+		s.loc = map[uint64]*profile.Location{}
+	}
+	s.loc[addr] = loc
+}
+
+// hasLoc returns true if a location is registered for adr.
+func (s *synthCode) hasLoc(addr uint64) bool {
 	_, ok := s.loc[addr]
 	return ok
 }

--- a/internal/report/synth_test.go
+++ b/internal/report/synth_test.go
@@ -1,0 +1,67 @@
+package report
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/pprof/internal/plugin"
+	"github.com/google/pprof/profile"
+)
+
+func TestSynthAddresses(t *testing.T) {
+	s := &synthCode{}
+	l1 := &profile.Location{}
+	addr1 := s.address(l1)
+	if s.address(l1) != addr1 {
+		t.Errorf("different calls with same location returned different addresses")
+	}
+	if !s.contains(addr1) {
+		t.Errorf("does not contain known synthetic address")
+	}
+	if s.contains(addr1 + 1) {
+		t.Errorf("contains unknown synthetic address")
+	}
+
+	l2 := &profile.Location{}
+	addr2 := s.address(l2)
+	if addr2 == addr1 {
+		t.Errorf("same address assigned to different locations")
+	}
+
+}
+
+func TestSynthAvoidsMapping(t *testing.T) {
+	s := &synthCode{mappings: []*profile.Mapping{
+		&profile.Mapping{Start: 100, Limit: 200},
+		&profile.Mapping{Start: 300, Limit: 400},
+	}}
+	loc := &profile.Location{}
+	addr := s.address(loc)
+	if addr >= 100 && addr < 200 || addr >= 300 && addr < 400 {
+		t.Errorf("synthetic location %d overlaps mapping %v", addr, s.mappings)
+	}
+}
+
+func TestSynthFrames(t *testing.T) {
+	s := &synthCode{}
+	loc := &profile.Location{
+		Line: []profile.Line{
+			profile.Line{
+				Function: &profile.Function{Name: "foo", Filename: "foo.cc"},
+				Line:     100,
+			},
+			profile.Line{
+				Function: &profile.Function{Name: "bar", Filename: "bar.cc"},
+				Line:     200,
+			},
+		},
+	}
+	frames := s.frames(s.address(loc))
+	expect := []plugin.Frame{
+		{Func: "foo", File: "foo.cc", Line: 100},
+		{Func: "bar", File: "bar.cc", Line: 200},
+	}
+	if !reflect.DeepEqual(expect, frames) {
+		t.Errorf("unexpected frames: %+v", frames)
+	}
+}

--- a/internal/report/synth_test.go
+++ b/internal/report/synth_test.go
@@ -32,8 +32,8 @@ func TestSynthAddresses(t *testing.T) {
 
 func TestSynthAvoidsMapping(t *testing.T) {
 	s := &synthCode{mappings: []*profile.Mapping{
-		&profile.Mapping{Start: 100, Limit: 200},
-		&profile.Mapping{Start: 300, Limit: 400},
+		{Start: 100, Limit: 200},
+		{Start: 300, Limit: 400},
 	}}
 	loc := &profile.Location{}
 	addr := s.address(loc)
@@ -46,11 +46,11 @@ func TestSynthFrames(t *testing.T) {
 	s := &synthCode{}
 	loc := &profile.Location{
 		Line: []profile.Line{
-			profile.Line{
+			{
 				Function: &profile.Function{Name: "foo", Filename: "foo.cc"},
 				Line:     100,
 			},
-			profile.Line{
+			{
 				Function: &profile.Function{Name: "bar", Filename: "bar.cc"},
 				Line:     200,
 			},

--- a/internal/report/synth_test.go
+++ b/internal/report/synth_test.go
@@ -15,12 +15,6 @@ func TestSynthAddresses(t *testing.T) {
 	if s.address(l1) != addr1 {
 		t.Errorf("different calls with same location returned different addresses")
 	}
-	if !s.contains(addr1) {
-		t.Errorf("does not contain known synthetic address")
-	}
-	if s.contains(addr1 + 1) {
-		t.Errorf("contains unknown synthetic address")
-	}
 
 	l2 := &profile.Location{}
 	addr2 := s.address(l2)
@@ -56,7 +50,15 @@ func TestSynthFrames(t *testing.T) {
 			},
 		},
 	}
-	frames := s.frames(s.address(loc))
+	addr := s.address(loc)
+	s.registerAddress(addr, loc)
+	if !s.hasLoc(addr) {
+		t.Errorf("does not contain known synthetic address")
+	}
+	if s.hasLoc(addr + 1) {
+		t.Errorf("contains unknown synthetic address")
+	}
+	frames := s.frames(addr)
 	expect := []plugin.Frame{
 		{Func: "foo", File: "foo.cc", Line: 100},
 		{Func: "bar", File: "bar.cc", Line: 200},


### PR DESCRIPTION
Some profiles can contain locations that do not fall inside a known
mapping. Treat these better when producing source listings by using
any source information present directly in the profile.Location.

Details: any location that does not fall in a mapping is stored in
a synthetic code object. The synthetic code object is used (instead
of Disasm) to fetch source info for such locations.

Tweaked generated html to clicking for source lines that have no
inlining/assembly to display.

Fixes #621.