### PR TITLE
Apply -noinlines flag to the proto output.

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -201,7 +201,6 @@ func applyCommandOverrides(cmd string, outputFormat int, cfg config) config {
 	case report.Proto, report.Raw, report.Callgrind:
 		trim = false
 		cfg.Granularity = "addresses"
-		cfg.NoInlines = false
 	}
 
 	if !trim {


### PR DESCRIPTION
This is similar in spirit to #393. By default this flag is not set, but if it's specified on the command line it's better to respect the value.

This addresses b/259563268.