### PR TITLE
Configure codecov token.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,9 @@ jobs:
       - name: Code coverage
         uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
         with:
-          file: ${{ env.WORKING_DIR }}/coverage.txt
+          files: ${{ env.WORKING_DIR }}/coverage.txt
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-linux:
     runs-on: ${{ matrix.os }}
@@ -199,7 +201,9 @@ jobs:
       - name: Code coverage
         uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5.5.0
         with:
-          file: ${{ env.WORKING_DIR }}/coverage.txt
+          files: ${{ env.WORKING_DIR }}/coverage.txt
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-windows:
     runs-on: windows-2022


### PR DESCRIPTION
The token is now required to upload the data. Also make sure the action fails when unsuccessful. It has been quietly failing for a long while.

Fixes #960 