### PR TITLE
Make config menu entries relative.

### DIFF
--- a/internal/driver/settings.go
+++ b/internal/driver/settings.go
@@ -79,7 +79,7 @@ type configMenuEntry struct {
 }
 
 // configMenu returns a list of items to add to a menu in the web UI.
-func configMenu(fname string, url url.URL) []configMenuEntry {
+func configMenu(fname string, u url.URL) []configMenuEntry {
 	// Start with system configs.
 	configs := []namedConfig{{Name: "Default", config: defaultConfig()}}
 	if settings, err := readSettings(fname); err == nil {
@@ -91,13 +91,15 @@ func configMenu(fname string, url url.URL) []configMenuEntry {
 	result := make([]configMenuEntry, len(configs))
 	lastMatch := -1
 	for i, cfg := range configs {
-		dst, changed := cfg.config.makeURL(url)
+		dst, changed := cfg.config.makeURL(u)
 		if !changed {
 			lastMatch = i
 		}
+		// Use a relative URL to work in presence of stripping/redirects in webui.go.
+		rel := &url.URL{RawQuery: dst.RawQuery, ForceQuery: true}
 		result[i] = configMenuEntry{
 			Name:       cfg.Name,
-			URL:        dst.String(),
+			URL:        rel.String(),
 			UserConfig: (i != 0),
 		}
 	}

--- a/internal/driver/settings_test.go
+++ b/internal/driver/settings_test.go
@@ -135,9 +135,9 @@ func TestConfigMenu(t *testing.T) {
 	pageURL, _ := url.Parse("/top?f=foo")
 	menu := configMenu(fname, *pageURL)
 	want := []configMenuEntry{
-		{Name: "Default", URL: "/top", Current: false, UserConfig: false},
-		{Name: "A", URL: "/top?f=foo", Current: true, UserConfig: true},
-		{Name: "B", URL: "/top?f=bar", Current: false, UserConfig: true},
+		{Name: "Default", URL: "?", Current: false, UserConfig: false},
+		{Name: "A", URL: "?f=foo", Current: true, UserConfig: true},
+		{Name: "B", URL: "?f=bar", Current: false, UserConfig: true},
 	}
 	if !reflect.DeepEqual(menu, want) {
 		t.Errorf("ConfigMenu returned %v; want %v", menu, want)


### PR DESCRIPTION
An earlier change had added support for placing pprof URLs under
the /ui prefix. However config menu entry URLs were built by
editing a URL produced by stripping the /ui prefix and were
therefore falling outside the /ui prefix. This ended up in
mis-navigation to the graph view when a config menu entry was
selected in another view.

Fixed by emitting a relative URL (e.g., ?f=foo) instead of an
absolute URL (e.g., /flamegraph?f=foo).