### PR TITLE
Change the main binary override feature to override all consecutive initial mappings

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -471,16 +471,24 @@ mapping:
 	// If configured, apply executable filename override and (maybe, see below)
 	// build ID override from source. Assume the executable is the first mapping.
 	if execName, buildID := s.ExecName, s.BuildID; execName != "" || buildID != "" {
-		m := p.Mapping[0]
-		// Explicitly do not update KernelRelocationSymbol --
-		// the source override is most likely missing it.
-		m.File = execName
+		// Keep overriding until there appears a different file.
+		var prevFile string
+		for i, m := range p.Mapping {
+			if i != 0 && m.File != prevFile {
+				break
+			}
+			prevFile = m.File
 
-		// Only apply the build ID override if the build ID in the main mapping is
-		// missing. Overwriting the build ID in case it's present is very likely a
-		// wrong thing to do so we refuse to do that.
-		if m.BuildID == "" {
-			m.BuildID = buildID
+			// Explicitly do not update KernelRelocationSymbol --
+			// the source override is most likely missing it.
+			m.File = execName
+
+			// Only apply the build ID override if the build ID in the main mapping is
+			// missing. Overwriting the build ID in case it's present is very likely a
+			// wrong thing to do so we refuse to do that.
+			if m.BuildID == "" {
+				m.BuildID = buildID
+			}
 		}
 	}
 }

--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -472,15 +472,14 @@ mapping:
 	// build ID override from source. Assume the executable is the first mapping.
 	if execName, buildID := s.ExecName, s.BuildID; execName != "" || buildID != "" {
 		m := p.Mapping[0]
-		if execName != "" {
-			// Explicitly do not update KernelRelocationSymbol --
-			// the source override is most likely missing it.
-			m.File = execName
-		}
+		// Explicitly do not update KernelRelocationSymbol --
+		// the source override is most likely missing it.
+		m.File = execName
+
 		// Only apply the build ID override if the build ID in the main mapping is
 		// missing. Overwriting the build ID in case it's present is very likely a
 		// wrong thing to do so we refuse to do that.
-		if buildID != "" && m.BuildID == "" {
+		if m.BuildID == "" {
 			m.BuildID = buildID
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/google/pprof/issues/885.

As described in the issue, in our use case, the mappings of the main binary consist of multiple lines. Although pprof offers a function to override the name of the main binary by passing a new one, it only overrides the first mapping.

This PR changes the behavior to override all consecutive initial mappings if their main binary names are the same.

I don't understand `pprof` enough to know what it means when there are multiple lines of mapping for the main binary. So if there's a better way to handle this, please let me know.

At the very least, the tests are passing, and I believe this PR does not change the existing behavior.