### PR TITLE
webhtml: fill search input from url parameter

### DIFF
--- a/internal/driver/html/common.js
+++ b/internal/driver/html/common.js
@@ -261,6 +261,10 @@ function initMenus() {
       cancelActiveMenu();
     }
   }, { passive: true, capture: true });
+
+  // fill search input from url parameter
+  const urlSearchParams = new URLSearchParams(window.location.search);
+  document.getElementById('search').value = urlSearchParams.get('f') || '';
 }
 
 function sendURL(method, url, done) {


### PR DESCRIPTION
Thank you for this great tool and contributors.

I think it would be more convenient if the conditions were restored to the text box when performing a search in the webui.
I think this fix will make exploratory searches easier.

This is a sample when accessing `http://localhost:2345/ui/?f=%5Emain`

<img width="677" alt="image" src="https://github.com/google/pprof/assets/20282867/2f51e2b3-7dbd-4dda-8fba-a9820012510f">

Currently, search inputs are cleared every time the page is refreshed.

<img width="657" alt="image" src="https://github.com/google/pprof/assets/20282867/91141c46-7d3c-4693-a587-151dc4fc6114">

I checked `CONTRIBUTING.md` and wanted to write a test, but there was no existing test suite or framework, so I didn't create one.

The PR below seems to partially writing test on the front end, so should I refer to it?
I would like to hear the opinions of reviewers.
https://github.com/google/pprof/pull/802