### PR TITLE
Bail out fast when no demangling is requested

### DIFF
--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -257,7 +257,7 @@ func Demangle(prof *profile.Profile, force bool, demanglerMode string) {
 	}
 
 	options := demanglerModeToOptions(demanglerMode)
-	// bail out fast to avoid any parsing, if we really don't want any demangling.
+	// Bail out fast to avoid any parsing, if we really don't want any demangling.
 	if len(options) == 0 {
 		return
 	}

--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -257,6 +257,10 @@ func Demangle(prof *profile.Profile, force bool, demanglerMode string) {
 	}
 
 	options := demanglerModeToOptions(demanglerMode)
+	// bail out fast to avoid any parsing, if we really don't want any demangling.
+	if len(options) == 0 {
+		return
+	}
 	for _, fn := range prof.Function {
 		demangleSingleFunction(fn, options)
 	}


### PR DESCRIPTION
Avoid trying to demangle functions one by one; besides, `demangleSingleFunction` doesn't quite behave correctly when **no** demangling is requested.