### PR TITLE
Fix tests run by Github Action and update the testing matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.15', '1.16', 'tip']
+        go: ['1.16', '1.17', 'tip']
         # Supported macOS versions can be found in
         # https://github.com/actions/virtual-environments#available-environments.
         os: ['macos-10.15']
@@ -56,7 +56,9 @@ jobs:
         run: |
           brew install graphviz
           # Do not let tools interfere with the main module's go.mod.
-          cd && go get -u golang.org/x/lint/golint honnef.co/go/tools/cmd/...
+          cd && go mod init tools 
+          go get -u golang.org/x/lint/golint honnef.co/go/tools/cmd/...
+          go install golang.org/x/lint/golint honnef.co/go/tools/cmd/...
           # Add PATH for installed tools.
           echo "$GOPATH/bin:$PATH" >> $GITHUB_PATH
 
@@ -88,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.15', '1.16', 'tip']
+        go: ['1.16', '1.17', 'tip']
         os: ['ubuntu-20.04', 'ubuntu-18.04', 'ubuntu-16.04'] 
     steps:
       - name: Update Go version using setup-go
@@ -116,7 +118,9 @@ jobs:
         run: |
           sudo apt-get install graphviz
           # Do not let tools interfere with the main module's go.mod.
-          cd && go get -u golang.org/x/lint/golint honnef.co/go/tools/cmd/...
+          cd && go mod init tools 
+          go get -u golang.org/x/lint/golint honnef.co/go/tools/cmd/...
+          go install golang.org/x/lint/golint honnef.co/go/tools/cmd/...
           # Add PATH for installed tools.
           echo "PATH=$GOPATH/bin:$PATH" >> $GITHUB_ENV
 
@@ -145,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.15', '1.16']
+        go: ['1.16', '1.17']
     steps:
       - name: Update Go version using setup-go
         uses: actions/setup-go@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         go: ['1.16', '1.17', 'tip']
-        os: ['ubuntu-20.04', 'ubuntu-18.04', 'ubuntu-16.04'] 
+        os: ['ubuntu-20.04', 'ubuntu-18.04'] 
     steps:
       - name: Update Go version using setup-go
         uses: actions/setup-go@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,16 @@ jobs:
         # Supported macOS versions can be found in
         # https://github.com/actions/virtual-environments#available-environments.
         os: ['macos-10.15', 'macos-11']
-        # Supported Xcode versions can be found in 
+        # Supported Xcode versions for macOS 10.15 can be found in 
         # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode.
-        xcode-version: ['12.4', '12.3', '12.2', '12.1.1', '12.0.1', '11.7']
+        # Supported Xcode versions for macOS 11 can be found in 
+        # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
+        xcode-version: ['11.7']
+        include:
+        - os: 'macos-10.15'
+          xcode-version: ['12.4', '12.3', '12.2', '12.1.1', '12.0.1']
+        - os: 'macos-11'
+          xcode-version: ['13.0','12.5']
     steps:
       - name: Update Go version using setup-go
         uses: actions/setup-go@v2
@@ -47,10 +54,17 @@ jobs:
         with:
           path: ${{ env.WORKING_DIR }}
 
-      - name: Set up Xcode
+      - name: Set up Xcode macOS 10
+        if: matrix.os == 'macos-10.15'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: ${{ matrix.xcode-version }}
+          xcode-version: ${{ matrix.macos-10-xcode-version }}
+
+      - name: Set up Xcode macOS 11
+        if: matrix.os == 'macos-11'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.macos-11-xcode-version }}
 
       - name: Fetch dependencies
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: ci
 on: 
   push:
     branches:
-      - master
+      - go_get_fix
   pull_request:
   schedule:
     - cron: '0 2 * * *' # Run every day, at 2AM UTC.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,12 +26,20 @@ jobs:
         # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode.
         # Supported Xcode versions for macOS 11 can be found in 
         # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
-        xcode-version: ['11.7']
+        xcode-version: ['12.4', '11.7']
         include:
         - os: 'macos-10.15'
-          xcode-version: ['12.4', '12.3', '12.2', '12.1.1', '12.0.1']
+          xcode-version: '12.3' 
+        - os: 'macos-10.15'
+          xcode-version: '12.3' 
+        - os: 'macos-10.15'
+          xcode-version: '12.1.1' 
+        - os: 'macos-10.15'
+          xcode-version: '12.0.1' 
         - os: 'macos-11'
-          xcode-version: ['13.0','12.5']
+          xcode-version: '13.0'
+        - os: 'macos-11'
+          xcode-version: '12.5'
     steps:
       - name: Update Go version using setup-go
         uses: actions/setup-go@v2
@@ -54,17 +62,10 @@ jobs:
         with:
           path: ${{ env.WORKING_DIR }}
 
-      - name: Set up Xcode macOS 10
-        if: matrix.os == 'macos-10.15'
+      - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: ${{ matrix.macos-10-xcode-version }}
-
-      - name: Set up Xcode macOS 11
-        if: matrix.os == 'macos-11'
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ matrix.macos-11-xcode-version }}
+          xcode-version: ${{ matrix.xcode-version }}
 
       - name: Fetch dependencies
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: ci
 on: 
   push:
     branches:
-      - go_get_fix
+      - master
   pull_request:
   schedule:
     - cron: '0 2 * * *' # Run every day, at 2AM UTC.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,20 +26,20 @@ jobs:
         # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode.
         # Supported Xcode versions for macOS 11 can be found in 
         # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
-        xcode-version: ['12.4', '11.7']
-        include:
+        xcode-version: ['13.0', '12.5', '12.4', '12.3', '12.1.1', '12.0.1', '11.7']
+        exclude:
         - os: 'macos-10.15'
+          xcode-version: '13.0' 
+        - os: 'macos-10.15'
+          xcode-version: '12.5' 
+        - os: 'macos-11'
+          xcode-version: '12.4' 
+        - os: 'macos-11'
           xcode-version: '12.3' 
-        - os: 'macos-10.15'
-          xcode-version: '12.3' 
-        - os: 'macos-10.15'
+        - os: 'macos-11'
           xcode-version: '12.1.1' 
-        - os: 'macos-10.15'
+        - os: 'macos-11'
           xcode-version: '12.0.1' 
-        - os: 'macos-11'
-          xcode-version: '13.0'
-        - os: 'macos-11'
-          xcode-version: '12.5'
     steps:
       - name: Update Go version using setup-go
         uses: actions/setup-go@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         go: ['1.16', '1.17', 'tip']
         # Supported macOS versions can be found in
         # https://github.com/actions/virtual-environments#available-environments.
-        os: ['macos-10.15']
+        os: ['macos-10.15', 'macos-11']
         # Supported Xcode versions can be found in 
         # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode.
         xcode-version: ['12.4', '12.3', '12.2', '12.1.1', '12.0.1', '11.7']


### PR DESCRIPTION
Fixes #653 

`go get` is no longer supported outside a module, and we need to use `go install` to install executables, see https://golang.org/doc/go-get-install-deprecation for more details.

This PR also updated Go versions, macOS versions and their supported Xcode versions, and Linux versions.

TESTED: https://github.com/wyk9787/pprof/actions/runs/1288644610

