### PR TITLE
Fix use of captured loop variable in go routine.

### DIFF
--- a/internal/driver/webui_test.go
+++ b/internal/driver/webui_test.go
@@ -151,11 +151,11 @@ func TestWebInterface(t *testing.T) {
 				defer wg.Done()
 				res, err := http.Get(path)
 				if err != nil {
-					t.Error("could not fetch", c.path, err)
+					t.Error("could not fetch", path, err)
 					return
 				}
 				if _, err = io.ReadAll(res.Body); err != nil {
-					t.Error("could not read response", c.path, err)
+					t.Error("could not read response", path, err)
 				}
 			}()
 		}


### PR DESCRIPTION
"go vet" (at tip) caught a use of a loop variable in a go routine inside the loop. This is not thread-safe since the loop variable value can change while the go routine is active.