### PR TITLE
Remove copying demangler options, not needed anymore.

### DIFF
--- a/internal/symbolizer/symbolizer.go
+++ b/internal/symbolizer/symbolizer.go
@@ -281,14 +281,11 @@ func demanglerModeToOptions(demanglerMode string) []demangle.Option {
 	panic(fmt.Sprintf("unknown demanglerMode %s", demanglerMode))
 }
 
-func demangleSingleFunction(fn *profile.Function, options []demangle.Option) {
+func demangleSingleFunction(fn *profile.Function, opts []demangle.Option) {
 	if fn.Name != "" && fn.SystemName != fn.Name {
 		return // Already demangled.
 	}
-	// Copy the options because they may be updated by the call.
-	o := make([]demangle.Option, len(options))
-	copy(o, options)
-	if demangled := demangle.Filter(fn.SystemName, o...); demangled != fn.SystemName {
+	if demangled := demangle.Filter(fn.SystemName, opts...); demangled != fn.SystemName {
 		fn.Name = demangled
 		return
 	}
@@ -296,10 +293,7 @@ func demangleSingleFunction(fn *profile.Function, options []demangle.Option) {
 	// OSX has all the symbols prefixed with extra '_' so lets try
 	// once more without it
 	if strings.HasPrefix(fn.SystemName, "_") {
-		// Copy the options because they may be updated by the call.
-		o := make([]demangle.Option, len(options))
-		copy(o, options)
-		if demangled := demangle.Filter(fn.SystemName[1:], o...); demangled != fn.SystemName[1:] {
+		if demangled := demangle.Filter(fn.SystemName[1:], opts...); demangled != fn.SystemName[1:] {
 			fn.Name = demangled
 			return
 		}
@@ -309,7 +303,7 @@ func demangleSingleFunction(fn *profile.Function, options []demangle.Option) {
 	// already demangled.
 	name := fn.SystemName
 	if looksLikeDemangledCPlusPlus(name) {
-		for _, o := range options {
+		for _, o := range opts {
 			switch o {
 			case demangle.NoParams:
 				name = removeMatching(name, '(', ')')


### PR DESCRIPTION
With [this demangler fix](https://github.com/ianlancetaylor/demangle/commit/f615e6bd150ba7c2231ba4be6104d64396a3ea50) this isn't needed anymore.