### PR TITLE
Fix broken URL parameters in new flame graph menus.

### DIFF
--- a/internal/driver/html/stacks.js
+++ b/internal/driver/html/stacks.js
@@ -76,11 +76,11 @@ function stackViewer(stacks, nodes) {
     current: () => {
       let r = new Map();
       if (pivots.length == 1 && pivots[0] == 0) {
-	// Not pivoting
+        // Not pivoting
       } else {
-	for (let p of pivots) {
+        for (let p of pivots) {
           r.set(p, true);
-	}
+        }
       }
       return r;
     }});

--- a/internal/driver/html/stacks.js
+++ b/internal/driver/html/stacks.js
@@ -75,8 +75,12 @@ function stackViewer(stacks, nodes) {
     hiliter: (n, on) => { return hilite(n, on); },
     current: () => {
       let r = new Map();
-      for (let p of pivots) {
-        r.set(p, true);
+      if (pivots.length == 1 && pivots[0] == 0) {
+	// Not pivoting
+      } else {
+	for (let p of pivots) {
+          r.set(p, true);
+	}
       }
       return r;
     }});
@@ -174,7 +178,11 @@ function stackViewer(stacks, nodes) {
   function switchPivots(regexp) {
     // Switch URL without hitting the server.
     const url = new URL(document.URL);
-    url.searchParams.set('p', regexp);
+    if (regexp === '' || regexp === '^$') {
+      url.searchParams.delete('p');  // Not pivoting
+    } else {
+      url.searchParams.set('p', regexp);
+    }
     history.pushState('', '', url.toString()); // Makes back-button work
     matches = new Set();
     search.value = '';

--- a/internal/driver/testdata/testflame.js
+++ b/internal/driver/testdata/testflame.js
@@ -87,6 +87,28 @@ function TestFlame() {
     checkWidth("F2", 100/100);
     checkWidth("F3", 100/100);
   });
+
+  test.run("NavigateWithoutPivot", function() {
+    // Clear pivot
+    boxMap.get("root").click();
+
+    // Trigger link update.
+    const btn = document.getElementById("graphbtn");
+    if (!btn) {
+      test.err("no graph button on page");
+      return;
+    }
+    const event = new Event("mouseenter");
+    btn.dispatchEvent(event);
+
+    // Check that URL does not contain a focus parameter.
+    test.log(btn.href);
+    const url = new URL(btn.href);
+    if (url.searchParams.has('f')) {
+      test.err("unexpected focus parameter in URL", btn.href);
+    }
+  });
+
   return test.result;
 }
 TestFlame();


### PR DESCRIPTION
Previously, we would pass an invalid 'f' URL parameter when switching from the new Flamegraph view to another view if nothing was selected. We now check for this case and avoid the bad behavior.

Also added a test for this behavior.

Fixes #812.