### PR TITLE
Update minimum Go version to 1.17 in go.mod.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/pprof
 
-go 1.14
+go 1.17
 
 require (
 	github.com/chzyer/logex v1.1.10 // indirect


### PR DESCRIPTION
pprof follows the Golang version policy and currently that mean
supporting 1.17 and 1.18. We've been following that in the CI
configuration, but go.mod has been lagging behind for a while.