### PR TITLE
Use a release version of staticcheck in `ci.yml`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,8 +80,7 @@ jobs:
           brew install graphviz
           # Do not let tools interfere with the main module's go.mod.
           cd && go mod init tools
-          # TODO: Update to a specific version when https://github.com/dominikh/go-tools/issues/1362 is fixed.
-          go install honnef.co/go/tools/cmd/staticcheck@master
+          go install honnef.co/go/tools/cmd/staticcheck@v0.4.6
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
           # Add PATH for installed tools.
           echo "$GOPATH/bin:$PATH" >> $GITHUB_PATH
@@ -139,8 +138,7 @@ jobs:
           sudo apt-get install graphviz
           # Do not let tools interfere with the main module's go.mod.
           cd && go mod init tools
-          # TODO: Update to a specific version when https://github.com/dominikh/go-tools/issues/1362 is fixed.
-          go install honnef.co/go/tools/cmd/staticcheck@master
+          go install honnef.co/go/tools/cmd/staticcheck@v0.4.6
           go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.0
           # Add PATH for installed tools.
           echo "$GOPATH/bin:$PATH" >> $GITHUB_PATH


### PR DESCRIPTION
I noticed the `ci.yml` workflow uses `honnef.co/go/tools/cmd/staticcheck@master` and mentions that it should be replaced by a specific version once an issue in that dependency is fixed.

It was fixed earlier this year, in [release 0.4.1](https://github.com/dominikh/go-tools/releases/tag/2023.1.1). This PR adopts the latest release version (0.4.6). Let me know if you'd rather just use 0.4.1.