### PR TITLE
internal/transport: avoid mutating request URL for https+insecure

### DIFF
--- a/internal/transport/transport.go
+++ b/internal/transport/transport.go
@@ -116,7 +116,8 @@ func (tr *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// Make shallow copy of request, and req.URL, so the request's URL can be
 		// modified.
 		r := *req
-		*r.URL = *req.URL
+		u := *req.URL
+		r.URL = &u
 		req = &r
 		tlsConfig.InsecureSkipVerify = true
 		req.URL.Scheme = "https"

--- a/internal/transport/transport_test.go
+++ b/internal/transport/transport_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHTTPSInsecureDoesNotModifyRequest(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/foo" {
+			t.Errorf("request path = %q, want /foo", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	url := strings.Replace(server.URL, "https://", "https+insecure://", 1) + "/foo"
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := New(nil).RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip() failed: %v", err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	if got, want := req.URL.Scheme, "https+insecure"; got != want {
+		t.Errorf("request URL scheme = %q after RoundTrip, want %q", got, want)
+	}
+}


### PR DESCRIPTION
`transport.RoundTrip` shallow-copies the request when handling `https+insecure`, but the copied request still shares the original `*url.URL`.

As a result, changing the copied URL scheme from `https+insecure` to `https` also mutates the caller's request.

Copy the `url.URL` value and update the copied request to point to the new value. Add a regression test that verifies the HTTPS request succeeds and the caller's URL scheme remains unchanged.
