### PR TITLE
Modify the name shortening heuristic to handle non-Go names

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -33,7 +33,7 @@ var (
 	javaRegExp = regexp.MustCompile(`^(?:[a-z]\w*\.)*([A-Z][\w\$]*\.(?:<init>|[a-z][\w\$]*(?:\$\d+)?))(?:(?:\()|$)`)
 	// Removes package name and method arguments for Go function names.
 	// See tests for examples.
-	goRegExp = regexp.MustCompile(`^(?:[\w\-\.]+\/)+(.+)`)
+	goRegExp = regexp.MustCompile(`^(?:[\w\-\.]+\/)+([^.]+\..+)`)
 	// Removes potential module versions in a package path.
 	goVerRegExp = regexp.MustCompile(`^(.*?)/v(?:[2-9]|[1-9][0-9]+)([./].*)$`)
 	// Strips C++ namespace prefix from a C++ function / method name.

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -526,6 +526,10 @@ func TestShortenFunctionName(t *testing.T) {
 			"foo",
 		},
 		{
+			"foo/xyz",
+			"foo/xyz",
+		},
+		{
 			"com.google.perftools.gwp.benchmark.FloatBench.lambda$run$0",
 			"FloatBench.lambda$run$0",
 		},


### PR DESCRIPTION
Names like foo/xyz are not Go names but match the current regular expression. Modify it to require a dot to be present for the Go shortening to trigger.

This should fix b/262922429.