### PR TITLE
Update macOs matrix since macos-10.15 is deprecated and unavailable.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,25 +21,31 @@ jobs:
         go: ['1.19', '1.20', 'tip']
         # Supported macOS versions can be found in
         # https://github.com/actions/virtual-environments#available-environments.
-        os: ['macos-10.15', 'macos-11']
-        # Supported Xcode versions for macOS 10.15 can be found in
-        # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode.
+        os: ['macos-11', 'macos-12']
         # Supported Xcode versions for macOS 11 can be found in
         # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
-        xcode-version: ['13.0', '12.5', '12.4', '12.3', '12.1.1', '12.0.1', '11.7']
+        # Supported Xcode versions for macOS 12 can be found in
+        # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md#xcode
+        xcode-version: ['14.2', '14.1', '14.0.1', '13.4.1', '13.3.1', '13.2.1', '13.1', '13.0', '12.5.1', '12.4', '11.7']
         exclude:
-        - os: 'macos-10.15'
-          xcode-version: '13.0'
-        - os: 'macos-10.15'
-          xcode-version: '12.5'
         - os: 'macos-11'
+          xcode-version: '13.3.1'
+        - os: 'macos-11'
+          xcode-version: '13.4.1'
+        - os: 'macos-11'
+          xcode-version: '14.0.1'
+        - os: 'macos-11'
+          xcode-version: '14.1'
+        - os: 'macos-11'
+          xcode-version: '14.2'
+        - os: 'macos-12'
+          xcode-version: '11.7'
+        - os: 'macos-12'
           xcode-version: '12.4'
-        - os: 'macos-11'
-          xcode-version: '12.3'
-        - os: 'macos-11'
-          xcode-version: '12.1.1'
-        - os: 'macos-11'
-          xcode-version: '12.0.1'
+        - os: 'macos-12'
+          xcode-version: '12.5.1'
+        - os: 'macos-12'
+          xcode-version: '13.0'
     steps:
       - name: Update Go version using setup-go
         uses: actions/setup-go@v4
@@ -193,3 +199,16 @@ jobs:
           go build github.com/google/pprof
           go test -v ./...
         working-directory: ${{ env.WORKING_DIR }}
+
+  check:
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+    - test-mac
+    - test-linux
+    - test-windows
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Also add using https://github.com/re-actors/alls-green to enforce a check that all CI jobs pass. This will ease configuring this in the GitHub project settings since before this we had to update that list manually with a lot of clicking every time the test matrix changes.