### PR TITLE
profile: propagate gzip close errors from Write

### DIFF
--- a/profile/profile.go
+++ b/profile/profile.go
@@ -344,9 +344,11 @@ func serialize(p *Profile) []byte {
 // Write writes the profile as a gzip-compressed marshaled protobuf.
 func (p *Profile) Write(w io.Writer) error {
 	zw := gzip.NewWriter(w)
-	defer zw.Close()
-	_, err := zw.Write(serialize(p))
-	return err
+	if _, err := zw.Write(serialize(p)); err != nil {
+		_ = zw.Close()
+		return err
+	}
+	return zw.Close()
 }
 
 // WriteUncompressed writes the profile as a marshaled protobuf.

--- a/profile/profile_test.go
+++ b/profile/profile_test.go
@@ -16,6 +16,7 @@ package profile
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -115,6 +116,33 @@ func TestParseError(t *testing.T) {
 			t.Errorf("got nil, want error for input #%d", i)
 		}
 	}
+}
+
+func TestWriteCloseError(t *testing.T) {
+	wantErr := errors.New("write failed")
+	w := &errorAfterNWriter{
+		n:   10, // Allow Write to emit the gzip header before Close fails.
+		err: wantErr,
+	}
+
+	if err := new(Profile).Write(w); !errors.Is(err, wantErr) {
+		t.Fatalf("Write() error = %v, want %v", err, wantErr)
+	}
+}
+
+type errorAfterNWriter struct {
+	n   int
+	err error
+}
+
+func (w *errorAfterNWriter) Write(p []byte) (int, error) {
+	if len(p) <= w.n {
+		w.n -= len(p)
+		return len(p), nil
+	}
+	n := w.n
+	w.n = 0
+	return n, w.err
 }
 
 func TestParseConcatentated(t *testing.T) {


### PR DESCRIPTION
Profile.Write currently defers gzip.Writer.Close and returns only the error from Write. gzip.Writer may buffer compressed data and report underlying writer failures only when Close flushes the stream and writes the trailer. As a result, Write can return nil even though the generated gzip profile is incomplete.

Return the Close error after a successful write while preserving the original Write error when writing fails. Add a regression test that allows the gzip header to be written and then makes the underlying writer fail during Close.