### PR TITLE
elfexec: fix typo in elfexec.go

### DIFF
--- a/internal/elfexec/elfexec.go
+++ b/internal/elfexec/elfexec.go
@@ -318,7 +318,7 @@ func ProgramHeadersForMapping(phdrs []elf.ProgHeader, mapOff, mapSz uint64) []*e
 		// The segment must overlap the mapping.
 		if p.Type == elf.PT_LOAD && mapOff < segLimit && p.Off < mapLimit {
 			// If the mapping offset is strictly less than the page aligned segment
-			// offset, then this mapping comes from a differnt segment, fixes
+			// offset, then this mapping comes from a different segment, fixes
 			// b/179920361.
 			alignedSegOffset := uint64(0)
 			if p.Off > (p.Vaddr & pageOffsetMask) {


### PR DESCRIPTION
Fixing a typo, differnt -> different