### PR TITLE
tui: use RFC3339-alike format with second precision for "Time"

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1173,7 +1173,7 @@ func ProfileLabels(rpt *Report) []string {
 		label = append(label, "Doc: "+url)
 	}
 	if prof.TimeNanos != 0 {
-		const layout = "Jan 2, 2006 at 3:04pm (MST)"
+		const layout = "2006-01-02 15:04:05 MST"
 		label = append(label, "Time: "+time.Unix(0, prof.TimeNanos).Format(layout))
 	}
 	if prof.DurationNanos != 0 {


### PR DESCRIPTION
The current time format (Jan 2, 2006 at 3:04pm (MST)) has a few issues:

 - It displays time at minute granularity, while profiles usually have have second-level (and more[^go]) granularity.
 - It uses a 12-hour clock, which is tricky to handle at AM/PM switchovers, for people (like myself) who are not used to it. By contrast, a 24-hour clock is unambiguous.
 - Minor: using names for months makes it more difficult to calculate with time differences.

Hence, I propose replacing it with an RFC3339-alike format, with spaces between elements for better readability.

[^go]: https://github.com/golang/go/blob/3aa71c12eacd68ec16e7172d92aa5c6af32f0c3b/src/runtime/pprof/proto.go#L351