### PR TITLE
Start using the new demangle.NoEnclosingParams demangling option.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/chzyer/readline v1.5.1
-	github.com/ianlancetaylor/demangle v0.0.0-20220517205856-0058ec4f073c
+	github.com/ianlancetaylor/demangle v0.0.0-20230524184225-eabc099b10ab
 )
 
 require golang.org/x/sys v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI
 github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
 github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
-github.com/ianlancetaylor/demangle v0.0.0-20220517205856-0058ec4f073c h1:rwmN+hgiyp8QyBqzdEX43lTjKAxaqCrYHaU5op5P9J8=
-github.com/ianlancetaylor/demangle v0.0.0-20220517205856-0058ec4f073c/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
+github.com/ianlancetaylor/demangle v0.0.0-20230524184225-eabc099b10ab h1:BA4a7pe6ZTd9F8kXETBoijjFJ/ntaa//1wiH9BZu4zU=
+github.com/ianlancetaylor/demangle v0.0.0-20230524184225-eabc099b10ab/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/binutils/disasm.go
+++ b/internal/binutils/disasm.go
@@ -95,8 +95,8 @@ func matchSymbol(names []string, start, end uint64, r *regexp.Regexp, address ui
 		// Match all possible demangled versions of the name.
 		for _, o := range [][]demangle.Option{
 			{demangle.NoClones},
-			{demangle.NoParams},
-			{demangle.NoParams, demangle.NoTemplateParams},
+			{demangle.NoParams, demangle.NoEnclosingParams},
+			{demangle.NoParams, demangle.NoEnclosingParams, demangle.NoTemplateParams},
 		} {
 			if demangled, err := demangle.ToString(name, o...); err == nil && r.MatchString(demangled) {
 				return []string{demangled}

--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -214,9 +214,9 @@ func Demangle(prof *profile.Profile, force bool, demanglerMode string) {
 func demanglerModeToOptions(demanglerMode string) []demangle.Option {
 	switch demanglerMode {
 	case "": // demangled, simplified: no parameters, no templates, no return type
-		return []demangle.Option{demangle.NoParams, demangle.NoTemplateParams}
+		return []demangle.Option{demangle.NoParams, demangle.NoEnclosingParams, demangle.NoTemplateParams}
 	case "templates": // demangled, simplified: no parameters, no return type
-		return []demangle.Option{demangle.NoParams}
+		return []demangle.Option{demangle.NoParams, demangle.NoEnclosingParams}
 	case "full":
 		return []demangle.Option{demangle.NoClones}
 	case "none": // no demangling


### PR DESCRIPTION
github.com/ianlancetaylor/demangle now has new
`demangle.NoEnclosingParams` option that enables stripping the parameters of a lambda's enclosing function, similar to how regular functions' names are simplified with the `demangle.NoParams` option pprof already uses.

E.g. we currently get
`foo_namespace::BarMethod(SomeArgType*)::$_0::operator()`, and with the new option it will be `foo_namespace::BarMethod::$_0::operator()`.

It seems the right thing to start using that option: If there is a function with a loop and then that loop is turned into an algorithm function call with a lambda, it doesn't seem right that the name of that lambda function suddenly gets parameters unstripped compared to the straight loop version.

This is part of b/284684693.