### PR TITLE
internal/report: error if filter argument has no matches

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -432,6 +432,10 @@ func PrintAssembly(w io.Writer, rpt *Report, obj plugin.ObjTool, maxFuncs int) e
 		}
 	}
 
+	if len(syms) == 0 {
+		return fmt.Errorf("no matches found for regexp: %s", o.Symbol)
+	}
+
 	// Correlate the symbols from the binary with the profile samples.
 	for _, s := range syms {
 		sns := symNodes[s]
@@ -1054,6 +1058,7 @@ func printTree(w io.Writer, rpt *Report) error {
 	var flatSum int64
 
 	rx := rpt.options.Symbol
+	matched := 0
 	for _, n := range g.Nodes {
 		name, flat, cum := n.Info.PrintableName(), n.FlatValue(), n.CumValue()
 
@@ -1061,6 +1066,7 @@ func printTree(w io.Writer, rpt *Report) error {
 		if rx != nil && !rx.MatchString(name) {
 			continue
 		}
+		matched++
 
 		fmt.Fprintln(w, separator)
 		// Print incoming edges.
@@ -1097,6 +1103,9 @@ func printTree(w io.Writer, rpt *Report) error {
 	}
 	if len(g.Nodes) > 0 {
 		fmt.Fprintln(w, separator)
+	}
+	if rx != nil && matched == 0 {
+		return fmt.Errorf("no matches found for regexp: %s", rx)
 	}
 	return nil
 }

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -58,6 +58,10 @@ func printSource(w io.Writer, rpt *Report) error {
 	}
 	functions.Sort(graph.NameOrder)
 
+	if len(functionNodes) == 0 {
+		return fmt.Errorf("no matches found for regexp: %s", o.Symbol)
+	}
+
 	sourcePath := o.SourcePath
 	if sourcePath == "" {
 		wd, err := os.Getwd()
@@ -206,6 +210,9 @@ func PrintWebList(w io.Writer, rpt *Report, obj plugin.ObjTool, maxFiles int) er
 		sourcePath = wd
 	}
 	sp := newSourcePrinter(rpt, obj, sourcePath)
+	if len(sp.interest) == 0 {
+		return fmt.Errorf("no matches found for regexp: %s", rpt.options.Symbol)
+	}
 	sp.print(w, maxFiles, rpt)
 	sp.close()
 	return nil


### PR DESCRIPTION
list, weblist, disasm, and peek all take a regexp argument that acts as
a filter.

Currently if this filter results in no matches we simply generate an
empty report, which can be confusing to users. Instead, explicitly treat
this as an error condition that is clearly reported to users.

Fixes #629