### PR TITLE
internal/report: guard against nil Symbol regexp in disasm and source rendering

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -397,8 +397,10 @@ func PrintAssembly(w io.Writer, rpt *Report, obj plugin.ObjTool, maxFuncs int) e
 	// If the regexp source can be parsed as an address, also match
 	// functions that land on that address.
 	var address *uint64
-	if hex, err := strconv.ParseUint(o.Symbol.String(), 0, 64); err == nil {
-		address = &hex
+	if o.Symbol != nil {
+		if hex, err := strconv.ParseUint(o.Symbol.String(), 0, 64); err == nil {
+			address = &hex
+		}
 	}
 
 	fmt.Fprintln(w, "Total:", rpt.formatValue(rpt.total))
@@ -436,7 +438,11 @@ func PrintAssembly(w io.Writer, rpt *Report, obj plugin.ObjTool, maxFuncs int) e
 	if len(syms) == 0 {
 		// The symbol regexp case
 		if address == nil {
-			return fmt.Errorf("no matches found for regexp %s", o.Symbol)
+			symStr := ""
+			if o.Symbol != nil {
+				symStr = o.Symbol.String()
+			}
+			return fmt.Errorf("no matches found for regexp %s", symStr)
 		}
 
 		// The address case

--- a/internal/report/source.go
+++ b/internal/report/source.go
@@ -49,7 +49,7 @@ func printSource(w io.Writer, rpt *Report) error {
 	var functions graph.Nodes
 	functionNodes := make(map[string]graph.Nodes)
 	for _, n := range g.Nodes {
-		if !o.Symbol.MatchString(n.Info.Name) {
+		if o.Symbol != nil && !o.Symbol.MatchString(n.Info.Name) {
 			continue
 		}
 		if functionNodes[n.Info.Name] == nil {
@@ -60,7 +60,11 @@ func printSource(w io.Writer, rpt *Report) error {
 	functions.Sort(graph.NameOrder)
 
 	if len(functionNodes) == 0 {
-		return fmt.Errorf("no matches found for regexp: %s", o.Symbol)
+		symStr := ""
+		if o.Symbol != nil {
+			symStr = o.Symbol.String()
+		}
+		return fmt.Errorf("no matches found for regexp: %s", symStr)
 	}
 
 	sourcePath := o.SourcePath
@@ -251,7 +255,11 @@ func MakeWebList(rpt *Report, obj plugin.ObjTool, maxFiles int) (WebListData, er
 	}
 	sp := newSourcePrinter(rpt, obj, sourcePath)
 	if len(sp.interest) == 0 {
-		return WebListData{}, fmt.Errorf("no matches found for regexp: %s", rpt.options.Symbol)
+		symStr := ""
+		if rpt.options.Symbol != nil {
+			symStr = rpt.options.Symbol.String()
+		}
+		return WebListData{}, fmt.Errorf("no matches found for regexp: %s", symStr)
 	}
 	defer sp.close()
 	return sp.generate(maxFiles, rpt), nil


### PR DESCRIPTION
The disasm page crashes when accessed without a filter parameter because the Symbol regexp is nil. The code in PrintAssembly (report.go:400) and printSource (source.go:52) attempted to dereference the nil pointer when calling o.Symbol.String() or o.Symbol.MatchString().

This fix adds nil checks before accessing the Symbol regexp in three locations: PrintAssembly, printSource, and MakeWebList. When Symbol is nil, the code now treats it as matching all symbols (for MatchString) or uses an empty string in error messages (for String()).

The issue manifests when viewing profiles from different architectures (e.g., darwin/arm64 on linux/amd64) because the web UI calls the disasm endpoint without a symbol filter, causing a nil pointer dereference that displays as "no matches found for regexp:" with an empty regexp value.

Fixes #789
