### PR TITLE
Change llvm-symbolizer to use --inlining

### DIFF
--- a/internal/binutils/addr2liner_llvm.go
+++ b/internal/binutils/addr2liner_llvm.go
@@ -76,7 +76,7 @@ func newLLVMSymbolizer(cmd, file string, base uint64, isData bool) (*llvmSymboli
 	}
 
 	j := &llvmSymbolizerJob{
-		cmd:     exec.Command(cmd, "-inlining", "-demangle=false"),
+		cmd:     exec.Command(cmd, "--inlining", "-demangle=false"),
 		symType: "CODE",
 	}
 	if isData {


### PR DESCRIPTION
The single dash -inlining is exotic.
Change it to the double-dash --inlining.

I removed most one-dash long options from llvm-symbolizer in
<https://reviews.llvm.org/D106377> (I forgot that pprof is still using
-inlining when I made the change.)

-demangle=false is also exotic but not changed. It is currently
implemented as a legacy alias
(llvm/llvm-project@c558c22cab9a555d2e521102b775759381e9727f).  We can
change it to --no-demangle once support for llvm-symbolizer < 9.0 is
dropped (https://reviews.llvm.org/D56773).