### PR TITLE
report: optimize newTrimmedGraph allocs

### DIFF
--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -615,3 +615,38 @@ func TestProfileLabels(t *testing.T) {
 		t.Errorf("wanted to find a label containing %q, but found none in %v", want, labels)
 	}
 }
+
+func BenchmarkNewDefaultReport(b *testing.B) {
+	data := proftest.LargeProfile(b)
+	prof, err := profile.Parse(bytes.NewBuffer(data))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rep := NewDefault(prof, Options{})
+		if rep == nil {
+			b.Error("empty report")
+		}
+	}
+}
+
+func BenchmarkReportNewTrimmedGraph(b *testing.B) {
+	data := proftest.LargeProfile(b)
+	prof, err := profile.Parse(bytes.NewBuffer(data))
+	if err != nil {
+		b.Fatal(err)
+	}
+	rep := NewDefault(prof, Options{})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g, _, _, _ := rep.newTrimmedGraph()
+		if g == nil {
+			b.Fatal("empty graph")
+		}
+	}
+}


### PR DESCRIPTION
`go test -bench='^\QBenchmarkReportNewTrimmedGraph\E$' -run='^$' -count=10 -benchtime=5s`

```
goos: linux
goarch: amd64
pkg: github.com/google/pprof/internal/report
cpu: 13th Gen Intel(R) Core(TM) i7-1360P
                         │ old-trimmed-graph.txt │        new-trimmed-graph.txt         │
                         │        sec/op         │    sec/op     vs base                │
ReportNewTrimmedGraph-16             600.2m ± 8%   345.4m ± 10%  -42.46% (p=0.000 n=10)

                         │ old-trimmed-graph.txt │        new-trimmed-graph.txt         │
                         │         B/op          │     B/op      vs base                │
ReportNewTrimmedGraph-16           234.91Mi ± 0%   67.60Mi ± 0%  -71.22% (p=0.000 n=10)

                         │ old-trimmed-graph.txt │        new-trimmed-graph.txt        │
                         │       allocs/op       │  allocs/op   vs base                │
ReportNewTrimmedGraph-16             6.912M ± 0%   1.938M ± 0%  -71.96% (p=0.000 n=10)
```