### PR TITLE
Prefix sample type menu entry ids with "sampletype-".

### DIFF
--- a/internal/driver/html/common.js
+++ b/internal/driver/html/common.js
@@ -563,11 +563,11 @@ function viewer(baseUrl, nodes, options) {
     return str.replace(/([\\\.?+*\[\](){}|^$])/g, '\\$1');
   }
 
-  function setSampleIndexLink(id) {
-    const elem = document.getElementById(id);
+  function setSampleIndexLink(si) {
+    const elem = document.getElementById('sampletype-' + si);
     if (elem != null) {
       setHrefParams(elem, function (params) {
-        params.set("si", id);
+        params.set("si", si);
       });
     }
   }

--- a/internal/driver/html/header.html
+++ b/internal/driver/html/header.html
@@ -28,7 +28,7 @@
     </div>
     <div class="submenu">
       {{range .SampleTypes}}
-      <a href="?si={{.}}" id="{{.}}">{{.}}</a>
+      <a href="?si={{.}}" id="sampletype-{{.}}">{{.}}</a>
       {{end}}
     </div>
   </div>


### PR DESCRIPTION
Previously, we would use the sample type name as the HTML id for the corresponding menu entry. However some profiles contain sample type names that conflict with other HTML ids we use (in particular, the sample type name "sample" conflicted with a different id). Remove this name clash by prefixing every menu entry with "sampletype-".

some profiles caused the Javascript to break bec