### PR TITLE
ci: Disable staticcheck on tip-of-tree compiler.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,13 +50,12 @@ jobs:
       - name: Update Go version manually
         if: matrix.go == 'tip'
         working-directory: ${{ github.workspace }}
-        env: 
-          RUN_STATICCHECK: false
         run: |
           git clone https://go.googlesource.com/go $HOME/gotip
           cd $HOME/gotip/src
           ./make.bash
           echo "GOROOT=$HOME/gotip" >> $GITHUB_ENV
+          echo "RUN_STATICCHECK=false" >> $GITHUB_ENV
           echo "$HOME/gotip/bin:$PATH" >> $GITHUB_PATH
 
       - name: Checkout the repo
@@ -118,14 +117,13 @@ jobs:
 
       - name: Update Go version manually
         if: matrix.go == 'tip'
-        env: 
-          RUN_STATICCHECK: false
         working-directory: ${{ github.workspace }}
         run: |
           git clone https://go.googlesource.com/go $HOME/gotip
           cd $HOME/gotip/src
           ./make.bash
           echo "GOROOT=$HOME/gotip" >> $GITHUB_ENV
+          echo "RUN_STATICCHECK=false" >> $GITHUB_ENV
           echo "$HOME/gotip/bin" >> $GITHUB_PATH
 
       - name: Checkout the repo

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,8 @@ jobs:
       - name: Update Go version manually
         if: matrix.go == 'tip'
         working-directory: ${{ github.workspace }}
+        env: 
+          RUN_STATICCHECK: false
         run: |
           git clone https://go.googlesource.com/go $HOME/gotip
           cd $HOME/gotip/src
@@ -116,6 +118,8 @@ jobs:
 
       - name: Update Go version manually
         if: matrix.go == 'tip'
+        env: 
+          RUN_STATICCHECK: false
         working-directory: ${{ github.workspace }}
         run: |
           git clone https://go.googlesource.com/go $HOME/gotip

--- a/test.sh
+++ b/test.sh
@@ -23,7 +23,9 @@ echo "mode: $MODE" > coverage.txt
 # All packages.
 PKG=$(go list ./...)
 
-staticcheck $PKG
+if [ "$RUN_STATICCHECK" != "false" ]; then
+  staticcheck $PKG
+fi
 
 # Packages that have any tests.
 PKG=$(go list -f '{{if .TestGoFiles}} {{.ImportPath}} {{end}}' ./...)


### PR DESCRIPTION
staticcheck only supports the latest 2 copmiler releases, not unreleased tip-of-tree versions.

Fixes #662.