### PR TITLE
measurement: count runes when stripping the plural suffix in sniffUnit

### DIFF
--- a/internal/measurement/measurement.go
+++ b/internal/measurement/measurement.go
@@ -21,6 +21,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/pprof/profile"
 )
@@ -209,7 +210,9 @@ func (ut UnitType) findByAlias(alias string) *Unit {
 // specified alias. It returns nil if the unit with such alias is not found.
 func (ut UnitType) sniffUnit(unit string) *Unit {
 	unit = strings.ToLower(unit)
-	if len(unit) > 2 {
+	// Count runes rather than bytes so that multi-byte aliases such as "μs"
+	// are not mistaken for a plural form and stripped down to "μ".
+	if utf8.RuneCountInString(unit) > 2 {
 		unit = strings.TrimSuffix(unit, "s")
 	}
 	return ut.findByAlias(unit)

--- a/internal/measurement/measurement_test.go
+++ b/internal/measurement/measurement_test.go
@@ -17,6 +17,8 @@ package measurement
 import (
 	"math"
 	"testing"
+
+	"github.com/google/pprof/profile"
 )
 
 func TestScale(t *testing.T) {
@@ -37,6 +39,10 @@ func TestScale(t *testing.T) {
 		{2048, "mb", "auto", 2, "GB"},
 		{3.1536e7, "s", "auto", 8760, "hrs"},
 		{-1, "s", "ms", -1000, "ms"},
+		{1, "μs", "ms", 0.001, "ms"},
+		{2000, "μs", "auto", 2, "ms"},
+		{1, "μS", "ns", 1000, "ns"},
+		{1, "us", "μs", 1, "us"},
 		{1, "foo", "count", 1, ""},
 		{1, "foo", "bar", 1, "bar"},
 		{2000, "count", "count", 2000, ""},
@@ -73,4 +79,42 @@ func floatEqual(a, b float64) bool {
 	diff := math.Abs(a - b)
 	avg := (math.Abs(a) + math.Abs(b)) / 2
 	return diff/avg < 0.0001
+}
+
+func TestCommonValueType(t *testing.T) {
+	for _, tc := range []struct {
+		desc     string
+		in       []*profile.ValueType
+		wantUnit string
+		wantErr  bool
+	}{
+		{
+			desc:     "microseconds and milliseconds are compatible",
+			in:       []*profile.ValueType{{Type: "cpu", Unit: "ms"}, {Type: "cpu", Unit: "μs"}},
+			wantUnit: "μs",
+		},
+		{
+			desc:     "microseconds and seconds are compatible",
+			in:       []*profile.ValueType{{Type: "cpu", Unit: "μs"}, {Type: "cpu", Unit: "s"}},
+			wantUnit: "μs",
+		},
+		{
+			desc:    "time and memory units are incompatible",
+			in:      []*profile.ValueType{{Type: "cpu", Unit: "μs"}, {Type: "cpu", Unit: "kb"}},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := CommonValueType(tc.in)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Fatalf("CommonValueType(%v) error = %v, want error presence %v", tc.in, err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if got == nil || got.Unit != tc.wantUnit {
+				t.Errorf("CommonValueType(%v) = %v, want unit %q", tc.in, got, tc.wantUnit)
+			}
+		})
+	}
 }


### PR DESCRIPTION
### The bug

`sniffUnit` strips a trailing `"s"` only when the unit is longer than two characters:

```go
func (ut UnitType) sniffUnit(unit string) *Unit {
	unit = strings.ToLower(unit)
	if len(unit) > 2 {
		unit = strings.TrimSuffix(unit, "s")
	}
	return ut.findByAlias(unit)
}
```

`len()` on a string counts **bytes**. The micro sign spelling is deliberately registered as an alias of the microsecond unit:

```go
{"us", []string{"μs", "us", "microsecond"}, float64(time.Microsecond)},
```

`"μs"` is two runes but three bytes, because `μ` is U+03BC (0xCE 0xBC). So the guard fires, the alias is trimmed to `"μ"`, and `findByAlias` matches nothing. That alias has never resolved.

### Why it matters

`sniffUnit` is the entry point for every unit lookup, so the failure shows up three ways, all silent:

**Wrong numbers from `Scale`.** With no `UnitType` claiming `"μs"`, `Scale` falls through to the non-interesting-unit path and returns the value unchanged while still attaching the target unit's name:

```
Scale(2000, "μs", "ms")  ->  (2000, "ms")     // 1000x off, no error
```

**`-unit=μs` prints zero.** `cfg.Unit` reaches `measurement.Scale(v, o.SampleUnit, o.OutputUnit)` in `internal/report/report.go`. An unrecognized `toUnit` falls back to the time type's default of seconds, so a 2.5 ms sample scales to `0.0025` and `ScaledLabel` truncates it:

```
$ pprof -top -unit=us  ...     2500us   100%   main.work
$ pprof -top -unit=μs  ...          0   100%   main.work
```

**Profile merging fails.** `compatibleValueTypes` asks whether both units sniff to the same `UnitType`. Since `"μs"` sniffs to nothing:

```
incompatible types: {cpu ms} {cpu μs}
```

### The change

Count runes instead of bytes, so a two-rune alias is left alone.

I considered simply dropping the `"μs"` alias instead, but the rune count is the more faithful reading: the alias was clearly written on purpose, and counting runes also fixes the `toUnit` direction and `compatibleValueTypes`, which removing the alias would not.

### Tests

Four cases added to the existing `TestScale` table, plus a new `TestCommonValueType` covering the merge path. Without the change:

```
measurement_test.go:72: Scale(1, "μs", "ms") = (1, "ms"), want (0.001, "ms")
measurement_test.go:72: Scale(2000, "μs", "auto") = (2000, ""), want (2, "ms")
measurement_test.go:72: Scale(1, "μS", "ns") = (1, "ns"), want (1000, "ns")
measurement_test.go:72: Scale(1, "us", "μs") = (1e-06, "s"), want (1, "us")
CommonValueType(...) error = incompatible types: {cpu ms} {cpu μs}, want error presence false
```

With it, the package passes. `gofmt -l internal/measurement/` and `go vet ./internal/measurement/` are clean.

Full `go test ./...` matches a clean checkout: the only failures are pre-existing and environmental on my machine (`internal/binutils` `TestPEFile` and `internal/report` `TestPrintAssemblyErrorMessage`, both because `nm`/`objdump` are not on PATH here). No new failures.
