### PR TITLE
internal/driver: fixes for fetch.go

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -408,13 +408,13 @@ func locateBinaries(p *profile.Profile, s *source, obj plugin.ObjTool, ui plugin
 	}
 mapping:
 	for _, m := range p.Mapping {
-		cleanFile := strings.TrimPrefix(m.File, filepath.VolumeName(m.File))
-
+		var noVolumeFile string
 		var baseName string
 		var dirName string
 		if m.File != "" {
+			noVolumeFile = strings.TrimPrefix(m.File, filepath.VolumeName(m.File))
 			baseName = filepath.Base(m.File)
-			dirName = filepath.Dir(cleanFile)
+			dirName = filepath.Dir(noVolumeFile)
 		}
 
 		for _, path := range filepath.SplitList(searchPath) {
@@ -424,7 +424,7 @@ mapping:
 				if matches, err := filepath.Glob(filepath.Join(path, m.BuildID, "*")); err == nil {
 					fileNames = append(fileNames, matches...)
 				}
-				fileNames = append(fileNames, filepath.Join(path, cleanFile, m.BuildID)) // perf path format
+				fileNames = append(fileNames, filepath.Join(path, noVolumeFile, m.BuildID)) // perf path format
 				// Llvm buildid protocol: the first two characters of the build id
 				// are used as directory, and the remaining part is in the filename.
 				// e.g. `/ab/cdef0123456.debug`
@@ -434,10 +434,10 @@ mapping:
 				// Try both the basename and the full path, to support the same directory
 				// structure as the perf symfs option.
 				fileNames = append(fileNames, filepath.Join(path, baseName))
-				fileNames = append(fileNames, filepath.Join(path, cleanFile))
+				fileNames = append(fileNames, filepath.Join(path, noVolumeFile))
 				// Other locations: use the same search paths as GDB, according to
 				// https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
-				fileNames = append(fileNames, filepath.Join(path, cleanFile+".debug"))
+				fileNames = append(fileNames, filepath.Join(path, noVolumeFile+".debug"))
 				fileNames = append(fileNames, filepath.Join(path, dirName, ".debug", baseName+".debug"))
 				fileNames = append(fileNames, filepath.Join(path, "usr", "lib", "debug", dirName, baseName+".debug"))
 			}

--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -397,12 +397,6 @@ func unsourceMappings(p *profile.Profile) {
 	}
 }
 
-// trimWindowsVolume removes windows volume name from path, if it exists.
-func trimWindowsVolume(path string) string {
-	volume := filepath.VolumeName(path)
-	return path[len(volume):]
-}
-
 // locateBinaries searches for binary files listed in the profile and, if found,
 // updates the profile accordingly.
 func locateBinaries(p *profile.Profile, s *source, obj plugin.ObjTool, ui plugin.UI) {
@@ -414,13 +408,14 @@ func locateBinaries(p *profile.Profile, s *source, obj plugin.ObjTool, ui plugin
 	}
 mapping:
 	for _, m := range p.Mapping {
+		cleanFile := strings.TrimPrefix(m.File, filepath.VolumeName(m.File))
+
 		var baseName string
 		var dirName string
 		if m.File != "" {
 			baseName = filepath.Base(m.File)
-			dirName = trimWindowsVolume(filepath.Dir(m.File))
+			dirName = filepath.Dir(cleanFile)
 		}
-		cleanFile := trimWindowsVolume(m.File)
 
 		for _, path := range filepath.SplitList(searchPath) {
 			var fileNames []string

--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -389,7 +389,7 @@ func collectMappingSources(p *profile.Profile, source string) plugin.MappingSour
 // set to the remote source URL by collectMappingSources back to empty string.
 func unsourceMappings(p *profile.Profile) {
 	for _, m := range p.Mapping {
-		if m.BuildID == "" {
+		if m.BuildID == "" && filepath.VolumeName(m.File) == "" {
 			if u, err := url.Parse(m.File); err == nil && u.IsAbs() {
 				m.File = ""
 			}

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -133,22 +133,24 @@ func TestUnsourceMappings(t *testing.T) {
 		{"windows", `C:\example.exe`, "", `C:\example.exe`},
 		{"windows", `c:/example.exe`, "", `c:/example.exe`},
 	} {
-		if tc.os != "" && tc.os != runtime.GOOS {
-			continue
-		}
+		t.Run("", func(t *testing.T) {
+			if tc.os != "" && tc.os != runtime.GOOS {
+				t.Skipf("%s only test", tc.os)
+			}
 
-		p := &profile.Profile{
-			Mapping: []*profile.Mapping{
-				{
-					File:    tc.file,
-					BuildID: tc.buildID,
+			p := &profile.Profile{
+				Mapping: []*profile.Mapping{
+					{
+						File:    tc.file,
+						BuildID: tc.buildID,
+					},
 				},
-			},
-		}
-		unsourceMappings(p)
-		if got := p.Mapping[0].File; got != tc.want {
-			t.Errorf("%s:%s, want %s, got %s", tc.file, tc.buildID, tc.want, got)
-		}
+			}
+			unsourceMappings(p)
+			if got := p.Mapping[0].File; got != tc.want {
+				t.Errorf("%s:%s, want %s, got %s", tc.file, tc.buildID, tc.want, got)
+			}
+		})
 	}
 }
 

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -126,11 +126,17 @@ func TestCollectMappingSources(t *testing.T) {
 
 func TestUnsourceMappings(t *testing.T) {
 	for _, tc := range []struct {
-		file, buildID, want string
+		os, file, buildID, want string
 	}{
-		{"/usr/bin/binary", "buildId", "/usr/bin/binary"},
-		{"http://example.com", "", ""},
+		{"", "/usr/bin/binary", "buildId", "/usr/bin/binary"},
+		{"", "http://example.com", "", ""},
+		{"windows", `C:\example.exe`, "", `C:\example.exe`},
+		{"windows", `c:/example.exe`, "", `c:/example.exe`},
 	} {
+		if tc.os != "" && tc.os != runtime.GOOS {
+			continue
+		}
+
 		p := &profile.Profile{
 			Mapping: []*profile.Mapping{
 				{

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -128,13 +128,13 @@ func TestUnsourceMappings(t *testing.T) {
 	for _, tc := range []struct {
 		os, file, buildID, want string
 	}{
-		{"", "/usr/bin/binary", "buildId", "/usr/bin/binary"},
-		{"", "http://example.com", "", ""},
+		{"any", "/usr/bin/binary", "buildId", "/usr/bin/binary"},
+		{"any", "http://example.com", "", ""},
 		{"windows", `C:\example.exe`, "", `C:\example.exe`},
 		{"windows", `c:/example.exe`, "", `c:/example.exe`},
 	} {
-		t.Run("", func(t *testing.T) {
-			if tc.os != "" && tc.os != runtime.GOOS {
+		t.Run(tc.file+"-"+tc.os, func(t *testing.T) {
+			if tc.os != "any" && tc.os != runtime.GOOS {
 				t.Skipf("%s only test", tc.os)
 			}
 


### PR DESCRIPTION
url.Parse can parse a Windows absolute path without problems.
This can cause mapping file to be cleared, even though it's not a
remote source.

For #710