### PR TITLE
Make flame graph the default view.

### DIFF
--- a/browsertests/browser_test.go
+++ b/browsertests/browser_test.go
@@ -80,7 +80,7 @@ func TestFlameGraph(t *testing.T) {
 
 	var ignored []byte // Some chromedp.Evaluate() versions wants non-nil result argument
 	err := chromedp.Run(ctx,
-		chromedp.Navigate(server.URL+"/flamegraph"),
+		chromedp.Navigate(server.URL),
 		chromedp.Evaluate(jsTestFixture, &ignored),
 		eval(t, jsCheckFlame),
 	)

--- a/internal/driver/html/header.html
+++ b/internal/driver/html/header.html
@@ -10,7 +10,7 @@
     </div>
     <div class="submenu">
       <a title="{{.Help.top}}"  href="./top" id="topbtn">Top</a>
-      <a title="{{.Help.graph}}" href="./" id="graphbtn">Graph</a>
+      <a title="{{.Help.graph}}" href="./graph" id="graphbtn">Graph</a>
       <a title="{{.Help.flamegraph}}" href="./flamegraph" id="flamegraph">Flame Graph</a>
       <a title="{{.Help.peek}}" href="./peek" id="peek">Peek</a>
       <a title="{{.Help.list}}" href="./source" id="list">Source</a>

--- a/internal/driver/webui.go
+++ b/internal/driver/webui.go
@@ -125,21 +125,23 @@ func serveWebInterface(hostport string, p *profile.Profile, o *plugin.Options, d
 		Host:     host,
 		Port:     port,
 		Handlers: map[string]http.Handler{
-			"/":              http.HandlerFunc(ui.dot),
-			"/top":           http.HandlerFunc(ui.top),
-			"/disasm":        http.HandlerFunc(ui.disasm),
-			"/source":        http.HandlerFunc(ui.source),
-			"/peek":          http.HandlerFunc(ui.peek),
-			"/flamegraph":    http.HandlerFunc(ui.stackView),
-			"/flamegraph2":   redirectWithQuery("flamegraph", http.StatusMovedPermanently), // Keep legacy URL working.
-			"/flamegraphold": redirectWithQuery("flamegraph", http.StatusMovedPermanently), // Keep legacy URL working.
-			"/saveconfig":    http.HandlerFunc(ui.saveConfig),
-			"/deleteconfig":  http.HandlerFunc(ui.deleteConfig),
+			"/":             redirectWithQuery("flamegraph", http.StatusMovedPermanently),
+			"/graph":        http.HandlerFunc(ui.dot),
+			"/top":          http.HandlerFunc(ui.top),
+			"/disasm":       http.HandlerFunc(ui.disasm),
+			"/source":       http.HandlerFunc(ui.source),
+			"/peek":         http.HandlerFunc(ui.peek),
+			"/flamegraph":   http.HandlerFunc(ui.stackView),
+			"/saveconfig":   http.HandlerFunc(ui.saveConfig),
+			"/deleteconfig": http.HandlerFunc(ui.deleteConfig),
 			"/download": http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				w.Header().Set("Content-Type", "application/vnd.google.protobuf+gzip")
 				w.Header().Set("Content-Disposition", "attachment;filename=profile.pb.gz")
 				p.Write(w)
 			}),
+			// Keep legacy URLs working.
+			"/flamegraph2":   redirectWithQuery("flamegraph", http.StatusMovedPermanently),
+			"/flamegraphold": redirectWithQuery("flamegraph", http.StatusMovedPermanently),
 		},
 	}
 


### PR DESCRIPTION
There is one compatibility caveat in this change. We previously served the graph view at the root path, without any redirects. If that old URL is used with the new UI, it will now be the flame graph, changing the meaning of the old URL.

I don't think there is a way around it and this does not seem to be an outright bug, so I'm accepting it. But the new code makes it so that the root URL redirects the browser to /flamegraph. This way any future changes of the meaning of the root URL won't affect existing old URLs since those will already have /flamegraph in them.

Fixes #950.