### PR TITLE
Add badge link to Go API docs in pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Github Action CI](https://github.com/google/pprof/workflows/ci/badge.svg)](https://github.com/google/pprof/actions)
 [![Codecov](https://codecov.io/gh/google/pprof/graph/badge.svg)](https://codecov.io/gh/google/pprof)
+[![Go Reference](https://pkg.go.dev/badge/github.com/google/pprof/profile.svg)](https://pkg.go.dev/github.com/google/pprof/profile)
 
 # Introduction
 


### PR DESCRIPTION
Thought this might be useful to point people at the API docs (after I tried searching for pprof API docs and couldn't find them easily on Google).

Points at https://pkg.go.dev/github.com/google/pprof/profile, as that's the only package we try to declare as an API.

Badge generated at https://pkg.go.dev/badge/?path=https%3A%2F%2Fpkg.go.dev%2Fgithub.com%2Fgoogle%2Fpprof%2Fprofile