### PR TITLE
css: add font color for inlined function calls

### DIFF
--- a/internal/report/source_html.go
+++ b/internal/report/source_html.go
@@ -42,6 +42,7 @@ h1 {
 }
 .livesrc {
 cursor: pointer;
+color: #F2503B;
 }
 .livesrc:hover {
 background-color: #eeeeee;


### PR DESCRIPTION
After adding color to the text of the line number, it is easier to recognize which lines are inlined function calls


<img width="812" alt="image" src="https://github.com/google/pprof/assets/5624855/7a07e078-6177-42d0-9a5c-dba14c361768">


---
<img width="855" alt="image" src="https://github.com/google/pprof/assets/5624855/baff56ff-6768-4f7f-bb29-f05c2c345421">
