### PR TITLE
Update instructions to use "git clone" instead of "go get".

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,20 +38,21 @@ specific platforms, making internal pprof APIs public, etc.
 
 # Development
 
-Make sure `GOPATH` is set in your current shell. The common way is to have
-something like `export GOPATH=$HOME/gocode` in your `.bashrc` file so that it's
-automatically set in all console sessions.
+The commands below assume `/tmp/pprof` as the location for the source code.
+You can change it to a directory of your choice.
 
 To get the source code, run
 
 ```
-go get github.com/google/pprof
+cd /tmp
+git clone git@github.com:google/pprof.git
+cd pprof
 ```
 
 To run the tests, do
 
 ```
-cd $GOPATH/src/github.com/google/pprof
+cd /tmp/pprof
 go test -v ./...
 ```
 
@@ -62,7 +63,7 @@ get` your fork directly, you'll be getting errors like `use of internal package
 not allowed` when running tests.  To set up the remote do something like
 
 ```
-cd $GOPATH/src/github.com/google/pprof
+cd /tmp/pprof
 git remote add aalexand git@github.com:aalexand/pprof.git
 git fetch aalexand
 git checkout -b my-new-feature

--- a/README.md
+++ b/README.md
@@ -28,19 +28,17 @@ them through the use of the native binutils tools (addr2line and nm).
 Prerequisites:
 
 - Go development kit of a [supported version](https://golang.org/doc/devel/release.html#policy).
-  Follow [these instructions](http://golang.org/doc/code.html) to install the 
-  go tool and set up GOPATH.
+  Follow [these instructions](http://golang.org/doc/code.html) to prepare
+  the environment.
 
 - Graphviz: http://www.graphviz.org/
   Optional, used to generate graphic visualizations of profiles
 
-To build and install it, use the `go get` tool.
+To build and install it:
 
-    go get -u github.com/google/pprof
+    go install github.com/google/pprof@latest
 
-Remember to set GOPATH to the directory where you want pprof to be
-installed.  The binary will be in `$GOPATH/bin` and the sources under
-`$GOPATH/src/github.com/google/pprof`.
+The binary will be installed `$GOPATH/bin` (`$HOME/go/bin` by default).
 
 # Basic usage
 


### PR DESCRIPTION
Fixes #648.