### PR TITLE
Avoid adding a redundant newline when printing weblistPageClosing

### DIFF
--- a/internal/driver/testdata/pprof.cpu.flat.addresses.weblist
+++ b/internal/driver/testdata/pprof.cpu.flat.addresses.weblist
@@ -99,4 +99,3 @@ Duration: 10s, Total samples = 1.12s (11.20%)<br>Total: 1.12s</div><h2>line1000<
 
 </body>
 </html>
-

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -874,7 +874,7 @@ func printFunctionClosing(w io.Writer) {
 
 // printPageClosing prints the end of the page in a weblist report.
 func printPageClosing(w io.Writer) {
-	fmt.Fprintln(w, weblistPageClosing)
+	fmt.Fprint(w, weblistPageClosing)
 }
 
 // getSourceFromFile collects the sources of a function from a source

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -874,7 +874,7 @@ func printFunctionClosing(w io.Writer) {
 
 // printPageClosing prints the end of the page in a weblist report.
 func printPageClosing(w io.Writer) {
-	fmt.Fprint(w, weblistPageClosing)
+	fmt.Fprintln(w, weblistPageClosing)
 }
 
 // getSourceFromFile collects the sources of a function from a source

--- a/internal/report/source_html.go
+++ b/internal/report/source_html.go
@@ -72,5 +72,4 @@ function pprof_toggle_asm(e) {
 
 const weblistPageClosing = `
 </body>
-</html>
-`
+</html>`


### PR DESCRIPTION
weblistPageClosing string ends in a new line, so printing it via fmt.Println will add an extra new line.