### PR TITLE
profile: optimize Parse allocs

### DIFF
--- a/profile/proto.go
+++ b/profile/proto.go
@@ -36,6 +36,7 @@ package profile
 import (
 	"errors"
 	"fmt"
+	"slices"
 )
 
 type buffer struct {
@@ -187,6 +188,16 @@ func le32(p []byte) uint32 {
 	return uint32(p[0]) | uint32(p[1])<<8 | uint32(p[2])<<16 | uint32(p[3])<<24
 }
 
+func peekNumVarints(data []byte) (numVarints int) {
+	for ; len(data) > 0; numVarints++ {
+		var err error
+		if _, data, err = decodeVarint(data); err != nil {
+			break
+		}
+	}
+	return numVarints
+}
+
 func decodeVarint(data []byte) (uint64, []byte, error) {
 	var u uint64
 	for i := 0; ; i++ {
@@ -286,6 +297,9 @@ func decodeInt64(b *buffer, x *int64) error {
 func decodeInt64s(b *buffer, x *[]int64) error {
 	if b.typ == 2 {
 		// Packed encoding
+		dataLen := peekNumVarints(b.data)
+		*x = slices.Grow(*x, dataLen)
+
 		data := b.data
 		for len(data) > 0 {
 			var u uint64
@@ -316,8 +330,11 @@ func decodeUint64(b *buffer, x *uint64) error {
 
 func decodeUint64s(b *buffer, x *[]uint64) error {
 	if b.typ == 2 {
-		data := b.data
 		// Packed encoding
+		dataLen := peekNumVarints(b.data)
+		*x = slices.Grow(*x, dataLen)
+
+		data := b.data
 		for len(data) > 0 {
 			var u uint64
 			var err error


### PR DESCRIPTION
`go test -bench='^\QBenchmarkParse\E$' -run='^$' -count=10 -benchtime=5s`

```
goos: linux
goarch: amd64
pkg: github.com/google/pprof/profile
cpu: 13th Gen Intel(R) Core(TM) i7-1360P
         │ old-parse.txt │            new-parse.txt             │
         │    sec/op     │    sec/op     vs base                │
Parse-16    62.07m ± 13%   55.54m ± 13%  -10.52% (p=0.035 n=10)

         │ old-parse.txt │            new-parse.txt             │
         │     B/op      │     B/op      vs base                │
Parse-16    47.56Mi ± 0%   41.09Mi ± 0%  -13.59% (p=0.000 n=10)

         │ old-parse.txt │            new-parse.txt            │
         │   allocs/op   │  allocs/op   vs base                │
Parse-16     272.9k ± 0%   175.8k ± 0%  -35.58% (p=0.000 n=10)
```