### PR TITLE
Refactor GetBase heuristics for kernels.

### DIFF
--- a/internal/elfexec/elfexec.go
+++ b/internal/elfexec/elfexec.go
@@ -168,7 +168,7 @@ func GetBuildID(binary io.ReaderAt) ([]byte, error) {
 // kernelBase caluclates the base for kernel mappings, which usually require
 // special handling. For kernel mappings, tools (like perf) use the address of
 // the kernel relocation symbol (_text or _stext) as the mmap start. Additionaly,
-// for obfuscation, ChromeOS kernels can get remapped to the 0-th page.
+// for obfuscation, ChromeOS profiles have the kernel image remapped to the 0-th page.
 func kernelBase(loadSegment *elf.ProgHeader, stextOffset *uint64, start, limit, offset uint64) (uint64, bool) {
 	const (
 		// PAGE_OFFSET for PowerPC64, see arch/powerpc/Kconfig in the kernel sources.

--- a/internal/elfexec/elfexec.go
+++ b/internal/elfexec/elfexec.go
@@ -165,14 +165,27 @@ func GetBuildID(binary io.ReaderAt) ([]byte, error) {
 	return nil, nil
 }
 
-// nonZeroKernel computes the heuristic base address for kernels *not* remapped to the zero page.
-func nonZeroKernel(loadSegment *elf.ProgHeader, stextOffset *uint64, start, limit, offset uint64) (uint64, bool) {
+// kernelBase caluclates the base for kernel mappings, which usually require
+// special handling. For kernel mappings, tools (like perf) use the address of
+// the kernel relocation symbol (_text or _stext) as the mmap start. Additionaly,
+// for obfuscation, ChromeOS kernels can get remapped to the 0-th page.
+func kernelBase(loadSegment *elf.ProgHeader, stextOffset *uint64, start, limit, offset uint64) (uint64, bool) {
 	const (
 		// PAGE_OFFSET for PowerPC64, see arch/powerpc/Kconfig in the kernel sources.
 		pageOffsetPpc64 = 0xc000000000000000
 		pageSize        = 4096
 	)
 
+	if loadSegment.Vaddr == start-offset {
+		return offset, true
+	}
+	if start == 0 && limit != 0 && stextOffset != nil {
+		// ChromeOS remaps its kernel to 0. Nothing else should come
+		// down this path. Empirical values:
+		//       VADDR=0xffffffff80200000
+		// stextOffset=0xffffffff80200198
+		return start - *stextOffset, true
+	}
 	if start >= loadSegment.Vaddr && limit > start && (offset == 0 || offset == pageOffsetPpc64 || offset == start) {
 		// Some kernels look like:
 		//       VADDR=0xffffffff80200000
@@ -190,17 +203,22 @@ func nonZeroKernel(loadSegment *elf.ProgHeader, stextOffset *uint64, start, limi
 
 		return start - loadSegment.Vaddr, true
 	}
+	if start%pageSize != 0 && stextOffset != nil && *stextOffset%pageSize == start%pageSize {
+		// ChromeOS remaps its kernel to 0 + start%pageSize. Nothing
+		// else should come down this path. Empirical values:
+		//       start=0x198 limit=0x2f9fffff offset=0
+		//       VADDR=0xffffffff81000000
+		// stextOffset=0xffffffff81000198
+		return start - *stextOffset, true
+	}
 	return 0, false
 }
 
 // GetBase determines the base address to subtract from virtual
 // address to get symbol table address. For an executable, the base
 // is 0. Otherwise, it's a shared library, and the base is the
-// address where the mapping starts. The kernel is special, and may
-// use the address of the _stext symbol as the mmap start. _stext
-// offset can be obtained with `nm vmlinux | grep _stext`
+// address where the mapping starts. The kernel needs special hanldling.
 func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint64, start, limit, offset uint64) (uint64, error) {
-	const pageSize = 4096
 
 	if start == 0 && offset == 0 && (limit == ^uint64(0) || limit == 0) {
 		// Some tools may introduce a fake mapping that spans the entire
@@ -226,29 +244,15 @@ func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint6
 			// the 64-bit address space.
 			return start - offset + loadSegment.Off - loadSegment.Vaddr, nil
 		}
-		// Various kernel heuristics and cases follow.
-		if loadSegment.Vaddr == start-offset {
-			return offset, nil
-		}
-		if start == 0 && limit != 0 {
-			// ChromeOS remaps its kernel to 0. Nothing else should come
-			// down this path. Empirical values:
-			//       VADDR=0xffffffff80200000
-			// stextOffset=0xffffffff80200198
-			if stextOffset != nil {
-				return -*stextOffset, nil
-			}
-			return -loadSegment.Vaddr, nil
-		}
-		if base, match := nonZeroKernel(loadSegment, stextOffset, start, limit, offset); match {
+		// Various kernel heuristics and cases are handled separately.
+		if base, match := kernelBase(loadSegment, stextOffset, start, limit, offset); match {
 			return base, nil
-		} else if start%pageSize != 0 && stextOffset != nil && *stextOffset%pageSize == start%pageSize {
-			// ChromeOS remaps its kernel to 0 + start%pageSize. Nothing
-			// else should come down this path. Empirical values:
-			//       start=0x198 limit=0x2f9fffff offset=0
-			//       VADDR=0xffffffff81000000
-			// stextOffset=0xffffffff81000198
-			return start - *stextOffset, nil
+		}
+		// ChromeOS can remap its kernel to 0, and the caller might have not found
+		// the _stext symbol. Split this case from kernelBase() above, since we don't
+		// want to apply it to an ET_DYN user-mode executable.
+		if start == 0 && limit != 0 && stextOffset == nil {
+			return start - loadSegment.Vaddr, nil
 		}
 
 		return 0, fmt.Errorf("don't know how to handle EXEC segment: %v start=0x%x limit=0x%x offset=0x%x", *loadSegment, start, limit, offset)

--- a/internal/elfexec/elfexec.go
+++ b/internal/elfexec/elfexec.go
@@ -165,6 +165,34 @@ func GetBuildID(binary io.ReaderAt) ([]byte, error) {
 	return nil, nil
 }
 
+// nonZeroKernel computes the heuristic base address for kernels *not* remapped to the zero page.
+func nonZeroKernel(loadSegment *elf.ProgHeader, stextOffset *uint64, start, limit, offset uint64) (uint64, bool) {
+	const (
+		// PAGE_OFFSET for PowerPC64, see arch/powerpc/Kconfig in the kernel sources.
+		pageOffsetPpc64 = 0xc000000000000000
+		pageSize        = 4096
+	)
+
+	if start >= loadSegment.Vaddr && limit > start && (offset == 0 || offset == pageOffsetPpc64 || offset == start) {
+		// Some kernels look like:
+		//       VADDR=0xffffffff80200000
+		// stextOffset=0xffffffff80200198
+		//       Start=0xffffffff83200000
+		//       Limit=0xffffffff84200000
+		//      Offset=0 (0xc000000000000000 for PowerPC64) (== Start for ASLR kernel)
+		// So the base should be:
+		if stextOffset != nil && (start%pageSize) == (*stextOffset%pageSize) {
+			// perf uses the address of _stext as start. Some tools may
+			// adjust for this before calling GetBase, in which case the page
+			// alignment should be different from that of stextOffset.
+			return start - *stextOffset, true
+		}
+
+		return start - loadSegment.Vaddr, true
+	}
+	return 0, false
+}
+
 // GetBase determines the base address to subtract from virtual
 // address to get symbol table address. For an executable, the base
 // is 0. Otherwise, it's a shared library, and the base is the
@@ -174,8 +202,6 @@ func GetBuildID(binary io.ReaderAt) ([]byte, error) {
 func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint64, start, limit, offset uint64) (uint64, error) {
 	const (
 		pageSize = 4096
-		// PAGE_OFFSET for PowerPC64, see arch/powerpc/Kconfig in the kernel sources.
-		pageOffsetPpc64 = 0xc000000000000000
 	)
 
 	if start == 0 && offset == 0 && (limit == ^uint64(0) || limit == 0) {
@@ -216,22 +242,8 @@ func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint6
 			}
 			return -loadSegment.Vaddr, nil
 		}
-		if start >= loadSegment.Vaddr && limit > start && (offset == 0 || offset == pageOffsetPpc64 || offset == start) {
-			// Some kernels look like:
-			//       VADDR=0xffffffff80200000
-			// stextOffset=0xffffffff80200198
-			//       Start=0xffffffff83200000
-			//       Limit=0xffffffff84200000
-			//      Offset=0 (0xc000000000000000 for PowerPC64) (== Start for ASLR kernel)
-			// So the base should be:
-			if stextOffset != nil && (start%pageSize) == (*stextOffset%pageSize) {
-				// perf uses the address of _stext as start. Some tools may
-				// adjust for this before calling GetBase, in which case the page
-				// alignment should be different from that of stextOffset.
-				return start - *stextOffset, nil
-			}
-
-			return start - loadSegment.Vaddr, nil
+		if base, match := nonZeroKernel(loadSegment, stextOffset, start, limit, offset); match {
+			return base, nil
 		} else if start%pageSize != 0 && stextOffset != nil && *stextOffset%pageSize == start%pageSize {
 			// ChromeOS remaps its kernel to 0 + start%pageSize. Nothing
 			// else should come down this path. Empirical values:

--- a/internal/elfexec/elfexec.go
+++ b/internal/elfexec/elfexec.go
@@ -200,9 +200,7 @@ func nonZeroKernel(loadSegment *elf.ProgHeader, stextOffset *uint64, start, limi
 // use the address of the _stext symbol as the mmap start. _stext
 // offset can be obtained with `nm vmlinux | grep _stext`
 func GetBase(fh *elf.FileHeader, loadSegment *elf.ProgHeader, stextOffset *uint64, start, limit, offset uint64) (uint64, error) {
-	const (
-		pageSize = 4096
-	)
+	const pageSize = 4096
 
 	if start == 0 && offset == 0 && (limit == ^uint64(0) || limit == 0) {
 		// Some tools may introduce a fake mapping that spans the entire


### PR DESCRIPTION
Not a functional change. Just separate a helper function to match most kernels heuristics.

This way they can be shared between ET_EXEC and ET_DYN kernels.

Tested: unit