### PR TITLE
Allow symbolz to try symbolize unsymbolizable mappings.

### DIFF
--- a/internal/symbolz/symbolz.go
+++ b/internal/symbolz/symbolz.go
@@ -37,17 +37,13 @@ var (
 // Symbolize symbolizes profile p by parsing data returned by a symbolz
 // handler. syms receives the symbolz query (hex addresses separated by '+')
 // and returns the symbolz output in a string. If force is false, it will only
-// symbolize locations from mappings not already marked as HasFunctions. Never
-// attempts symbolization of addresses from unsymbolizable system
-// mappings as those may look negative - e.g. "[vsyscall]".
+// symbolize locations from mappings not already marked as HasFunctions. Does
+// not skip unsymbolizable files since the symbolz handler can be flexible
+// enough to handle some of those cases such as JIT locations in //anon.
 func Symbolize(p *profile.Profile, force bool, sources plugin.MappingSources, syms func(string, string) ([]byte, error), ui plugin.UI) error {
 	for _, m := range p.Mapping {
 		if !force && m.HasFunctions {
 			// Only check for HasFunctions as symbolz only populates function names.
-			continue
-		}
-		// Skip well-known system mappings.
-		if m.Unsymbolizable() {
 			continue
 		}
 		mappingSources := sources[m.File]


### PR DESCRIPTION
We added skipping unsymbolizable mappings in symbolz long time ago in PR #368 to address #339 where we saw error like "unexpected negative adjusted address".

But that error was fixed in a more proper way in subsequent #397 to fix another reported issue #280 (and internal b/32020573). So skipping unsymbolized mappings shouldn't be needed anymore.

I tested this by verifying that the test case from #339 still works fine with the proposed change. And that it does fail if I roll back #397 locally.

This change is useful as we experiment with using symbolz to symbolize JIT locations from //anon (which is unsymbolizable per current terminology).