### PR TITLE
Added doc link to profile header.

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1169,6 +1169,9 @@ func ProfileLabels(rpt *Report) []string {
 	if o.SampleType != "" {
 		label = append(label, "Type: "+o.SampleType)
 	}
+	if url := prof.DocURL; url != "" {
+		label = append(label, "Doc: "+url)
+	}
 	if prof.TimeNanos != 0 {
 		const layout = "Jan 2, 2006 at 3:04pm (MST)"
 		label = append(label, "Time: "+time.Unix(0, prof.TimeNanos).Format(layout))

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -16,6 +16,7 @@ package report
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -574,5 +575,23 @@ func TestDocURL(t *testing.T) {
 				t.Errorf("bad doc URL %q, expecting %q", got, c.want)
 			}
 		})
+	}
+}
+
+func TestDocURLInLabels(t *testing.T) {
+	const url = "http://example.com/pprof-help"
+	profile := testProfile.Copy()
+	profile.DocURL = url
+	rpt := New(profile, &Options{
+		OutputFormat: Text,
+		Symbol:       regexp.MustCompile(`.`),
+		TrimPath:     "/some/path",
+		SampleValue:  func(v []int64) int64 { return v[1] },
+		SampleUnit:   testProfile.SampleType[1].Unit,
+	})
+
+	labels := fmt.Sprintf("%v", ProfileLabels(rpt))
+	if !strings.Contains(labels, url) {
+		t.Errorf("expected URL %q not found in %s", url, labels)
 	}
 }


### PR DESCRIPTION
Output looks something like:

```
% pprof -top ...
File: ...
Build ID: ...
Type: cpu
Doc: http://example.com/cpuprofile
Duration: 6.71s, Total samples = 5.72s (85.30%)
Showing nodes accounting for 5.17s, 90.38% of 5.72s total
Dropped 326 nodes (cum <= 0.03s)
...
```