### PR TITLE
Bump codecov/codecov-action from 6.0.0 to 7.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
           ./test.sh
 
       - name: Code coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ${{ env.WORKING_DIR }}/coverage.txt
           fail_ci_if_error: true
@@ -203,7 +203,7 @@ jobs:
           ./test.sh
 
       - name: Code coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ${{ env.WORKING_DIR }}/coverage.txt
           fail_ci_if_error: true


### PR DESCRIPTION
This fixes the "Could not verify signature. Please contact Codecov if problem continues" CI error.