### PR TITLE
fix: fix miss makezero bug

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -444,7 +444,7 @@ func newTree(prof *profile.Profile, o *Options) (g *Graph) {
 		}
 	}
 
-	nodes := make(Nodes, len(prof.Location))
+	nodes := make(Nodes, 0, len(prof.Location))
 	for _, nm := range parentNodeMap {
 		nodes = append(nodes, nm.nodes()...)
 	}


### PR DESCRIPTION
I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output https://github.com/alingse/go-linter-runner/actions/runs/9241873083/job/25423942721 

```
====================================================================================================
append to slice `nodes` with non-zero initialized length at https://github.com/google/pprof/blob/main/internal/graph/graph.go#L44[9](https://github.com/alingse/go-linter-runner/actions/runs/9241873083/job/25423942721#step:4:10):11
====================================================================================================
```