### PR TITLE
Update mapassign regex to match both call variants

### DIFF
--- a/internal/report/source_test.go
+++ b/internal/report/source_test.go
@@ -47,7 +47,7 @@ func TestWebList(t *testing.T) {
 	}
 	output := buf.String()
 
-	for _, expect := range []string{"func busyLoop", "callq.*mapassign"} {
+	for _, expect := range []string{"func busyLoop", "call.*mapassign"} {
 		if match, _ := regexp.MatchString(expect, output); !match {
 			t.Errorf("weblist output does not contain '%s':\n%s", expect, output)
 		}


### PR DESCRIPTION
Different versions of `objdump` output `call` or `callq`.

Both work fine for the purposes of the test.

Fixes #650