### PR TITLE
Fix flamegraph name matching.

### DIFF
--- a/internal/driver/html/common.js
+++ b/internal/driver/html/common.js
@@ -558,11 +558,6 @@ function viewer(baseUrl, nodes, options) {
     return null;
   }
 
-  // convert a string to a regexp that matches that string.
-  function quotemeta(str) {
-    return str.replace(/([\\\.?+*\[\](){}|^$])/g, '\\$1');
-  }
-
   function setSampleIndexLink(si) {
     const elem = document.getElementById('sampletype-' + si);
     if (elem != null) {
@@ -595,7 +590,7 @@ function viewer(baseUrl, nodes, options) {
       // list-based.  Construct regular expression depending on mode.
       let re = regexpActive
           ? search.value
-          : Array.from(getSelection().keys()).map(key => quotemeta(nodes[key])).join('|');
+          : Array.from(getSelection().keys()).map(key => pprofQuoteMeta(nodes[key])).join('|');
 
       setHrefParams(elem, function (params) {
         if (re != '') {
@@ -711,4 +706,9 @@ function viewer(baseUrl, nodes, options) {
   if (main) {
     main.focus();
   }
+}
+
+// convert a string to a regexp that matches exactly that string.
+function pprofQuoteMeta(str) {
+  return '^' + str.replace(/([\\\.?+*\[\](){}|^$])/g, '\\$1') + '$';
 }

--- a/internal/driver/html/stacks.js
+++ b/internal/driver/html/stacks.js
@@ -145,7 +145,7 @@ function stackViewer(stacks, nodes) {
     }
 
     // Update params to include src.
-    let v = stacks.Sources[src].RE;
+    let v = pprofQuoteMeta(stacks.Sources[src].FullName);
     if (param != 'f' && param != 'sf') { // old f,sf values are overwritten
       // Add new source to current parameter value.
       const old = params.get(param);
@@ -445,7 +445,7 @@ function stackViewer(stacks, nodes) {
       r.appendChild(t);
     }
 
-    r.addEventListener('click', () => { switchPivots(src.RE); });
+    r.addEventListener('click', () => { switchPivots(pprofQuoteMeta(src.UniqueName)); });
     r.addEventListener('mouseenter', () => { handleEnter(box, r); });
     r.addEventListener('mouseleave', () => { handleLeave(box); });
     r.addEventListener('contextmenu', (e) => { showActionMenu(e, box); });

--- a/internal/report/stacks.go
+++ b/internal/report/stacks.go
@@ -18,7 +18,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
-	"regexp"
 
 	"github.com/google/pprof/internal/measurement"
 	"github.com/google/pprof/profile"
@@ -53,9 +52,6 @@ type StackSource struct {
 	// Alternative names to display (with decreasing lengths) to make text fit.
 	// Guaranteed to be non-empty.
 	Display []string
-
-	// Regular expression (anchored) that matches exactly FullName.
-	RE string
 
 	// Places holds the list of stack slots where this source occurs.
 	// In particular, if [a,b] is an element in Places,
@@ -135,7 +131,6 @@ func (s *StackSet) makeInitialStacks(rpt *Report) {
 			unknownIndex++
 		}
 		x.Inlined = inlined
-		x.RE = "^" + regexp.QuoteMeta(x.UniqueName) + "$"
 		x.Display = shortNameList(x.FullName)
 		s.Sources = append(s.Sources, x)
 		srcs[k] = len(s.Sources) - 1


### PR DESCRIPTION
Previously, we were using the same regexp to match both a node's FunctionName (for server-side filtering) and UniqueName (for browser-side pivoting). However the two strings can differ (UniqueName can end with a #<number> in case of overloads). This resulted in us being unable to ignore/focus/hide overloaded functions.

We now use distinct regexps for the two different use cases.  And we no longer compute the regexps in Go. Instead we do this in Javascript using the pre-existing quotemeta function.

The quotemeta function has now been moved to the top-level and renamed to pprofQuoteMeta.