### PR TITLE
Fix canvas to fill the full height.

### DIFF
--- a/internal/driver/html/common.css
+++ b/internal/driver/html/common.css
@@ -218,10 +218,12 @@ a {
 }
 #graph {
   overflow: hidden;
+  width: 100%;
+  height: 100%;
 }
 #graph svg {
   width: 100%;
-  height: auto;
+  height: 100%;
   padding: 10px;
 }
 #content.source .filename {


### PR DESCRIPTION
The canvas used to scale itself to the aspect ratio of the full graph, which might be fairly wide. That means even while zooming, the original aspect ratio is preserved and only a 'letterbox' is shown.

This CSS change fixes that.

Fixes: #835