### PR TITLE
Update kernel base to work for non-KASLR kernels.

### DIFF
--- a/internal/elfexec/elfexec.go
+++ b/internal/elfexec/elfexec.go
@@ -181,7 +181,7 @@ func kernelBase(loadSegment *elf.ProgHeader, stextOffset *uint64, start, limit, 
 		// stextOffset=0xffffffff80200198
 		return start - *stextOffset, true
 	}
-	if start >= loadSegment.Vaddr && limit > start && (offset == 0 || offset == pageOffsetPpc64 || offset == start) {
+	if start >= 0x8000000000000000 && limit > start && (offset == 0 || offset == pageOffsetPpc64 || offset == start) {
 		// Some kernels look like:
 		//       VADDR=0xffffffff80200000
 		// stextOffset=0xffffffff80200198

--- a/internal/elfexec/elfexec_test.go
+++ b/internal/elfexec/elfexec_test.go
@@ -46,7 +46,7 @@ func TestGetBase(t *testing.T) {
 	}
 	// Kernel PIE header with vaddr aligned to a 4k boundary
 	kernelPieAlignedHeader := &elf.ProgHeader{
-		Vaddr: 0xffff000010080000,
+		Vaddr: 0xffff800010010000,
 		Off:   0x10000,
 	}
 	// Kernel PIE header with vaddr that doesn't fall on a 4k boundary
@@ -87,7 +87,7 @@ func TestGetBase(t *testing.T) {
 		{"dyn map", fhDyn, lsOffset, nil, 0x0, 0x300000, 0, 0xFFFFFFFFFFE00000, false},
 		{"dyn nomap", fhDyn, nil, nil, 0x0, 0x0, 0, 0, false},
 		{"dyn map+offset", fhDyn, lsOffset, nil, 0x900000, 0xa00000, 0x200000, 0x500000, false},
-		{"dyn kernel", fhDyn, kernelPieAlignedHeader, uint64p(0xffff000010080000), 0xffff000010080000, 0xffffffffffffffff, 0xffff000010080000, 0, false},
+		{"dyn kernel", fhDyn, kernelPieAlignedHeader, uint64p(0xffff800010000000), 0xffff800010000000, 0xffff800012815c00, 0xffff800010000000, 0, false},
 		{"dyn chromeos aslr kernel", fhDyn, kernelPieUnalignedHeader, uint64p(0xffffffc010080800), 0x800, 0xb7f800, 0, 0x3feff80000, false},
 		{"dyn chromeos aslr kernel unremapped", fhDyn, kernelPieUnalignedHeader, uint64p(0xffffffc010080800), 0xffffffdb5d680800, 0xffffffdb5e200000, 0xffffffdb5d680800, 0x1b4d600000, false},
 		{"rel", fhRel, nil, nil, 0x2000000, 0x3000000, 0, 0x2000000, false},


### PR DESCRIPTION
Replace an existing check for "start >= loadSegment.Vaddr" with "start >= 0x8000000000000000".

The old condition was checking for the mapping start address to be greater or equal to the program segment Vaddr. However, for kernels without KASLR, the mapping start address (start) is less or equal the program header Vaddr. If the program header that includes the '.text' section is not the first segment, then the mapping start is strictly less than loadSegment.Vaddr.

Instead of removing the condition, we replace it with a check that start is in the kernel address space, so we don't take this path for user space binaries.

Adjusted the test case for PIE kernels to match actual addresses seen for a non-KASLR kernel. The new test fails with the old code and succeeds now.