### PR TITLE
Fix test failure on go1.25 due to empty TLS host

### DIFF
--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -819,7 +819,10 @@ func selfSignedCert(t *testing.T, host string) (tls.Certificate, []byte, []byte)
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().Add(10 * time.Minute),
 		IsCA:         true,
-		DNSNames:     []string{host},
+	}
+
+	if host != "" {
+		tmpl.DNSNames = []string{host}
 	}
 
 	b, err = x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, privKey.Public(), privKey)
@@ -830,7 +833,7 @@ func selfSignedCert(t *testing.T, host string) (tls.Certificate, []byte, []byte)
 
 	cert, err := tls.X509KeyPair(bc, bk)
 	if err != nil {
-		t.Fatalf("failed to create TLS key pair: %v", err)
+		t.Fatalf("failed to create TLS key pair for '%s': %v", host, err)
 	}
 	return cert, bc, bk
 }


### PR DESCRIPTION
Fixing this:

```
--- FAIL: TestHTTPSInsecure (0.00s)
    fetch_test.go:833: failed to create TLS key pair: x509: SAN dNSName is malformed
```