### PR TITLE
Fix the OSX demangling fallback comparison.

### DIFF
--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -296,7 +296,10 @@ func demangleSingleFunction(fn *profile.Function, options []demangle.Option) {
 	// OSX has all the symbols prefixed with extra '_' so lets try
 	// once more without it
 	if strings.HasPrefix(fn.SystemName, "_") {
-		if demangled := demangle.Filter(fn.SystemName[1:], o...); demangled != fn.SystemName {
+		// Copy the options because they may be updated by the call.
+		o := make([]demangle.Option, len(options))
+		copy(o, options)
+		if demangled := demangle.Filter(fn.SystemName[1:], o...); demangled != fn.SystemName[1:] {
 			fn.Name = demangled
 			return
 		}

--- a/internal/symbolizer/symbolizer_test.go
+++ b/internal/symbolizer/symbolizer_test.go
@@ -381,6 +381,11 @@ func TestDemangleSingleFunction(t *testing.T) {
 			want:   "operator delete[]",
 		},
 		{
+			// Leave special double underscore symbols as is.
+			symbol: "__some_special_name",
+			want:   "__some_special_name",
+		},
+		{
 			// Already demangled.
 			symbol: "operator delete[](void*)",
 			want:   "operator delete[]",


### PR DESCRIPTION
This is a follow-up to #924. In the comparison we should compare to the string with stripped underscore, otherwise the comparison will never be true and we strip the underscore in cases we shouldn't. See the added test case.

Also, while we are here, add copying demangling options that we also missed. Hopefully we can get
https://github.com/ianlancetaylor/demangle/pull/24 in and this won't be needed.