### PR TITLE
Fixed a CSS bug that caused the upper right dialog box to be covered by the frame graph.

### DIFF
--- a/internal/driver/html/common.css
+++ b/internal/driver/html/common.css
@@ -52,7 +52,7 @@ a {
 }
 #detailsbox {
   display: none;
-  z-index: 1;
+  z-index: 3;
   position: fixed;
   top: 40px;
   right: 20px;


### PR DESCRIPTION
Fixed a bug in the WebUI for new frame graphs where the dialog box in the upper right was displayed below the frame box.

before
![2023-05-14_144001](https://github.com/google/pprof/assets/20206121/6bbd2bc1-0f7b-4b38-b4ff-d5d6b8222354)

after
![2023-05-14_144028](https://github.com/google/pprof/assets/20206121/5d8f86c4-8d08-489e-bf4d-d652e7848530)
