### PR TITLE
Fix tagroot to properly format unitless numeric tags.

### DIFF
--- a/internal/driver/tagroot.go
+++ b/internal/driver/tagroot.go
@@ -113,12 +113,17 @@ func formatLabelValues(s *profile.Sample, k string, outputUnit string) []string 
 	values = append(values, s.Label[k]...)
 	numLabels := s.NumLabel[k]
 	numUnits := s.NumUnit[k]
-	if len(numLabels) != len(numUnits) {
+	if len(numLabels) != len(numUnits) && len(numUnits) != 0 {
 		return values
 	}
 	for i, numLabel := range numLabels {
-		unit := numUnits[i]
-		values = append(values, measurement.ScaledLabel(numLabel, unit, outputUnit))
+		var value string
+		if len(numUnits) != 0 {
+			value = measurement.ScaledLabel(numLabel, numUnits[i], outputUnit)
+		} else {
+			value = measurement.ScaledLabel(numLabel, "", "")
+		}
+		values = append(values, value)
 	}
 	return values
 }


### PR DESCRIPTION
It's possible for the unit array to be empty for a unitless numeric tag.
In this case the tag value should be formatted properly but before this
change it was output empty.

Fixes #651. From the bug description it doesn't look like exactly this
issue but it does get fixed.

The added tests fail before the change and pass after.