### PR TITLE
Fix 'show source [in new tab]' under -lines

### DIFF
--- a/internal/driver/html/stacks.js
+++ b/internal/driver/html/stacks.js
@@ -135,6 +135,8 @@ function stackViewer(stacks, nodes) {
     }
 
     // Update params to include src.
+    // When `pprof` is invoked with `-lines`, FullName will be suffixed with `:<line>`,
+    // which we need to remove.
     let v = pprofQuoteMeta(stacks.Sources[src].FullName.replace(/:[0-9]+$/, ''));
     if (param != 'f' && param != 'sf') { // old f,sf values are overwritten
       // Add new source to current parameter value.

--- a/internal/driver/html/stacks.js
+++ b/internal/driver/html/stacks.js
@@ -135,7 +135,7 @@ function stackViewer(stacks, nodes) {
     }
 
     // Update params to include src.
-    let v = pprofQuoteMeta(stacks.Sources[src].FullName);
+    let v = pprofQuoteMeta(stacks.Sources[src].FullName.replace(/:[0-9]+$/, ''));
     if (param != 'f' && param != 'sf') { // old f,sf values are overwritten
       // Add new source to current parameter value.
       const old = params.get(param);


### PR DESCRIPTION
With this patch, it's possible to navigate from the (new and now only) flame graph to the source code for a box.