### PR TITLE
internal/driver: guard BuildID slice in locateBinaries to prevent panic on short BuildID

### DIFF
--- a/internal/driver/fetch.go
+++ b/internal/driver/fetch.go
@@ -430,7 +430,9 @@ mapping:
 				// Llvm buildid protocol: the first two characters of the build id
 				// are used as directory, and the remaining part is in the filename.
 				// e.g. `/ab/cdef0123456.debug`
-				fileNames = append(fileNames, filepath.Join(path, m.BuildID[:2], m.BuildID[2:]+".debug"))
+				if len(m.BuildID) >= 2 {
+					fileNames = append(fileNames, filepath.Join(path, m.BuildID[:2], m.BuildID[2:]+".debug"))
+				}
 			}
 			if m.File != "" {
 				// Try both the basename and the full path, to support the same directory

--- a/internal/driver/fetch_test.go
+++ b/internal/driver/fetch_test.go
@@ -77,6 +77,10 @@ func TestSymbolizationPath(t *testing.T) {
 		{"", "", "fghij10001", filepath.Join(tempdir, "pprof/binaries/fg/hij10001.debug"), 0},
 		{"/nowhere:/alternate/architecture", "/usr/bin/binary", "fedcb10000", "/usr/bin/binary", 1},
 		{"/nowhere:/alternate/architecture", "/usr/bin/binary", "abcde10002", "/usr/bin/binary", 1},
+		// A single-character BuildID must not panic when the LLVM debug-file
+		// lookup slices BuildID[:2] / BuildID[2:]. Prior to the fix, this caused
+		// a "slice bounds out of range" panic.
+		{"", "/usr/bin/binary", "X", "/usr/bin/binary", 0},
 	} {
 		os.Setenv("PPROF_BINARY_PATH", tc.env)
 		p := &profile.Profile{


### PR DESCRIPTION
## Summary

`locateBinaries` in `internal/driver/fetch.go` constructs an LLVM debug-file path by slicing `m.BuildID[:2]` and `m.BuildID[2:]` (line 433). The guard at line 424 only checks `m.BuildID != ""`, so a BuildID with fewer than two characters passes the check and causes a panic:

```
runtime error: slice bounds out of range [:2] with length 1
```

The `profile.proto` format places no minimum length requirement on the `build_id` field, and `profile.CheckValid()` does not validate it. A crafted profile file with `build_id = "X"` (or any single-byte value) reliably panics any process that calls `locateBinaries`.

## Impact

Any tool or server that accepts a user-supplied profile and analyzes it (symbolization, flamegraph rendering, etc.) can be crashed by this one-byte `build_id`. This includes:
- The standalone `pprof` binary run by an operator against an untrusted profile
- Any service that wraps `pprof` as a library and accepts uploaded profiles

## Fix

Add `len(m.BuildID) >= 2` guard before the LLVM path construction. This matches the documented precondition of the LLVM build-id convention ("the first two characters are used as the directory name").

## Test

Added `BuildID: "X"` case to `TestSymbolizationPath` — this panicked before the fix and passes after.