### PR TITLE
Require at least 1.24.9.

### DIFF
--- a/browsertests/go.mod
+++ b/browsertests/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/pprof/browsertests
 
-go 1.24.0
+go 1.24.9
 
 // Use the version of pprof in this directory tree.
 replace github.com/google/pprof => ../

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/pprof
 
-go 1.24.0
+go 1.24.9
 
 require (
 	github.com/chzyer/readline v1.5.1


### PR DESCRIPTION
Go 1.24.8 has a bug that is causing a test failure like in #970. To avoid running into this when the local version has the bug, require 1.24.9 at least.

Tested with "go test ./..." on a machine where 1.24.8 is the default system-wide Go. The test run fails before this fix and passes after.