### PR TITLE
report: optimize newTrimmedGraph allocs

### DIFF
--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -615,3 +615,21 @@ func TestProfileLabels(t *testing.T) {
 		t.Errorf("wanted to find a label containing %q, but found none in %v", want, labels)
 	}
 }
+
+func BenchmarkReportNewTrimmedGraph(b *testing.B) {
+	data := proftest.LargeProfile(b)
+	prof, err := profile.Parse(bytes.NewBuffer(data))
+	if err != nil {
+		b.Fatal(err)
+	}
+	rep := NewDefault(prof, Options{})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		g, _, _, _ := rep.newTrimmedGraph()
+		if g == nil {
+			b.Fatal("empty graph")
+		}
+	}
+}


### PR DESCRIPTION
`go test -bench='^\QBenchmarkReportNewTrimmedGraph\E$' -run='^$' -count=10 -benchtime=5s -benchmem`

```
goos: linux
goarch: amd64
pkg: github.com/google/pprof/internal/report
cpu: 13th Gen Intel(R) Core(TM) i7-1360P
                         │   old.txt   │               new.txt               │
                         │   sec/op    │   sec/op     vs base                │
ReportNewTrimmedGraph-16   547.4m ± 6%   225.4m ± 4%  -58.81% (p=0.000 n=10)

                         │    old.txt    │               new.txt                │
                         │     B/op      │     B/op      vs base                │
ReportNewTrimmedGraph-16   234.27Mi ± 1%   51.38Mi ± 0%  -78.07% (p=0.000 n=10)

                         │   old.txt    │               new.txt               │
                         │  allocs/op   │  allocs/op   vs base                │
ReportNewTrimmedGraph-16   6889.2k ± 1%   520.4k ± 0%  -92.45% (p=0.000 n=10)
```