### PR TITLE
Assume //anon files unsymbolizable.

### DIFF
--- a/profile/profile.go
+++ b/profile/profile.go
@@ -847,7 +847,7 @@ func (p *Profile) HasFileLines() bool {
 // "[vdso]", [vsyscall]" and some others, see the code.
 func (m *Mapping) Unsymbolizable() bool {
 	name := filepath.Base(m.File)
-	return strings.HasPrefix(name, "[") || strings.HasPrefix(name, "linux-vdso") || strings.HasPrefix(m.File, "/dev/dri/")
+	return strings.HasPrefix(name, "[") || strings.HasPrefix(name, "linux-vdso") || strings.HasPrefix(m.File, "/dev/dri/") || m.File == "//anon"
 }
 
 // Copy makes a fully independent copy of a profile.


### PR DESCRIPTION
The //anon mappings do not correspond to an actual file so pprof trying to look them up on disk and complaining with a warning is not useful.