### PR TITLE
Add Zircon kernel symbolization support.

### DIFF
--- a/internal/elfexec/elfexec.go
+++ b/internal/elfexec/elfexec.go
@@ -206,6 +206,25 @@ func kernelBase(loadSegment *elf.ProgHeader, stextOffset *uint64, start, limit, 
 		// stextOffset=0xffffffff81000198
 		return start - *stextOffset, true
 	}
+
+	// Here comme kernel mapped in the upper half of the address space.
+	if start >= 0x8000000000000000 {
+
+		// Fuchsia Zircon kernel profiles have the following
+		// `start` > 0x8000000000000000, and non-zero `limit`, `offset`,
+		// `loadSegment.Off`, `loadSegment.Vaddr`. The only null value is
+		// `stextOffset`.
+		// Start being the virtual address for the beginning of mapped range.
+		// Offset being the position of that first byte in the binary file.
+		//
+		// Base, the amount to be removed to a virtual address to turn it into a
+		// file offset, is a simple substraction (`start - offset`) which is the
+		// same as for ET_DYN.
+		//
+		// Reference Fuchsia symbolization implementation at
+		// https://cs.opensource.google/fuchsia/fuchsia/+/main:tools/symbolizer/symbolizer_impl.cc;l=236;drc=534a61053c54c048640d5298d8337619a528e251
+		return start - offset, true
+	}
 	return 0, false
 }
 

--- a/internal/elfexec/elfexec_test.go
+++ b/internal/elfexec/elfexec_test.go
@@ -44,6 +44,10 @@ func TestGetBase(t *testing.T) {
 		Vaddr: 0xffffffff80200000,
 		Off:   0x1000,
 	}
+	kernelFuchsiaHeader := &elf.ProgHeader{
+		Vaddr: 0xffffffff80100000,
+		Off:   0x1000,
+	}
 	// Kernel PIE header with vaddr aligned to a 4k boundary
 	kernelPieAlignedHeader := &elf.ProgHeader{
 		Vaddr: 0xffff000010080000,
@@ -83,6 +87,7 @@ func TestGetBase(t *testing.T) {
 		{"exec chromeos kernel 3", fhExec, kernelHeader, uint64p(0xffffffff81000198), 0x198, 0x100000, 0, 0x7f000000, false},
 		{"exec chromeos kernel 4", fhExec, kernelHeader, uint64p(0xffffffff81200198), 0x198, 0x100000, 0, 0x7ee00000, false},
 		{"exec chromeos kernel unremapped", fhExec, kernelHeader, uint64p(0xffffffff810001c8), 0xffffffff834001c8, 0xffffffffc0000000, 0xffffffff834001c8, 0x2400000, false},
+		{"exec fuchsia kernel", fhExec, kernelFuchsiaHeader, nil, 0xffffffff00100000, 0xffffffff00426d60, 0xffffffff80100000, 0xffffffff80000000, false},
 		{"dyn", fhDyn, nil, nil, 0x200000, 0x300000, 0, 0x200000, false},
 		{"dyn map", fhDyn, lsOffset, nil, 0x0, 0x300000, 0, 0xFFFFFFFFFFE00000, false},
 		{"dyn nomap", fhDyn, nil, nil, 0x0, 0x0, 0, 0, false},


### PR DESCRIPTION
In the context of Fuchsia Zircon kernel heap memory profiler I need symbolization support.