### PR TITLE
pprof/internal/report: check mapping buildID

### DIFF
--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -750,7 +750,7 @@ func (sp *sourcePrinter) objectFile(m *profile.Mapping) plugin.ObjFile {
 	if err != nil {
 		return nil
 	}
-	if m.BuildID != "" && string(buildID) != m.BuildID {
+	if m.BuildID != "" && fmt.Sprintf("%x", buildID) != m.BuildID {
 		return nil
 	}
 	if object, ok := sp.objects[m.File]; ok {

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -29,6 +29,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/pprof/internal/elfexec"
 	"github.com/google/pprof/internal/graph"
 	"github.com/google/pprof/internal/measurement"
 	"github.com/google/pprof/internal/plugin"
@@ -739,6 +740,17 @@ func (sp *sourcePrinter) functions(f *sourceFile) []sourceFunction {
 // It returns nil on error.
 func (sp *sourcePrinter) objectFile(m *profile.Mapping) plugin.ObjFile {
 	if m == nil {
+		return nil
+	}
+	f, err := os.Open(m.File)
+	if err != nil {
+		return nil
+	}
+	buildID, err := elfexec.GetBuildID(f)
+	if err != nil {
+		return nil
+	}
+	if m.BuildID != "" && string(buildID) != m.BuildID {
 		return nil
 	}
 	if object, ok := sp.objects[m.File]; ok {


### PR DESCRIPTION
if objectfile's buildid is not consistent with mapping buildid.
the source html would not work right.