### PR TITLE
Made flamegraph test less brittle.

### DIFF
--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -90,8 +90,8 @@ func TestWebInterface(t *testing.T) {
 			// Check profile frame JSON is included.
 			`\\u0022n\\u0022:\\u0022root\\u0022`,
 			`\\u0022n\\u0022:\\u0022F1\\u0022`,
-			// Check minified d3-flame-graph JS is included.
-			`flamegraph:\(\)=>`,
+			// Check d3-flame-graph JS is included.
+			`flamegraph:\(\)=>|flamegraph.*function|function.*flamegraph`,
 			// Check d3-flame-graph CSS is included.
 			".d3-flame-graph rect {",
 		}, false},


### PR DESCRIPTION
Different environments may have compiled flamegraph JS code
differently. Generalize regular expression that checks
generated code to allow some variation.