### PR TITLE
Use  'git clone' instead of 'go get' for the build or developer's …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,8 @@ automatically set in all console sessions.
 To get the source code, run
 
 ```
-go get github.com/google/pprof
+eval {'mkdir -p',cd}\ $GOPATH/src/github.com/google\;
+git clone git@github.com:google/pprof.git
 ```
 
 To run the tests, do

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Prerequisites:
 - Graphviz: http://www.graphviz.org/
   Optional, used to generate graphic visualizations of profiles
 
-To build and install it, use the `go get` tool.
+To build and install it, use `git clone`.
 
-    go get -u github.com/google/pprof
+    eval {'mkdir -p',cd}\ $GOPATH/src/github.com/google\;
+    git clone git@github.com:google/pprof.git
+    go install
 
 Remember to set GOPATH to the directory where you want pprof to be
 installed.  The binary will be in `$GOPATH/bin` and the sources under


### PR DESCRIPTION
Use  'git clone' instead of 'go get' for the build or developer's workflow documentation.

As golang released their new version 1.17.1 go get is not supported
anymore. https://github.com/golang/go/issues/31529#issuecomment-484931428
suggests using 'git clone' rather than 'go get'.