### PR TITLE
Log build ID in local symbolization error messages.

### DIFF
--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -325,6 +325,9 @@ func newMapping(prof *profile.Profile, obj plugin.ObjTool, ui plugin.UI, force b
 		}
 
 		name := filepath.Base(m.File)
+		if m.BuildID != "" {
+			name += fmt.Sprintf(" (build ID %s)", m.BuildID)
+		}
 		f, err := obj.Open(m.File, m.Start, m.Limit, m.Offset)
 		if err != nil {
 			ui.PrintErr("Local symbolization failed for ", name, ": ", err)


### PR DESCRIPTION
This helps diagnose symbolization issues.