### PR TITLE
Add visual indication of inlined frames.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -438,8 +438,8 @@ Flame Graph
 :   Displays a view similar to a flame graph that can show the selected node's
     callers and callees simultaneously.
 
-NOTE: This view is currently experimental and may eventually replace the normal
-Flame Graph view.
+    NOTE: This view is currently experimental and may eventually replace the normal
+    Flame Graph view.
 
 Peek
 :   Shows callers / callees per function in a simple textual forma.
@@ -476,15 +476,11 @@ prompting the user to confirm).
 The `Flame graph (new)` view displays profile information as a
 [flame graph](https://www.brendangregg.com/flamegraphs.html).
 
-Boxes on this view corresponding to stack frames in the profile. Caller boxes
-are directly above callee boxes. The width of each box is proportional to the
-number of profile samples where that frame was present on the call stack.
-Children of a particular box are laid out left to right in decreasing size
-order.
-
-Inlining is indicated by the absence of a horizontal border between a caller and
-a callee. E.g., suppose X calls Y calls Z and the call from Y to Z is inlined into
-Y. There will be a black border between X and Y, but no border between Y and Z.
+Boxes on this view correspond to stack frames in the profile. Caller boxes are
+directly above callee boxes. The width of each box is proportional to the sum of
+the sample value of profile samples where that frame was present on the call
+stack. Children of a particular box are laid out left to right in decreasing
+size order.
 
 Names displayed in different boxes may have different font sizes. These size
 differences are due to an attempt to fit as much of the name into the box as
@@ -494,10 +490,14 @@ Boxes are colored according to the name of the package in which the correspondin
 function occurs. E.g., in C++ profiles all frames corresponding to `std::` functions
 will be assigned the same color.
 
-In addition to the package-based coloring, the left hand side of a box may be darker.
-This darker area corresponds to the number of samples that occurred directly in
-the code representated by the box (as opposed to samples in functions called by
-the code.)
+In addition to the package-based coloring, the left hand side of a box may be
+darker. This darker area corresponds to the sum of the sample values of samples
+that occurred directly in the code representated by the box (as opposed to
+samples in functions called by the code.)
+
+Inlining is indicated by the absence of a horizontal border between a caller and
+a callee. E.g., suppose X calls Y calls Z and the call from Y to Z is inlined into
+Y. There will be a black border between X and Y, but no border between Y and Z.
 
 ## TODO: cover the following issues:
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -434,7 +434,7 @@ Graph
 Flame Graph
 :   Displays a [flame graph](https://www.brendangregg.com/flamegraphs.html).
 
-Flame (experimental)
+[Flame Graph (new)](#flame-graph)
 :   Displays a view similar to a flame graph that can show the selected node's
     callers and callees simultaneously.
 
@@ -470,6 +470,34 @@ configuration. Selecting such an entry applies that configuration. The
 currently selected entry is marked with a ✓. Clicking on the 🗙 on the
 right-hand side of such an entry deletes the configuration (after
 prompting the user to confirm).
+
+## Flame graph
+
+The `Flame graph (new)` view displays profile information as a
+[flame graph](https://www.brendangregg.com/flamegraphs.html).
+
+Boxes on this view corresponding to stack frames in the profile. Caller boxes
+are directly above callee boxes. The width of each box is proportional to the
+number of profile samples where that frame was present on the call stack.
+Children of a particular box are laid out left to right in decreasing size
+order.
+
+Inlining is indicated by the absence of a horizontal border between a caller and
+a callee. E.g., suppose X calls Y calls Z and the call from Y to Z is inlined into
+Y. There will be a black border between X and Y, but no border between Y and Z.
+
+Names displayed in different boxes may have different font sizes. These size
+differences are due to an attempt to fit as much of the name into the box as
+possible; no other interpretation should be placed on the size.
+
+Boxes are colored according to the name of the package in which the corresponding
+function occurs. E.g., in C++ profiles all frames corresponding to `std::` functions
+will be assigned the same color.
+
+In addition to the package-based coloring, the left hand side of a box may be darker.
+This darker area corresponds to the number of samples that occurred directly in
+the code representated by the box (as opposed to samples in functions called by
+the code.)
 
 ## TODO: cover the following issues:
 

--- a/internal/driver/html/stacks.css
+++ b/internal/driver/html/stacks.css
@@ -27,6 +27,11 @@ body {
   border-width: 0px;
   position: absolute;
   overflow: hidden;
+  box-sizing: border-box;
+}
+/* Not-inlined frames are visually separated from their caller. */
+.not-inlined {
+  border-top: 1px solid black;
 }
 /* Function name */
 .boxtext {

--- a/internal/driver/html/stacks.js
+++ b/internal/driver/html/stacks.js
@@ -176,8 +176,9 @@ function stackViewer(stacks, nodes) {
 
   function handleEnter(box, div) {
     if (actionMenuOn) return;
+    const src = stacks.Sources[box.src];
     const d = details(box);
-    div.title = d + ' ' + stacks.Sources[box.src].FullName;
+    div.title = d + ' ' + src.FullName + (src.Inlined ? "\n(inlined)" : "");
     detailBox.innerText = d;
     // Highlight all boxes that have the same source as box.
     toggleClass(box.src, 'hilite2', true);
@@ -371,10 +372,13 @@ function stackViewer(stacks, nodes) {
     r.style.left = box.x + 'px';
     r.style.top = box.y + 'px';
     r.style.width = w + 'px';
-    r.style.height = (ROW-1) + 'px';  // Leave 1px gap
+    r.style.height = ROW + 'px';
     r.classList.add('boxbg');
     r.style.background = makeColor(src.Color);
     addElem(srcIndex, r);
+    if (!src.Inlined) {
+      r.classList.add('not-inlined');
+    }
 
     // Box that shows time spent in self
     if (box.selfWidth >= MIN_WIDTH) {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -233,6 +233,20 @@ var testL = []*profile.Location{
 			},
 		},
 	},
+	{
+		ID:      6,
+		Mapping: testM[0],
+		Line: []profile.Line{
+			{
+				Function: testF[3],
+				Line:     7,
+			},
+			{
+				Function: testF[2],
+				Line:     6,
+			},
+		},
+	},
 }
 
 // testSample returns a profile sample with specified value and stack.


### PR DESCRIPTION
Mark frames sent to javascript with a boolean "Inlined" field. Use
this field to change the display by (1) adding an "(inlined)" marker
to the tooltip for the frame, and (2) by dropping any border between
the caller and the caller.

Document flame graph display, including coloring and visual indication
of inlining.