### PR TITLE
Fix stacking order of profile details box.

### DIFF
--- a/internal/driver/html/common.css
+++ b/internal/driver/html/common.css
@@ -52,7 +52,6 @@ a {
 }
 #detailsbox {
   display: none;
-  z-index: 1;
   position: fixed;
   top: 40px;
   right: 20px;
@@ -107,7 +106,6 @@ a {
 }
 .submenu {
   display: none;
-  z-index: 1;
   margin-top: -4px;
   min-width: 10em;
   position: absolute;
@@ -169,8 +167,6 @@ a {
   top: 60px;
   left: 50%;
   transform: translateX(-50%);
-
-  z-index: 3;
   font-size: 125%;
   background-color: #ffffff;
   box-shadow: 0 1px 5px rgba(0,0,0,.3);
@@ -271,3 +267,9 @@ table tr td {
   background-color: #ebf5fb;
   font-weight: bold;
 }
+/* stacking order */
+.boxtext         { z-index: 2; }  /* flame graph box text */
+#current-details { z-index: 2; }  /* flame graph current box info */
+#detailsbox      { z-index: 3; }  /* profile details */
+.submenu         { z-index: 4; }
+.dialog          { z-index: 5; }

--- a/internal/driver/html/stacks.css
+++ b/internal/driver/html/stacks.css
@@ -19,7 +19,6 @@ body {
   position: absolute;
   top: 5px;
   right: 5px;
-  z-index: 2;
   font-size: 12pt;
 }
 /* Background of a single flame-graph frame */
@@ -57,8 +56,6 @@ body {
   font-size: 12pt;
   font-weight: bold;
 }
-/* Ensure that pprof menu is above boxes */
-.submenu { z-index: 3; }
 /* Right-click menu */
 #action-menu {
   max-width: 15em;


### PR DESCRIPTION
Previously the profile details box (displayed when clicking button at top-right of web view), would partially overlap flame graph text. Tweak z-index values to fix this problem.

Also, colocate all z-index CSS entries to make the stacking order of different things easier to compare.