### PR TITLE
Add pseudo locations.

### DIFF
--- a/internal/driver/commands.go
+++ b/internal/driver/commands.go
@@ -199,6 +199,12 @@ var configHelp = map[string]string{
 		"Use name=value syntax to limit the matching to a specific tag.",
 		"Numeric tag filter examples: 1kb, 1kb:10kb, memory=32mb:",
 		"String tag filter examples: foo, foo.*bar, mytag=foo.*bar"),
+	"tagleaf": helpText(
+		"Adds a leaf location for samples with a matching tag.",
+		"Example: tagleaf=latency, where latency is numeric tag, adds leaf locations with name latency=<tagvalue>"),
+	"tagroot": helpText(
+		"Adds a root node for samples with a matching tag.",
+		"Example: tagroot=method, where method is string tag, adds root locations with name method=<tagvalue>"),
 	"tagshow": helpText(
 		"Only consider tags matching this regexp",
 		"Discard tags that do not match this regexp"),

--- a/internal/driver/config.go
+++ b/internal/driver/config.go
@@ -29,6 +29,8 @@ type config struct {
 	DivideBy            float64 `json:"-"`
 	Normalize           bool    `json:"normalize,omitempty"`
 	Sort                string  `json:"sort,omitempty"`
+	TagLeaf             string  `json:"tagleaf,omitempty"`
+	TagRoot             string  `json:"tagroot,omitempty"`
 
 	// Filtering options
 	DropNegative bool    `json:"drop_negative,omitempty"`
@@ -145,6 +147,8 @@ func init() {
 		"show_from":            "sf",
 		"tagfocus":             "tf",
 		"tagignore":            "ti",
+		"tagleaf":              "tl",
+		"tagroot":              "tr",
 		"tagshow":              "ts",
 		"taghide":              "th",
 		"mean":                 "mean",

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -99,6 +99,7 @@ func generateRawReport(p *profile.Profile, cmd []string, cfg config, o *plugin.O
 			return nil, nil, err
 		}
 	}
+	addRootLeafTagsAsLocations(p, cfg, o.UI)
 	if err := aggregate(p, cfg); err != nil {
 		return nil, nil, err
 	}
@@ -341,4 +342,10 @@ func valueExtractor(ix int) sampleValueFunc {
 	return func(v []int64) int64 {
 		return v[ix]
 	}
+}
+
+func addRootLeafTagsAsLocations(p *profile.Profile, cfg config, ui plugin.UI) {
+	tr, tl := p.AddRootLeafTagsAsLocations(cfg.TagRoot, cfg.TagLeaf)
+	warnNoMatches(len(cfg.TagRoot) == 0 || tr, "TagRoot", ui)
+	warnNoMatches(len(cfg.TagLeaf) == 0 || tl, "TagLeaf", ui)
 }

--- a/profile/root_leaf_tags.go
+++ b/profile/root_leaf_tags.go
@@ -1,0 +1,121 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profile
+
+// Implements methods to add tags as locations to samples.
+
+import "fmt"
+
+// AddRootLeafTagsAsLocations adds root and leaf locations for tags in a
+// profile as requested in the provided options.
+//
+// The arguments can be empty strings in which case no action would be taken.
+// The two boolean return values indicate whether root and leaf locations were
+// added to any of the samples respectively.
+func (p *Profile) AddRootLeafTagsAsLocations(rootTag, leafTag string) (bool, bool) {
+	addedRootLoc := false
+	addedLeafLoc := false
+	for _, s := range p.Sample {
+		rootLoc, added := addTagAsLocation(p, s, rootTag)
+		if added {
+			addedRootLoc = true
+			s.Location = append(s.Location, rootLoc)
+		}
+		leafLoc, added := addTagAsLocation(p, s, leafTag)
+		if added {
+			addedLeafLoc = true
+			s.Location = append([]*Location{leafLoc}, s.Location...)
+		}
+	}
+	return addedRootLoc, addedLeafLoc
+}
+
+func addTagAsLocation(p *Profile, s *Sample, tag string) (*Location, bool) {
+	if tag == "" {
+		return nil, false
+	}
+	if l1, ok1 := s.Label[tag]; ok1 {
+		return addStringLocation(p, tag, l1), true
+	}
+	if l2, ok2 := s.NumLabel[tag]; ok2 {
+		l3 := s.NumUnit[tag]
+		return addNumLocation(p, tag, l2, l3), true
+	}
+	return nil, false
+}
+
+func addStringLocation(p *Profile, tag string, sl []string) *Location {
+	loc := new(Location)
+	loc.ID = findUniqueLocation(p)
+	var line Line
+	line.Function = addStrFun(p, tag, sl)
+	loc.Line = append(loc.Line, line)
+	loc.IsFolded = false
+	p.Location = append(p.Location, loc)
+	return loc
+}
+
+func addNumLocation(p *Profile, tag string, nl []int64, nu []string) *Location {
+	loc := new(Location)
+	loc.ID = findUniqueLocation(p)
+	var line Line
+	line.Function = addNumFun(p, tag, nl, nu)
+	loc.Line = append(loc.Line, line)
+	loc.IsFolded = false
+	p.Location = append(p.Location, loc)
+	return loc
+}
+
+func findUniqueLocation(p *Profile) uint64 {
+	ids := make(map[uint64]bool)
+	for _, loc := range p.Location {
+		ids[loc.ID] = true
+	}
+	for id := uint64(1); ; id++ {
+		if ok := ids[id]; !ok {
+			return id
+		}
+	}
+}
+
+func addStrFun(p *Profile, tag string, sl []string) *Function {
+	fun := new(Function)
+	fun.ID = findUniqueFun(p)
+	fun.Name = fmt.Sprint(tag, ":", sl)
+	p.Function = append(p.Function, fun)
+	return fun
+}
+
+func addNumFun(p *Profile, tag string, nums []int64, units []string) *Function {
+	fun := new(Function)
+	fun.ID = findUniqueFun(p)
+	for i, n := range nums {
+		fun.Name = fun.Name + fmt.Sprintf("%s:%d%s", tag, n, units[i])
+	}
+	p.Function = append(p.Function, fun)
+	return fun
+}
+
+func findUniqueFun(p *Profile) uint64 {
+	ids := make(map[uint64]bool)
+	for _, fun := range p.Function {
+		ids[fun.ID] = true
+	}
+	for id := uint64(1); ; id++ {
+		if ok := ids[id]; !ok {
+			return id
+		}
+	}
+}

--- a/profile/root_leaf_tags_test.go
+++ b/profile/root_leaf_tags_test.go
@@ -1,0 +1,64 @@
+// Copyright 2020 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profile
+
+import (
+	"reflect"
+	"testing"
+)
+
+func countSampleLocations(p *Profile) []int {
+	var locs []int
+	for _, s := range p.Sample {
+		locs = append(locs, len(s.Location))
+	}
+	return locs
+}
+
+func TestAddRootLeafTagsAdLocations(t *testing.T) {
+	// Perform several forms of pseudo location addition on the test
+	// profile.
+	const notfound = "notfound"
+	const key1 = "key1"
+	const key2 = "key2"
+	type pseudoTestcase struct {
+		name             string
+		rootTag, leafTag string
+		wr, wl           bool
+		locs             []int
+	}
+	for _, tc := range []pseudoTestcase{
+		// Empty root and leaf tags.
+		{"EmptyRootAndLeafTags", "", "", false, false, []int{1, 2, 2, 2, 2}},
+		// Root and leaf tags not present in any of the samples.
+		{"TagsNotFound", notfound, notfound, false, false, []int{1, 2, 2, 2, 2}},
+		// One root tag.
+		{"AddRootTag", key1, "", true, false, []int{2, 3, 3, 3, 3}},
+		// One leaf tag.
+		{"AddLeafTag", "", key2, false, true, []int{2, 2, 3, 3, 3}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prof := testProfile1.Copy()
+			gr, gl := prof.AddRootLeafTagsAsLocations(tc.rootTag, tc.leafTag)
+			if gr != tc.wr || gl != tc.wl {
+				t.Fatalf("AddRootLeafTagsAsLocations(%s, %s)=%v,%v want %v,%v", tc.rootTag, tc.leafTag, gr, gl, tc.wr, tc.wl)
+			}
+			// Test that samples with matching tag have expected number of locations.
+			if locs := countSampleLocations(prof); !reflect.DeepEqual(locs, tc.locs) {
+				t.Errorf("locs = %v, want %v", locs, tc.locs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Pseudo locations can be added using tagroot and tagleaf commands.  For
example, the following flame graph was generated by adding pseudo
locations in the following fashion:
(pprof) tagroot=method
(pprof) tagleaf=duration

http://pprof.corp.google.com/user-profile?id=41836144a6bd473147ab7e1f248f55bb&tab=flame