### PR TITLE
Remove special coloring for self region in new flame graph view.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -490,11 +490,6 @@ Boxes are colored according to the name of the package in which the correspondin
 function occurs. E.g., in C++ profiles all frames corresponding to `std::` functions
 will be assigned the same color.
 
-In addition to the package-based coloring, the left hand side of a box may be
-darker. This darker area corresponds to the sum of the sample values of samples
-that occurred directly in the code representated by the box (as opposed to
-samples in functions called by the code.)
-
 Inlining is indicated by the absence of a horizontal border between a caller and
 a callee. E.g., suppose X calls Y calls Z and the call from Y to Z is inlined into
 Y. There will be a black border between X and Y, but no border between Y and Z.

--- a/internal/driver/html/stacks.css
+++ b/internal/driver/html/stacks.css
@@ -47,11 +47,6 @@ body {
 /* Box highlighting via shadows to avoid size changes */
 .hilite { box-shadow: 0px 0px 0px 2px #000; z-index: 1; }
 .hilite2 { box-shadow: 0px 0px 0px 2px #000; z-index: 1; }
-/* Self-cost region inside a box */
-.self {
-  position: absolute;
-  background: rgba(0,0,0,0.25); /* Darker hue */
-}
 /* Gap left between callers and callees */
 .separator {
   position: absolute;

--- a/internal/driver/html/stacks.js
+++ b/internal/driver/html/stacks.js
@@ -380,15 +380,6 @@ function stackViewer(stacks, nodes) {
       r.classList.add('not-inlined');
     }
 
-    // Box that shows time spent in self
-    if (box.selfWidth >= MIN_WIDTH) {
-      const s = document.createElement('div');
-      s.style.width = Math.min(box.selfWidth, w)+'px';
-      s.style.height = (ROW-1)+'px';
-      s.classList.add('self');
-      r.appendChild(s);
-    }
-
     // Label
     if (box.width >= MIN_TEXT_WIDTH) {
       const t = document.createElement('div');


### PR DESCRIPTION
Previously, the self cost part of a flame graph box  was shown with a tweaked color.

```
[<-- self --><-- rest of the cost -->]
             [child 1][child2][child3]
```

However this added clutter and was too subtle (I asked a couple of colleagues and they hadn't noticed it).

This change removes this coloring. The self cost is still available in the tooltip for each box and is also visible as the area to the left of the first child.