### PR TITLE
Fix doc comments format to become compatible with tip gofmt.

### DIFF
--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -188,16 +188,18 @@ func createExpectedEdges(parent expectedNode, children ...expectedNode) {
 }
 
 // createTestCase1 creates a test case that initially looks like:
-//     0
-//     |(5)
-//     1
-// (3)/ \(4)
-//   2   3.
+//
+//	    0
+//	    |(5)
+//	    1
+//	(3)/ \(4)
+//	  2   3.
 //
 // After keeping 0, 2, and 3, it expects the graph:
-//     0
-// (3)/ \(4)
-//   2   3.
+//
+//	    0
+//	(3)/ \(4)
+//	  2   3.
 func createTestCase1() trimTreeTestcase {
 	// Create initial graph
 	graph := &Graph{make(Nodes, 4)}
@@ -229,20 +231,22 @@ func createTestCase1() trimTreeTestcase {
 }
 
 // createTestCase2 creates a test case that initially looks like:
-//   3
-//   | (12)
-//   1
-//   | (8)
-//   2
-//   | (15)
-//   0
-//   | (10)
-//   4.
+//
+//	3
+//	| (12)
+//	1
+//	| (8)
+//	2
+//	| (15)
+//	0
+//	| (10)
+//	4.
 //
 // After keeping 3 and 4, it expects the graph:
-//   3
-//   | (10)
-//   4.
+//
+//	3
+//	| (10)
+//	4.
 func createTestCase2() trimTreeTestcase {
 	// Create initial graph
 	graph := &Graph{make(Nodes, 5)}
@@ -284,10 +288,12 @@ func createTestCase3() trimTreeTestcase {
 }
 
 // createTestCase4 creates a test case that initially looks like:
-//   0.
+//
+//	0.
 //
 // After keeping 0, it expects the graph:
-//   0.
+//
+//	0.
 func createTestCase4() trimTreeTestcase {
 	graph := &Graph{make(Nodes, 1)}
 	nodes := graph.Nodes

--- a/profile/legacy_profile.go
+++ b/profile/legacy_profile.go
@@ -295,11 +295,12 @@ func get64b(b []byte) (uint64, []byte) {
 //
 // The general format for profilez samples is a sequence of words in
 // binary format. The first words are a header with the following data:
-//   1st word -- 0
-//   2nd word -- 3
-//   3rd word -- 0 if a c++ application, 1 if a java application.
-//   4th word -- Sampling period (in microseconds).
-//   5th word -- Padding.
+//
+//	1st word -- 0
+//	2nd word -- 3
+//	3rd word -- 0 if a c++ application, 1 if a java application.
+//	4th word -- Sampling period (in microseconds).
+//	5th word -- Padding.
 func parseCPU(b []byte) (*Profile, error) {
 	var parse func([]byte) (uint64, []byte)
 	var n1, n2, n3, n4, n5 uint64
@@ -403,15 +404,18 @@ func cleanupDuplicateLocations(p *Profile) {
 //
 // profilez samples are a repeated sequence of stack frames of the
 // form:
-//    1st word -- The number of times this stack was encountered.
-//    2nd word -- The size of the stack (StackSize).
-//    3rd word -- The first address on the stack.
-//    ...
-//    StackSize + 2 -- The last address on the stack
+//
+//	1st word -- The number of times this stack was encountered.
+//	2nd word -- The size of the stack (StackSize).
+//	3rd word -- The first address on the stack.
+//	...
+//	StackSize + 2 -- The last address on the stack
+//
 // The last stack trace is of the form:
-//   1st word -- 0
-//   2nd word -- 1
-//   3rd word -- 0
+//
+//	1st word -- 0
+//	2nd word -- 1
+//	3rd word -- 0
 //
 // Addresses from stack traces may point to the next instruction after
 // each call. Optionally adjust by -1 to land somewhere on the actual


### PR DESCRIPTION
https://github.com/golang/go/issues/51082 changed how gofmt handles some
comments, so we need to slightly reformat them to avoid `gofmt -s -d .`
errors.