### PR TITLE
Add support for matching split mappings to segments.

### DIFF
--- a/internal/binutils/binutils_test.go
+++ b/internal/binutils/binutils_test.go
@@ -808,7 +808,7 @@ func TestELFObjAddr(t *testing.T) {
 		wantAddrError        bool
 	}{
 		{"exec mapping, good address", 0x5400000, 0x5401000, 0, false, 0x5400400, 0x400400, false},
-		{"exec mapping, address outside segment", 0x5400000, 0x5401000, 0, false, 0x5400800, 0x400800, false},
+		{"exec mapping, address outside segment", 0x5400000, 0x5401000, 0, false, 0x5400800, 0, true},
 		{"short data mapping, good address", 0x5600e00, 0x5602000, 0xe00, false, 0x5600e10, 0x600e10, false},
 		{"short data mapping, address outside segment", 0x5600e00, 0x5602000, 0xe00, false, 0x5600e00, 0x600e00, false},
 		{"page aligned data mapping, good address", 0x5600000, 0x5602000, 0, false, 0x5601000, 0x601000, false},

--- a/internal/binutils/binutils_test.go
+++ b/internal/binutils/binutils_test.go
@@ -812,7 +812,7 @@ func TestELFObjAddr(t *testing.T) {
 		{"short data mapping, good address", 0x5600e00, 0x5602000, 0xe00, false, 0x5600e10, 0x600e10, false},
 		{"short data mapping, address outside segment", 0x5600e00, 0x5602000, 0xe00, false, 0x5600e00, 0x600e00, false},
 		{"page aligned data mapping, good address", 0x5600000, 0x5602000, 0, false, 0x5601000, 0x601000, false},
-		{"page aligned data mapping, address outside segment", 0x5600000, 0x5602000, 0, false, 0x5601048, 0x601048, false},
+		{"page aligned data mapping, address outside segment", 0x5600000, 0x5602000, 0, false, 0x5601048, 0, true},
 		{"bad file offset, no matching segment", 0x5600000, 0x5602000, 0x2000, false, 0x5600e10, 0, true},
 		{"large mapping size, match by sample offset", 0x5600000, 0x5603000, 0, false, 0x5600e10, 0x600e10, false},
 	} {

--- a/internal/elfexec/elfexec_test.go
+++ b/internal/elfexec/elfexec_test.go
@@ -238,11 +238,14 @@ func TestFindProgHeaderForMapping(t *testing.T) {
 			wantHeaders: []*elf.ProgHeader{{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_X, Off: 0, Vaddr: 0x400000, Paddr: 0x400000, Filesz: 0x6fc, Memsz: 0x6fc, Align: 0x200000}},
 		},
 		{
-			desc:        "small file, offset 0, memsz 8KB matches data segment",
-			phdrs:       smallHeaders,
-			pgoff:       0,
-			memsz:       0x2000,
-			wantHeaders: []*elf.ProgHeader{{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_W, Off: 0xe10, Vaddr: 0x600e10, Paddr: 0x600e10, Filesz: 0x230, Memsz: 0x238, Align: 0x200000}},
+			desc:  "small file, offset 0, memsz 8KB matches both segments",
+			phdrs: smallHeaders,
+			pgoff: 0,
+			memsz: 0x2000,
+			wantHeaders: []*elf.ProgHeader{
+				{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_X, Off: 0, Vaddr: 0x400000, Paddr: 0x400000, Filesz: 0x6fc, Memsz: 0x6fc, Align: 0x200000},
+				{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_W, Off: 0xe10, Vaddr: 0x600e10, Paddr: 0x600e10, Filesz: 0x230, Memsz: 0x238, Align: 0x200000},
+			},
 		},
 		{
 			desc:        "small file, offset 4KB matches no segment",
@@ -250,16 +253,6 @@ func TestFindProgHeaderForMapping(t *testing.T) {
 			pgoff:       0x1000,
 			memsz:       0x1000,
 			wantHeaders: nil,
-		},
-		{
-			desc:  "small file, offset 0, memsz 12KB matches both segments",
-			phdrs: smallHeaders,
-			pgoff: 0,
-			memsz: 0x3000,
-			wantHeaders: []*elf.ProgHeader{
-				{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_X, Off: 0, Vaddr: 0x400000, Paddr: 0x400000, Filesz: 0x6fc, Memsz: 0x6fc, Align: 0x200000},
-				{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_W, Off: 0xe10, Vaddr: 0x600e10, Paddr: 0x600e10, Filesz: 0x230, Memsz: 0x238, Align: 0x200000},
-			},
 		},
 		{
 			desc:  "small bad BSS file, offset 0, memsz 4KB matches two segments",
@@ -272,11 +265,15 @@ func TestFindProgHeaderForMapping(t *testing.T) {
 			},
 		},
 		{
-			desc:        "small bad BSS file, offset 0, memsz 8KB matches second data segment",
-			phdrs:       smallBadBSSHeaders,
-			pgoff:       0,
-			memsz:       0x2000,
-			wantHeaders: []*elf.ProgHeader{{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_W, Off: 0xe10, Vaddr: 0x600e10, Paddr: 0x600e10, Filesz: 0x230, Memsz: 0x238, Align: 0x200000}},
+			desc:  "small bad BSS file, offset 0, memsz 8KB matches all three segments",
+			phdrs: smallBadBSSHeaders,
+			pgoff: 0,
+			memsz: 0x2000,
+			wantHeaders: []*elf.ProgHeader{
+				{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_X, Off: 0, Vaddr: 0x200000, Paddr: 0x200000, Filesz: 0x6fc, Memsz: 0x6fc, Align: 0x200000},
+				{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_W, Off: 0x700, Vaddr: 0x400700, Paddr: 0x400700, Filesz: 0x500, Memsz: 0x710, Align: 0x200000},
+				{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_W, Off: 0xe10, Vaddr: 0x600e10, Paddr: 0x600e10, Filesz: 0x230, Memsz: 0x238, Align: 0x200000},
+			},
 		},
 		{
 			desc:        "small bad BSS file, offset 4KB matches no segment",
@@ -284,17 +281,6 @@ func TestFindProgHeaderForMapping(t *testing.T) {
 			pgoff:       0x1000,
 			memsz:       0x1000,
 			wantHeaders: nil,
-		},
-		{
-			desc:  "small bad BSS file, offset 0, memsz 12KB matches all three segments",
-			phdrs: smallBadBSSHeaders,
-			pgoff: 0,
-			memsz: 0x3000,
-			wantHeaders: []*elf.ProgHeader{
-				{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_X, Off: 0, Vaddr: 0x200000, Paddr: 0x200000, Filesz: 0x6fc, Memsz: 0x6fc, Align: 0x200000},
-				{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_W, Off: 0x700, Vaddr: 0x400700, Paddr: 0x400700, Filesz: 0x500, Memsz: 0x710, Align: 0x200000},
-				{Type: elf.PT_LOAD, Flags: elf.PF_R | elf.PF_W, Off: 0xe10, Vaddr: 0x600e10, Paddr: 0x600e10, Filesz: 0x230, Memsz: 0x238, Align: 0x200000},
-			},
 		},
 		{
 			desc:        "medium file large mapping that includes all address space matches executable segment",


### PR DESCRIPTION
Update the heuristic that matches mappings to segments to support split mappings.

The existing logic assumes a mapping is at least as large as the program segment. However, the loader, or some managing service, may split a program segment into multiple mappings for different reasons:
- to map part of the segment to huge pages, while other parts use regular sized pages;
- the last page may be remapped with write protection to zero out the bytes after the segment end in the last partial mapping page;
- if the segment includes both initialized and uninitialized data.

The list is not exhaustive. While https://github.com/google/perf_data_converter tries to combine associated split mappings into a single mapping, that heuristic also has limitations. Being able to match split mappings to segments increases symbolization coverage.
