### PR TITLE
Do not overwrite main binary build ID when it's present.

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -461,8 +461,8 @@ mapping:
 			l.Mapping = m
 		}
 	}
-	// Replace executable filename/buildID with the overrides from source.
-	// Assumes the executable is the first Mapping entry.
+	// If configured, apply executable filename override and (maybe, see below)
+	// build ID override from source. Assume the executable is the first mapping.
 	if execName, buildID := s.ExecName, s.BuildID; execName != "" || buildID != "" {
 		m := p.Mapping[0]
 		if execName != "" {
@@ -470,7 +470,10 @@ mapping:
 			// the source override is most likely missing it.
 			m.File = execName
 		}
-		if buildID != "" {
+		// Only apply the build ID override if the build ID in the main mapping is
+		// missing. Overwriting the build ID in case it's present is very likely a
+		// wrong thing to do so we refuse to do that.
+		if buildID != "" && m.BuildID == "" {
 			m.BuildID = buildID
 		}
 	}


### PR DESCRIPTION
When users specify the path to the main binary on the command line as an easy way to make pprof find it, there is a possibility to make a mistake and point to a wrong version of the binary. This will break symbolization in unpredictable ways. I think we should only insert the build ID if it is not present in the profile.