### PR TITLE
Extend search for debug symbols

### DIFF
--- a/internal/driver/cli.go
+++ b/internal/driver/cli.go
@@ -364,5 +364,7 @@ var usageMsgVars = "\n\n" +
 	"   PPROF_BINARY_PATH  Search path for local binary files\n" +
 	"                      default: $HOME/pprof/binaries\n" +
 	"                      searches $buildid/$name, $buildid/*, $path/$buildid,\n" +
-	"                      ${buildid:0:2}/${buildid:2}.debug, $name, $path\n" +
+	"                      ${buildid:0:2}/${buildid:2}.debug, $name, $path,\n" +
+	"                      ${name}.debug, $dir/.debug/${name}.debug,\n" +
+	"                      usr/lib/debug/$dir/${name}.debug\n" +
 	"   * On Windows, %USERPROFILE% is used instead of $HOME"


### PR DESCRIPTION
Look for debug symbols in all locations GDB does (https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html)
, e.g.:

- /usr/lib/debug/.build-id/ab/cdef1234.debug
- /usr/bin/binary.debug
- /usr/bin/.debug/binary.debug
- /usr/lib/debug/usr/bin/binary.debug.

My use case is development for embedded devices using Yocto. There I get a rootfs which I boot on target, and a rootfs-dbg with all debug symbols in `/usr/lib/debug/path/to/file.debug`. I record data with tcmalloc on target, and run pprof on that data after copying it to my development host. This change (specifically option 4 from the list below) lets me point `PPROF_BINARY_PATH=/path/to/rootfs-dbg/`, and find debug symbols for my application and all shared libraries it uses.

Option 1 from the list above is already implemented, option 4 is the one I would like to support, and I added 2 and 3 to the patch for completeness.

Signed-off-by: Adriaan Schmidt <adriaan.schmidt@siemens.com>