### PR TITLE
Increase chunk size for concurrent fetch to 128

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -166,7 +166,7 @@ func grabSourcesAndBases(sources, bases []profileSource, fetch plugin.Fetcher, o
 // a single profile. It fetches a chunk of profiles concurrently, with a maximum
 // chunk size to limit its memory usage.
 func chunkedGrab(sources []profileSource, fetch plugin.Fetcher, obj plugin.ObjTool, ui plugin.UI, tr http.RoundTripper) (*profile.Profile, plugin.MappingSources, bool, int, error) {
-	const chunkSize = 64
+	const chunkSize = 128
 
 	var p *profile.Profile
 	var msrc plugin.MappingSources


### PR DESCRIPTION
This makes it more convenient to profile jobs with many replicas. Per offline discussion with aalexand, we prefer to just raise the limit rather than adding another config knob.