### PR TITLE
Replace io.ReadFull to save an allocation

### DIFF
--- a/internal/binutils/binutils.go
+++ b/internal/binutils/binutils.go
@@ -22,7 +22,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -300,7 +299,6 @@ func (bu *Binutils) Open(name string, start, limit, offset uint64, relocationSym
 	}
 
 	// Read the first 4 bytes of the file.
-
 	f, err := os.Open(name)
 	if err != nil {
 		return nil, fmt.Errorf("error opening %s: %v", name, err)
@@ -308,7 +306,7 @@ func (bu *Binutils) Open(name string, start, limit, offset uint64, relocationSym
 	defer f.Close()
 
 	var header [4]byte
-	if _, err = io.ReadFull(f, header[:]); err != nil {
+	if _, err = f.Read(header[:]); err != nil {
 		return nil, fmt.Errorf("error reading magic number from %s: %v", name, err)
 	}
 


### PR DESCRIPTION
A small change to save an allocation in `func (bu *Binutils) Open()`.

```
$ go test -bench=. -benchmem .
goos: darwin
goarch: amd64
pkg: tt
cpu: Intel(R) Core(TM) i5-10600 CPU @ 3.30GHz
BenchmarkReadFull-12    	  120055	      9929 ns/op	     120 B/op	       4 allocs/op
BenchmarkRead-12        	  117966	      9917 ns/op	     112 B/op	       3 allocs/op
PASS
ok  	tt	2.734s
```

<details>

```go
func BenchmarkReadFull(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if err := readFull(); err != nil {
			b.Fatal(err)
		}
	}
}

func BenchmarkRead(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if err := read(); err != nil {
			b.Fatal(err)
		}
	}
}

func readFull() error {
	f, err := os.Open("go.mod")
	if err != nil {
		return err
	}
	defer f.Close()

	var header [4]byte
	if _, err = io.ReadFull(f, header[:]); err != nil {
		return err
	}

	return nil
}

func read() error {
	f, err := os.Open("go.mod")
	if err != nil {
		return err
	}
	defer f.Close()

	var header [4]byte
	if _, err = f.Read(header[:]); err != nil {
		return err
	}

	return nil
}
```

</details>