### PR TITLE
Add Go 1.18 to testing, remove Go 1.16.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: ci
-on: 
+on:
   push:
     branches:
       - master
@@ -11,42 +11,42 @@ env:
   WORKING_DIR: ./src/github.com/google/pprof/
 jobs:
   test-mac:
-    runs-on: ${{ matrix.os }} 
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: ${{ env.WORKING_DIR }}
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.16', '1.17', 'tip']
+        go: ['1.17', '1.18', 'tip']
         # Supported macOS versions can be found in
         # https://github.com/actions/virtual-environments#available-environments.
         os: ['macos-10.15', 'macos-11']
-        # Supported Xcode versions for macOS 10.15 can be found in 
+        # Supported Xcode versions for macOS 10.15 can be found in
         # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode.
-        # Supported Xcode versions for macOS 11 can be found in 
+        # Supported Xcode versions for macOS 11 can be found in
         # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
         xcode-version: ['13.0', '12.5', '12.4', '12.3', '12.1.1', '12.0.1', '11.7']
         exclude:
         - os: 'macos-10.15'
-          xcode-version: '13.0' 
+          xcode-version: '13.0'
         - os: 'macos-10.15'
-          xcode-version: '12.5' 
+          xcode-version: '12.5'
         - os: 'macos-11'
-          xcode-version: '12.4' 
+          xcode-version: '12.4'
         - os: 'macos-11'
-          xcode-version: '12.3' 
+          xcode-version: '12.3'
         - os: 'macos-11'
-          xcode-version: '12.1.1' 
+          xcode-version: '12.1.1'
         - os: 'macos-11'
-          xcode-version: '12.0.1' 
+          xcode-version: '12.0.1'
     steps:
       - name: Update Go version using setup-go
         uses: actions/setup-go@v2
         if: matrix.go != 'tip'
         with:
           go-version: ${{ matrix.go }}
-      
+
       - name: Update Go version manually
         if: matrix.go == 'tip'
         working-directory: ${{ github.workspace }}
@@ -72,13 +72,13 @@ jobs:
         run: |
           brew install graphviz
           # Do not let tools interfere with the main module's go.mod.
-          cd && go mod init tools 
+          cd && go mod init tools
           go get -u golang.org/x/lint/golint honnef.co/go/tools/cmd/...
           go install golang.org/x/lint/golint honnef.co/go/tools/cmd/...
           # Add PATH for installed tools.
           echo "$GOPATH/bin:$PATH" >> $GITHUB_PATH
 
-      - name: Run the script 
+      - name: Run the script
         run: |
           go version
           gofmtdiff=$(gofmt -s -d .) && if [ -n "$gofmtdiff" ]; then printf 'gofmt -s found:\n%s\n' "$gofmtdiff" && exit 1; fi
@@ -87,7 +87,7 @@ jobs:
           ./test.sh
 
       - name: Check to make sure that tests also work in GOPATH mode
-        env: 
+        env:
           GO111MODULE: off
         run: |
           go get -d .
@@ -102,12 +102,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
-        working-directory: ${{ env.WORKING_DIR }} 
+        working-directory: ${{ env.WORKING_DIR }}
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.16', '1.17', 'tip']
-        os: ['ubuntu-20.04', 'ubuntu-18.04'] 
+        go: ['1.17', '1.18', 'tip']
+        os: ['ubuntu-20.04', 'ubuntu-18.04']
     steps:
       - name: Update Go version using setup-go
         uses: actions/setup-go@v2
@@ -135,13 +135,13 @@ jobs:
         run: |
           sudo apt-get install graphviz
           # Do not let tools interfere with the main module's go.mod.
-          cd && go mod init tools 
+          cd && go mod init tools
           go get -u golang.org/x/lint/golint honnef.co/go/tools/cmd/...
           go install golang.org/x/lint/golint honnef.co/go/tools/cmd/...
           # Add PATH for installed tools.
           echo "PATH=$GOPATH/bin:$PATH" >> $GITHUB_ENV
 
-      - name: Run the script 
+      - name: Run the script
         run: |
           go version
           gofmtdiff=$(gofmt -s -d .) && if [ -n "$gofmtdiff" ]; then printf 'gofmt -s found:\n%s\n' "$gofmtdiff" && exit 1; fi
@@ -150,7 +150,7 @@ jobs:
           ./test.sh
 
       - name: Check to make sure that tests also work in GOPATH mode
-        env: 
+        env:
           GO111MODULE: off
         run: |
           go get -d .
@@ -166,7 +166,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.16', '1.17']
+        go: ['1.17', '1.18']
     steps:
       - name: Update Go version using setup-go
         uses: actions/setup-go@v2
@@ -187,7 +187,7 @@ jobs:
         run: |
           go version
           # This is a workaround to make graphviz installed through choco work.
-          # It generates a config file to tell dot what layout engine and 
+          # It generates a config file to tell dot what layout engine and
           # format types are available. See
           # https://github.com/google/pprof/issues/585 for more details.
           dot -c


### PR DESCRIPTION
Like Go itself, pprof supports two latest major versions of Go. Since
1.18 was released, we should add it and drop 1.16.