### PR TITLE
Get rid of strings.ReplaceAll to save an allocation

### DIFF
--- a/profile/encode.go
+++ b/profile/encode.go
@@ -258,10 +258,10 @@ func (p *Profile) postDecode() error {
 		// If this a main linux kernel mapping with a relocation symbol suffix
 		// ("[kernel.kallsyms]_text"), extract said suffix.
 		// It is fairly hacky to handle at this level, but the alternatives appear even worse.
-		if strings.HasPrefix(m.File, "[kernel.kallsyms]") {
-			m.KernelRelocationSymbol = strings.ReplaceAll(m.File, "[kernel.kallsyms]", "")
+		const prefix = "[kernel.kallsyms]"
+		if strings.HasPrefix(m.File, prefix) {
+			m.KernelRelocationSymbol = m.File[len(prefix):]
 		}
-
 	}
 
 	functions := make(map[uint64]*Function, len(p.Function))


### PR DESCRIPTION
Just a small change to save an allocation in `postDecode()` function.

```
# new
BenchmarkKernelRelocationSymbol-12    	154684881	         7.796 ns/op	       0 B/op	       0 allocs/op
# strings.ReplaceAll
BenchmarkKernelRelocationSymbol-12    	23326599	        49.38 ns/op	       8 B/op	       1 allocs/op
```