### PR TITLE
internal/graph: escape double quotes in tag names in DOT output

### DIFF
--- a/internal/graph/dotgraph.go
+++ b/internal/graph/dotgraph.go
@@ -247,7 +247,7 @@ func (b *builder) addNodelets(node *Node, nodeID int) bool {
 			continue
 		}
 		weight := b.config.FormatValue(w)
-		nodelets += fmt.Sprintf(`N%d_%d [label = "%s" id="N%d_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", nodeID, i, t.Name, nodeID, i, weight)
+		nodelets += fmt.Sprintf(`N%d_%d [label = "%s" id="N%d_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", nodeID, i, escapeForDot(t.Name), nodeID, i, weight)
 		nodelets += fmt.Sprintf(`N%d -> N%d_%d [label=" %s" weight=100 tooltip="%s" labeltooltip="%s"]`+"\n", nodeID, nodeID, i, weight, weight, weight)
 		if nts := lnts[t.Name]; nts != nil {
 			nodelets += b.numericNodelets(nts, maxNodelets, flatTags, fmt.Sprintf(`N%d_%d`, nodeID, i))
@@ -274,7 +274,7 @@ func (b *builder) numericNodelets(nts []*Tag, maxNumNodelets int, flatTags bool,
 		}
 		if w != 0 {
 			weight := b.config.FormatValue(w)
-			nodelets += fmt.Sprintf(`N%s_%d [label = "%s" id="N%s_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", source, j, t.Name, source, j, weight)
+			nodelets += fmt.Sprintf(`N%s_%d [label = "%s" id="N%s_%d" fontsize=8 shape=box3d tooltip="%s"]`+"\n", source, j, escapeForDot(t.Name), source, j, weight)
 			nodelets += fmt.Sprintf(`%s -> N%s_%d [label=" %s" weight=100 tooltip="%s" labeltooltip="%s"%s]`+"\n", source, source, j, weight, weight, weight, attr)
 		}
 	}

--- a/internal/graph/dotgraph_test.go
+++ b/internal/graph/dotgraph_test.go
@@ -92,6 +92,25 @@ func TestComposeWithTagsAndResidualEdge(t *testing.T) {
 	compareGraphs(t, buf.Bytes(), "compose3.dot")
 }
 
+func TestComposeWithTagsThatNeedEscaping(t *testing.T) {
+	g := baseGraph()
+	a, c := baseAttrsAndConfig()
+
+	// A label tag whose name contains a double quote must be escaped in the
+	// generated DOT; otherwise the `label = "..."` attribute is malformed and
+	// the whole graph fails to render (golang/pprof#769).
+	g.Nodes[0].LabelTags["a"] = &Tag{
+		Name: `range_str:"{quote}"`,
+		Cum:  10,
+		Flat: 10,
+	}
+
+	var buf bytes.Buffer
+	ComposeDot(&buf, g, a, c)
+
+	compareGraphs(t, buf.Bytes(), "compose10.dot")
+}
+
 func TestComposeWithNestedTags(t *testing.T) {
 	g := baseGraph()
 	a, c := baseAttrsAndConfig()

--- a/internal/graph/testdata/compose10.dot
+++ b/internal/graph/testdata/compose10.dot
@@ -1,0 +1,9 @@
+digraph "testtitle" {
+node [style=filled fillcolor="#f8f8f8"]
+subgraph cluster_L { "label1" [shape=box fontsize=16 label="label1\llabel2\llabel3: \"foo\"\l" tooltip="testtitle"] }
+N1 [label="src\n10 (10.00%)\nof 25 (25.00%)" id="node1" fontsize=22 shape=box tooltip="src (25)" color="#b23c00" fillcolor="#edddd5"]
+N1_0 [label = "range_str:\"{quote}\"" id="N1_0" fontsize=8 shape=box3d tooltip="10"]
+N1 -> N1_0 [label=" 10" weight=100 tooltip="10" labeltooltip="10"]
+N2 [label="dest\n15 (15.00%)\nof 25 (25.00%)" id="node2" fontsize=24 shape=box tooltip="dest (25)" color="#b23c00" fillcolor="#edddd5"]
+N1 -> N2 [label=" 10" weight=11 color="#b28559" tooltip="src -> dest (10)" labeltooltip="src -> dest (10)" minlen=2]
+}


### PR DESCRIPTION
Fixes #769

## Problem

Tag (nodelet) labels in the DOT renderer interpolate the tag name directly into the `label = "..."` attribute without escaping:

```go
nodelets += fmt.Sprintf(`N%d_%d [label = "%s" ...]`, nodeID, i, t.Name, ...)
```

Every other label in `dotgraph.go` (node names, edge labels, legend title) is passed through `escapeForDot`, but the two tag-nodelet paths were not. A tag name containing a double quote — common in CPU-profile string tags, e.g. `range_str:.../"{...}"` — produces invalid DOT that graphviz cannot render, breaking the whole graph (see the example in #769).

## Fix

Apply the existing `escapeForDot` helper to `t.Name` in both the label-tag path (`tagsToNodelets`) and the numeric-nodelet path (`numericNodelets`). No other behavior changes.

## Test

Added `TestComposeWithTagsThatNeedEscaping` (golden `compose10.dot`): a label tag whose name contains `"` now renders as `label = "range_str:\"{quote}\""`. The test **fails before** this change (unescaped quote → malformed DOT) and **passes after**. Full `internal/graph` package tests pass; `go vet` and `gofmt` are clean.
